### PR TITLE
Add coordinated in-place access and clarify copy semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,12 @@ The native method channel name has been renamed from `icloud_storage` to
 `invalidEntries` rather than a raw list, so malformed metadata is visible to
 callers.
 
+#### New Coordinated In-Place APIs
+Added coordinated in-place access for text and bytes:
+`readInPlace` / `writeInPlace` and `readInPlaceBytes` / `writeInPlaceBytes`.
+In-place reads use an idle watchdog with retry backoff and surface `E_TIMEOUT`
+if the download stalls.
+
 **Migration:**
 ```dart
 final result = await ICloudStorage.gather(...);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ Dependency changed from `flutter_lints` to `very_good_analysis`.
 ### Added
 
 - Directory support via `ICloudFile.isDirectory`.
+- Coordinated in-place text APIs: `readInPlace` and `writeInPlace` for small
+  JSON/text files using UIDocument/NSDocument.
 - Error code `E_PLUGIN_INTERNAL` for unexpected Dart-side stream errors.
 - Error code `E_INVALID_EVENT` for invalid event types from native layer.
 - `PlatformExceptionCode` constants for all error codes (`argumentError`,
@@ -107,6 +109,9 @@ Dependency changed from `flutter_lints` to `very_good_analysis`.
 
 - Updated iOS/macOS podspec metadata (name, version, summary, description,
   homepage, author) to match the package.
+- Clarified `uploadFile` and `downloadFile` semantics in documentation:
+  - `uploadFile` = copy-in (local -> iCloud container); OS uploads afterward.
+  - `downloadFile` = download-then-copy-out (iCloud container -> local).
 - Native implementation and metadata extraction updated to support the new API
   surface (file-path transfers + richer metadata).
 - Structural operations (`delete`, `move`, `copy`, `documentExists`,

--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ final content = await File(downloadPath).readAsString();
 Use coordinated in-place access for small text/JSON files stored in the
 ubiquity container. These APIs load/write the full file contents in memory.
 Reads wait for iCloud downloads to complete, using metadata when available and
-falling back to the requested file URL if the index is still catching up.
+falling back to the requested file URL if the index is still catching up. You
+can optionally configure idle watchdog timeouts and retry backoff in Dart
+(defaults to 60/90/180s with 2/4s backoff).
 
 ```dart
 // Read directly inside the container with coordination.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ falling back to the requested file URL if the index is still catching up. You
 can optionally configure idle watchdog timeouts and retry backoff in Dart
 (defaults to 60/90/180s with 2/4s backoff).
 File-not-found and other failures surface as errors.
+In-place access only supports UTF-8 text/JSON files.
 
 ```dart
 // Read directly inside the container with coordination.

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ Reads wait for iCloud downloads to complete, using metadata when available and
 falling back to the requested file URL if the index is still catching up. You
 can optionally configure idle watchdog timeouts and retry backoff in Dart
 (defaults to 60/90/180s with 2/4s backoff).
-File-not-found and other failures surface as errors.
-In-place access only supports UTF-8 text/JSON files.
+File-not-found and other failures surface as errors. Text reads use UTF-8; use
+the bytes APIs for binary files.
 
 ```dart
 // Read directly inside the container with coordination.
@@ -96,6 +96,21 @@ await ICloudStorage.writeInPlace(
   containerId: 'iCloud.com.yourapp.container',
   relativePath: 'Documents/notes.txt',
   contents: 'Updated text',
+);
+```
+
+For binary files (images, PDFs), use the bytes APIs:
+
+```dart
+final bytes = await ICloudStorage.readInPlaceBytes(
+  containerId: 'iCloud.com.yourapp.container',
+  relativePath: 'Documents/image.png',
+);
+
+await ICloudStorage.writeInPlaceBytes(
+  containerId: 'iCloud.com.yourapp.container',
+  relativePath: 'Documents/image.png',
+  contents: bytes!,
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ final content = await File(downloadPath).readAsString();
 
 Use coordinated in-place access for small text/JSON files stored in the
 ubiquity container. These APIs load/write the full file contents in memory.
+Reads wait for iCloud downloads to complete, using metadata when available and
+falling back to the requested file URL if the index is still catching up.
 
 ```dart
 // Read directly inside the container with coordination.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Reads wait for iCloud downloads to complete, using metadata when available and
 falling back to the requested file URL if the index is still catching up. You
 can optionally configure idle watchdog timeouts and retry backoff in Dart
 (defaults to 60/90/180s with 2/4s backoff).
+File-not-found and other failures surface as errors.
 
 ```dart
 // Read directly inside the container with coordination.

--- a/doc/download-flow.md
+++ b/doc/download-flow.md
@@ -36,12 +36,11 @@ downloaded.
 Coordinated in-place reads (`readInPlace`) do not pre-check file existence.
 Instead, they:
 - Trigger download with `startDownloadingUbiquitousItem` when needed.
-- Wait for metadata to report download status `current`.
+- Wait for metadata to report download status `current` (with idle watchdog retries).
 - Attempt a coordinated document open/read.
 
-A file-not-found error from the coordinated open/read is mapped to `null`.
-This avoids false negatives from `fileExists` and treats UIDocument/NSDocument
-as the source of truth for read availability.
+File-not-found and other failures surface as errors (not null). `readInPlace`
+treats UIDocument/NSDocument as the source of truth for read availability.
 
 ## Error codes
 
@@ -49,5 +48,6 @@ We map Cocoa file-not-found errors to distinct codes:
 - `E_FNF` for `NSFileNoSuchFileError`
 - `E_FNF_READ` for `NSFileReadNoSuchFileError`
 - `E_FNF_WRITE` for `NSFileWriteNoSuchFileError`
+Idle watchdog timeouts return `E_TIMEOUT`.
 
 All other errors are reported as native errors.

--- a/doc/download-flow.md
+++ b/doc/download-flow.md
@@ -36,6 +36,7 @@ downloaded.
 Coordinated in-place reads (`readInPlace`) do not pre-check file existence.
 Instead, they:
 - Trigger download with `startDownloadingUbiquitousItem` when needed.
+- Wait for metadata to report download status `current`.
 - Attempt a coordinated document open/read.
 
 A file-not-found error from the coordinated open/read is mapped to `null`.

--- a/doc/download-flow.md
+++ b/doc/download-flow.md
@@ -39,8 +39,8 @@ Instead, they:
 - Wait for metadata to report download status `current` (with idle watchdog retries).
 - Attempt a coordinated document open/read.
 
-File-not-found and other failures surface as errors (not null). `readInPlace`
-treats UIDocument/NSDocument as the source of truth for read availability.
+File-not-found and other failures surface as errors (not null). Text reads use
+UTF-8 decoding; use `readInPlaceBytes` for binary formats.
 
 ## Error codes
 

--- a/doc/download-flow.md
+++ b/doc/download-flow.md
@@ -31,6 +31,17 @@ metadata queries. iCloud placeholders are local entries, so `fileExists`
 returns true once the directory metadata syncs, even if the file is not
 downloaded.
 
+## In-place access
+
+Coordinated in-place reads (`readInPlace`) do not pre-check file existence.
+Instead, they:
+- Trigger download with `startDownloadingUbiquitousItem` when needed.
+- Attempt a coordinated document open/read.
+
+A file-not-found error from the coordinated open/read is mapped to `null`.
+This avoids false negatives from `fileExists` and treats UIDocument/NSDocument
+as the source of truth for read availability.
+
 ## Error codes
 
 We map Cocoa file-not-found errors to distinct codes:

--- a/ios/Classes/iOSICloudStoragePlugin.swift
+++ b/ios/Classes/iOSICloudStoragePlugin.swift
@@ -654,7 +654,7 @@ public class SwiftICloudStoragePlugin: NSObject, FlutterPlugin {
       for: query,
       name: NSNotification.Name.NSMetadataQueryDidFinishGathering
     ) { [self] _ in
-      let evaluation = evaluateDownloadStatus(query: query)
+      let evaluation = evaluateDownloadStatus(query: query, fileURL: fileURL)
       if evaluation.completed {
         removeObservers(query)
         query.stop()
@@ -666,7 +666,7 @@ public class SwiftICloudStoragePlugin: NSObject, FlutterPlugin {
       for: query,
       name: NSNotification.Name.NSMetadataQueryDidUpdate
     ) { [self] _ in
-      let evaluation = evaluateDownloadStatus(query: query)
+      let evaluation = evaluateDownloadStatus(query: query, fileURL: fileURL)
       if evaluation.completed {
         removeObservers(query)
         query.stop()
@@ -679,14 +679,13 @@ public class SwiftICloudStoragePlugin: NSObject, FlutterPlugin {
 
   /// Evaluates download status for a metadata query result.
   private func evaluateDownloadStatus(
-    query: NSMetadataQuery
+    query: NSMetadataQuery,
+    fileURL: URL
   ) -> (completed: Bool, error: Error?) {
-    guard let fileItem = query.results.first as? NSMetadataItem else {
-      return (false, nil)
-    }
-    guard let resolvedURL = fileItem.value(forAttribute: NSMetadataItemURLKey) as? URL else {
-      return (false, nil)
-    }
+    let resolvedURL = (query.results.first as? NSMetadataItem)
+      .flatMap { $0.value(forAttribute: NSMetadataItemURLKey) as? URL }
+      ?? fileURL
+
     guard let values = try? resolvedURL.resourceValues(
       forKeys: [.ubiquitousItemDownloadingStatusKey, .ubiquitousItemDownloadingErrorKey]
     ) else {

--- a/ios/Classes/iOSICloudStoragePlugin.swift
+++ b/ios/Classes/iOSICloudStoragePlugin.swift
@@ -677,7 +677,12 @@ public class SwiftICloudStoragePlugin: NSObject, FlutterPlugin {
     query.start()
   }
 
-  /// Evaluates download status for a metadata query result.
+  /// Checks if the file is fully downloaded and available for access.
+  ///
+  /// Strategy:
+  /// 1) Index check: resolve via `NSMetadataQuery` results (handles recent moves/renames).
+  /// 2) Filesystem fallback: if query returns no results, use the original `fileURL`
+  ///    to avoid hanging on metadata indexing latency.
   private func evaluateDownloadStatus(
     query: NSMetadataQuery,
     fileURL: URL

--- a/ios/Classes/iOSICloudStoragePlugin.swift
+++ b/ios/Classes/iOSICloudStoragePlugin.swift
@@ -615,6 +615,10 @@ public class SwiftICloudStoragePlugin: NSObject, FlutterPlugin {
   }
 
   /// Waits until an iCloud item reports download status "current".
+  /// Waits for an iCloud download to reach "current" or fail.
+  ///
+  /// Note: there is intentionally no timeout; this waits indefinitely unless
+  /// the download completes or an error is detected.
   private func waitForDownloadCompletion(
     fileURL: URL,
     completion: @escaping (Error?) -> Void
@@ -691,20 +695,26 @@ public class SwiftICloudStoragePlugin: NSObject, FlutterPlugin {
       .flatMap { $0.value(forAttribute: NSMetadataItemURLKey) as? URL }
       ?? fileURL
 
-    guard let values = try? resolvedURL.resourceValues(
-      forKeys: [.ubiquitousItemDownloadingStatusKey, .ubiquitousItemDownloadingErrorKey]
-    ) else {
+    do {
+      let values = try resolvedURL.resourceValues(
+        forKeys: [.ubiquitousItemDownloadingStatusKey, .ubiquitousItemDownloadingErrorKey]
+      )
+
+      if let error = values.ubiquitousItemDownloadingError {
+        return (true, error)
+      }
+
+      if values.ubiquitousItemDownloadingStatus == URLUbiquitousItemDownloadingStatus.current {
+        return (true, nil)
+      }
+      return (false, nil)
+    } catch {
+      let nsError = error as NSError
+      if nsError.domain == NSCocoaErrorDomain && nsError.code == NSFileNoSuchFileError {
+        return (true, fileNotFoundError)
+      }
       return (false, nil)
     }
-
-    if let error = values.ubiquitousItemDownloadingError {
-      return (true, error)
-    }
-
-    if values.ubiquitousItemDownloadingStatus == URLUbiquitousItemDownloadingStatus.current {
-      return (true, nil)
-    }
-    return (false, nil)
   }
   
   /// Check if an item exists without downloading.

--- a/ios/Classes/iOSICloudStoragePlugin.swift
+++ b/ios/Classes/iOSICloudStoragePlugin.swift
@@ -507,7 +507,8 @@ public class SwiftICloudStoragePlugin: NSObject, FlutterPlugin {
     do {
       try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
     } catch {
-      result(nativeCodeError(error))
+      let mapped = mapFileNotFoundError(error) ?? nativeCodeError(error)
+      result(mapped)
       return
     }
 
@@ -527,7 +528,8 @@ public class SwiftICloudStoragePlugin: NSObject, FlutterPlugin {
 
       readInPlaceDocument(at: fileURL) { [self] contents, error in
         if let error = error {
-          result(nativeCodeError(error))
+          let mapped = mapFileNotFoundError(error) ?? nativeCodeError(error)
+          result(mapped)
           return
         }
 
@@ -605,7 +607,8 @@ public class SwiftICloudStoragePlugin: NSObject, FlutterPlugin {
     do {
       try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
     } catch {
-      result(nativeCodeError(error))
+      let mapped = mapFileNotFoundError(error) ?? nativeCodeError(error)
+      result(mapped)
       return
     }
 
@@ -625,7 +628,8 @@ public class SwiftICloudStoragePlugin: NSObject, FlutterPlugin {
 
       readInPlaceBinaryDocument(at: fileURL) { [self] contents, error in
         if let error = error {
-          result(nativeCodeError(error))
+          let mapped = mapFileNotFoundError(error) ?? nativeCodeError(error)
+          result(mapped)
           return
         }
 

--- a/lib/icloud_storage.dart
+++ b/lib/icloud_storage.dart
@@ -175,6 +175,9 @@ class ICloudStorage {
   /// Returns the file contents as a String.
   ///
   /// Throws on file-not-found and other failures.
+  /// Note: the return type is nullable to match the platform interface, but
+  /// the native implementations only return `null` if a platform explicitly
+  /// chooses to.
   static Future<String?> readInPlace({
     required String containerId,
     required String relativePath,

--- a/lib/icloud_storage.dart
+++ b/lib/icloud_storage.dart
@@ -173,6 +173,8 @@ class ICloudStorage {
   /// backoff by default).
   ///
   /// Returns the file contents as a String.
+  ///
+  /// Throws on file-not-found and other failures.
   static Future<String?> readInPlace({
     required String containerId,
     required String relativePath,

--- a/lib/icloud_storage.dart
+++ b/lib/icloud_storage.dart
@@ -167,10 +167,17 @@ class ICloudStorage {
   /// Coordinated access loads the full contents into memory. Use for small
   /// text/JSON files.
   ///
-  /// Returns the file contents as a String, or null if the file does not exist.
+  /// [idleTimeouts] configures the idle watchdog for downloads (defaults to
+  /// 60s, 90s, 180s).
+  /// [retryBackoff] configures the retry delay between attempts (exponential
+  /// backoff by default).
+  ///
+  /// Returns the file contents as a String.
   static Future<String?> readInPlace({
     required String containerId,
     required String relativePath,
+    List<Duration>? idleTimeouts,
+    List<Duration>? retryBackoff,
   }) async {
     // Reads are file-centric; reject directory paths.
     if (relativePath.endsWith('/')) {
@@ -184,6 +191,8 @@ class ICloudStorage {
     return ICloudStoragePlatform.instance.readInPlace(
       containerId: containerId,
       relativePath: relativePath,
+      idleTimeouts: idleTimeouts,
+      retryBackoff: retryBackoff,
     );
   }
 

--- a/lib/icloud_storage.dart
+++ b/lib/icloud_storage.dart
@@ -184,6 +184,10 @@ class ICloudStorage {
       throw InvalidArgumentException('invalid relativePath: $relativePath');
     }
 
+    if (relativePath.trim().isEmpty) {
+      throw InvalidArgumentException('invalid relativePath: $relativePath');
+    }
+
     if (!_validateRelativePath(relativePath)) {
       throw InvalidArgumentException('invalid relativePath: $relativePath');
     }
@@ -214,6 +218,10 @@ class ICloudStorage {
   }) async {
     // Writes are file-centric; reject directory paths.
     if (relativePath.endsWith('/')) {
+      throw InvalidArgumentException('invalid relativePath: $relativePath');
+    }
+
+    if (relativePath.trim().isEmpty) {
       throw InvalidArgumentException('invalid relativePath: $relativePath');
     }
 

--- a/lib/icloud_storage_method_channel.dart
+++ b/lib/icloud_storage_method_channel.dart
@@ -129,6 +129,31 @@ class MethodChannelICloudStorage extends ICloudStoragePlatform {
   }
 
   @override
+  Future<String?> readInPlace({
+    required String containerId,
+    required String relativePath,
+  }) async {
+    final result = await methodChannel.invokeMethod<String>('readInPlace', {
+      'containerId': containerId,
+      'relativePath': relativePath,
+    });
+    return result;
+  }
+
+  @override
+  Future<void> writeInPlace({
+    required String containerId,
+    required String relativePath,
+    required String contents,
+  }) async {
+    await methodChannel.invokeMethod('writeInPlace', {
+      'containerId': containerId,
+      'relativePath': relativePath,
+      'contents': contents,
+    });
+  }
+
+  @override
   Future<void> delete({
     required String containerId,
     required String relativePath,

--- a/lib/icloud_storage_method_channel.dart
+++ b/lib/icloud_storage_method_channel.dart
@@ -140,6 +140,7 @@ class MethodChannelICloudStorage extends ICloudStoragePlatform {
       {
         'containerId': containerId,
         'relativePath': relativePath,
+        // Send integer seconds; sub-second precision is intentionally ignored.
         if (idleTimeouts != null)
           'idleTimeoutSeconds': idleTimeouts
               .map((duration) => duration.inSeconds)

--- a/lib/icloud_storage_method_channel.dart
+++ b/lib/icloud_storage_method_channel.dart
@@ -132,11 +132,24 @@ class MethodChannelICloudStorage extends ICloudStoragePlatform {
   Future<String?> readInPlace({
     required String containerId,
     required String relativePath,
+    List<Duration>? idleTimeouts,
+    List<Duration>? retryBackoff,
   }) async {
-    final result = await methodChannel.invokeMethod<String>('readInPlace', {
-      'containerId': containerId,
-      'relativePath': relativePath,
-    });
+    final result = await methodChannel.invokeMethod<String>(
+      'readInPlace',
+      {
+        'containerId': containerId,
+        'relativePath': relativePath,
+        if (idleTimeouts != null)
+          'idleTimeoutSeconds': idleTimeouts
+              .map((duration) => duration.inSeconds)
+              .toList(growable: false),
+        if (retryBackoff != null)
+          'retryBackoffSeconds': retryBackoff
+              .map((duration) => duration.inSeconds)
+              .toList(growable: false),
+      },
+    );
     return result;
   }
 

--- a/lib/icloud_storage_method_channel.dart
+++ b/lib/icloud_storage_method_channel.dart
@@ -250,7 +250,7 @@ class MethodChannelICloudStorage extends ICloudStoragePlatform {
           ..add(ICloudTransferProgress.error(exception))
           ..close();
       },
-      handleError: (Object error, StackTrace stackTrace, sink) {
+      handleError: (error, stackTrace, sink) {
         final exception = error is PlatformException
             ? error
             : () {

--- a/lib/icloud_storage_method_channel.dart
+++ b/lib/icloud_storage_method_channel.dart
@@ -155,12 +155,51 @@ class MethodChannelICloudStorage extends ICloudStoragePlatform {
   }
 
   @override
+  Future<Uint8List?> readInPlaceBytes({
+    required String containerId,
+    required String relativePath,
+    List<Duration>? idleTimeouts,
+    List<Duration>? retryBackoff,
+  }) async {
+    final result = await methodChannel.invokeMethod<Uint8List>(
+      'readInPlaceBytes',
+      {
+        'containerId': containerId,
+        'relativePath': relativePath,
+        // Send integer seconds; sub-second precision is intentionally ignored.
+        if (idleTimeouts != null)
+          'idleTimeoutSeconds': idleTimeouts
+              .map((duration) => duration.inSeconds)
+              .toList(growable: false),
+        if (retryBackoff != null)
+          'retryBackoffSeconds': retryBackoff
+              .map((duration) => duration.inSeconds)
+              .toList(growable: false),
+      },
+    );
+    return result;
+  }
+
+  @override
   Future<void> writeInPlace({
     required String containerId,
     required String relativePath,
     required String contents,
   }) async {
     await methodChannel.invokeMethod('writeInPlace', {
+      'containerId': containerId,
+      'relativePath': relativePath,
+      'contents': contents,
+    });
+  }
+
+  @override
+  Future<void> writeInPlaceBytes({
+    required String containerId,
+    required String relativePath,
+    required Uint8List contents,
+  }) async {
+    await methodChannel.invokeMethod('writeInPlaceBytes', {
       'containerId': containerId,
       'relativePath': relativePath,
       'contents': contents,

--- a/lib/icloud_storage_platform_interface.dart
+++ b/lib/icloud_storage_platform_interface.dart
@@ -64,13 +64,13 @@ abstract class ICloudStoragePlatform extends PlatformInterface {
     throw UnimplementedError('getContainerPath() has not been implemented.');
   }
 
-  /// Upload a local file to iCloud from a local path.
+  /// Copy a local file into the iCloud container (copy-in).
   ///
   /// [containerId] is the iCloud Container Id.
   ///
-  /// [localPath] is the full path of the local file.
+  /// [localPath] is the full path of the local file to copy.
   ///
-  /// [cloudRelativePath] is the relative path of the file in iCloud.
+  /// [cloudRelativePath] is the relative path inside the iCloud container.
   ///
   /// Trailing slashes are rejected here because transfers are file-centric and
   /// coordinated through UIDocument/NSDocument (directories are not supported).
@@ -81,8 +81,8 @@ abstract class ICloudStoragePlatform extends PlatformInterface {
   /// - terminal `done` events
   /// - terminal `error` events (data events, not stream `onError`)
   ///
-  /// The returned future completes without waiting for the file to be uploaded
-  /// to iCloud.
+  /// The returned future completes once the copy finishes; iCloud uploads the
+  /// file automatically in the background. The local file is not kept in sync.
   Future<void> uploadFile({
     required String containerId,
     required String localPath,
@@ -92,13 +92,13 @@ abstract class ICloudStoragePlatform extends PlatformInterface {
     throw UnimplementedError('uploadFile() has not been implemented.');
   }
 
-  /// Download a file from iCloud to a local path.
+  /// Download a file from iCloud, then copy it out to a local path.
   ///
   /// [containerId] is the iCloud Container Id.
   ///
-  /// [cloudRelativePath] is the relative path of the file on iCloud.
+  /// [cloudRelativePath] is the relative path of the file in the container.
 
-  /// [localPath] is the full path where the file should be written locally.
+  /// [localPath] is the full path where the local copy should be written.
   ///
   /// Trailing slashes are rejected here because transfers are file-centric and
   /// coordinated through UIDocument/NSDocument (directories are not supported).
@@ -109,8 +109,8 @@ abstract class ICloudStoragePlatform extends PlatformInterface {
   /// - terminal `done` events
   /// - terminal `error` events (data events, not stream `onError`)
   ///
-  /// The returned future completes without waiting for the file to be
-  /// downloaded.
+  /// The returned future completes once the copy-out finishes (not when iCloud
+  /// completes any background sync). This is not in-place access.
   Future<void> downloadFile({
     required String containerId,
     required String cloudRelativePath,
@@ -118,6 +118,41 @@ abstract class ICloudStoragePlatform extends PlatformInterface {
     StreamHandler<ICloudTransferProgress>? onProgress,
   }) async {
     throw UnimplementedError('downloadFile() has not been implemented.');
+  }
+
+  /// Read a file in place from the iCloud container using coordinated access.
+  ///
+  /// [containerId] is the iCloud Container Id.
+  /// [relativePath] is the relative path to the file inside the container.
+  ///
+  /// Trailing slashes are rejected here because reads are file-centric.
+  ///
+  /// Returns the file contents as a String, or null if the file does not exist.
+  /// Coordinated access uses UIDocument/NSDocument and loads the full contents
+  /// into memory. Use for small text/JSON files.
+  Future<String?> readInPlace({
+    required String containerId,
+    required String relativePath,
+  }) async {
+    throw UnimplementedError('readInPlace() has not been implemented.');
+  }
+
+  /// Write a file in place inside the iCloud container using coordinated
+  /// access.
+  ///
+  /// [containerId] is the iCloud Container Id.
+  /// [relativePath] is the relative path to the file inside the container.
+  /// [contents] is the full contents to write.
+  ///
+  /// Trailing slashes are rejected here because writes are file-centric.
+  /// Coordinated access uses UIDocument/NSDocument and writes the full contents
+  /// as a single operation. Use for small text/JSON files.
+  Future<void> writeInPlace({
+    required String containerId,
+    required String relativePath,
+    required String contents,
+  }) async {
+    throw UnimplementedError('writeInPlace() has not been implemented.');
   }
 
   /// Delete a file from iCloud container directory, whether it is been

--- a/lib/icloud_storage_platform_interface.dart
+++ b/lib/icloud_storage_platform_interface.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:icloud_storage_plus/icloud_storage_method_channel.dart';
 import 'package:icloud_storage_plus/models/gather_result.dart';
 import 'package:icloud_storage_plus/models/transfer_progress.dart';
@@ -128,8 +130,8 @@ abstract class ICloudStoragePlatform extends PlatformInterface {
   /// Trailing slashes are rejected here because reads are file-centric.
   ///
   /// Returns the file contents as a String. Coordinated access uses
-  /// UIDocument/NSDocument and loads the full contents into memory. Use for
-  /// small text/JSON files.
+  /// UIDocument/NSDocument and loads the full contents into memory. Text is
+  /// decoded as UTF-8; use [readInPlaceBytes] for binary formats.
   ///
   /// Throws on file-not-found and other failures.
   ///
@@ -142,6 +144,31 @@ abstract class ICloudStoragePlatform extends PlatformInterface {
     List<Duration>? retryBackoff,
   }) async {
     throw UnimplementedError('readInPlace() has not been implemented.');
+  }
+
+  /// Read a file in place as bytes from the iCloud container using coordinated
+  /// access.
+  ///
+  /// [containerId] is the iCloud Container Id.
+  /// [relativePath] is the relative path to the file inside the container.
+  ///
+  /// Trailing slashes are rejected here because reads are file-centric.
+  ///
+  /// Returns the file contents as bytes. Coordinated access uses
+  /// UIDocument/NSDocument and loads the full contents into memory. Use for
+  /// small files.
+  ///
+  /// [idleTimeouts] controls idle watchdog timeouts between retries.
+  /// [retryBackoff] controls retry delays between attempts.
+  ///
+  /// Throws on file-not-found and other failures.
+  Future<Uint8List?> readInPlaceBytes({
+    required String containerId,
+    required String relativePath,
+    List<Duration>? idleTimeouts,
+    List<Duration>? retryBackoff,
+  }) async {
+    throw UnimplementedError('readInPlaceBytes() has not been implemented.');
   }
 
   /// Write a file in place inside the iCloud container using coordinated
@@ -160,6 +187,24 @@ abstract class ICloudStoragePlatform extends PlatformInterface {
     required String contents,
   }) async {
     throw UnimplementedError('writeInPlace() has not been implemented.');
+  }
+
+  /// Write a file in place as bytes inside the iCloud container using
+  /// coordinated access.
+  ///
+  /// [containerId] is the iCloud Container Id.
+  /// [relativePath] is the relative path to the file inside the container.
+  /// [contents] is the full contents to write.
+  ///
+  /// Trailing slashes are rejected here because writes are file-centric.
+  /// Coordinated access uses UIDocument/NSDocument and writes the full contents
+  /// as a single operation. Use for small files.
+  Future<void> writeInPlaceBytes({
+    required String containerId,
+    required String relativePath,
+    required Uint8List contents,
+  }) async {
+    throw UnimplementedError('writeInPlaceBytes() has not been implemented.');
   }
 
   /// Delete a file from iCloud container directory, whether it is been

--- a/lib/icloud_storage_platform_interface.dart
+++ b/lib/icloud_storage_platform_interface.dart
@@ -127,12 +127,17 @@ abstract class ICloudStoragePlatform extends PlatformInterface {
   ///
   /// Trailing slashes are rejected here because reads are file-centric.
   ///
-  /// Returns the file contents as a String, or null if the file does not exist.
-  /// Coordinated access uses UIDocument/NSDocument and loads the full contents
-  /// into memory. Use for small text/JSON files.
+  /// Returns the file contents as a String. Coordinated access uses
+  /// UIDocument/NSDocument and loads the full contents into memory. Use for
+  /// small text/JSON files.
+  ///
+  /// [idleTimeouts] controls idle watchdog timeouts between retries.
+  /// [retryBackoff] controls retry delays between attempts.
   Future<String?> readInPlace({
     required String containerId,
     required String relativePath,
+    List<Duration>? idleTimeouts,
+    List<Duration>? retryBackoff,
   }) async {
     throw UnimplementedError('readInPlace() has not been implemented.');
   }

--- a/lib/icloud_storage_platform_interface.dart
+++ b/lib/icloud_storage_platform_interface.dart
@@ -131,6 +131,8 @@ abstract class ICloudStoragePlatform extends PlatformInterface {
   /// UIDocument/NSDocument and loads the full contents into memory. Use for
   /// small text/JSON files.
   ///
+  /// Throws on file-not-found and other failures.
+  ///
   /// [idleTimeouts] controls idle watchdog timeouts between retries.
   /// [retryBackoff] controls retry delays between attempts.
   Future<String?> readInPlace({

--- a/macos/Classes/ICloudDocument.swift
+++ b/macos/Classes/ICloudDocument.swift
@@ -344,6 +344,8 @@ extension ICloudStoragePlugin {
     ) {
         let document = ICloudInPlaceDocument()
 
+        // NSDocument reads synchronously; run off the main thread and rely on
+        // its default URL->data read chain (read(from:ofType:) -> read(from:Data:)).
         DispatchQueue.global(qos: .userInitiated).async {
             do {
                 try document.read(from: url, ofType: "public.data")

--- a/macos/Classes/macOSICloudStoragePlugin.swift
+++ b/macos/Classes/macOSICloudStoragePlugin.swift
@@ -677,7 +677,12 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     query.start()
   }
 
-  /// Evaluates download status for a metadata query result.
+  /// Checks if the file is fully downloaded and available for access.
+  ///
+  /// Strategy:
+  /// 1) Index check: resolve via `NSMetadataQuery` results (handles recent moves/renames).
+  /// 2) Filesystem fallback: if query returns no results, use the original `fileURL`
+  ///    to avoid hanging on metadata indexing latency.
   private func evaluateDownloadStatus(
     query: NSMetadataQuery,
     fileURL: URL

--- a/macos/Classes/macOSICloudStoragePlugin.swift
+++ b/macos/Classes/macOSICloudStoragePlugin.swift
@@ -507,7 +507,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     do {
       try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
     } catch {
-      result(nativeCodeError(error))
+      let mapped = mapFileNotFoundError(error) ?? nativeCodeError(error)
+      result(mapped)
       return
     }
 
@@ -527,7 +528,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
 
       readInPlaceDocument(at: fileURL) { [self] contents, error in
         if let error = error {
-          result(nativeCodeError(error))
+          let mapped = mapFileNotFoundError(error) ?? nativeCodeError(error)
+          result(mapped)
           return
         }
 
@@ -605,7 +607,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     do {
       try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
     } catch {
-      result(nativeCodeError(error))
+      let mapped = mapFileNotFoundError(error) ?? nativeCodeError(error)
+      result(mapped)
       return
     }
 
@@ -625,7 +628,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
 
       readInPlaceBinaryDocument(at: fileURL) { [self] contents, error in
         if let error = error {
-          result(nativeCodeError(error))
+          let mapped = mapFileNotFoundError(error) ?? nativeCodeError(error)
+          result(mapped)
           return
         }
 

--- a/macos/Classes/macOSICloudStoragePlugin.swift
+++ b/macos/Classes/macOSICloudStoragePlugin.swift
@@ -654,7 +654,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       for: query,
       name: NSNotification.Name.NSMetadataQueryDidFinishGathering
     ) { [self] _ in
-      let evaluation = evaluateDownloadStatus(query: query)
+      let evaluation = evaluateDownloadStatus(query: query, fileURL: fileURL)
       if evaluation.completed {
         removeObservers(query)
         query.stop()
@@ -666,7 +666,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       for: query,
       name: NSNotification.Name.NSMetadataQueryDidUpdate
     ) { [self] _ in
-      let evaluation = evaluateDownloadStatus(query: query)
+      let evaluation = evaluateDownloadStatus(query: query, fileURL: fileURL)
       if evaluation.completed {
         removeObservers(query)
         query.stop()
@@ -679,14 +679,12 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
 
   /// Evaluates download status for a metadata query result.
   private func evaluateDownloadStatus(
-    query: NSMetadataQuery
+    query: NSMetadataQuery,
+    fileURL: URL
   ) -> (completed: Bool, error: Error?) {
-    guard let fileItem = query.results.first as? NSMetadataItem else {
-      return (false, nil)
-    }
-    guard let resolvedURL = fileItem.value(forAttribute: NSMetadataItemURLKey) as? URL else {
-      return (false, nil)
-    }
+    let resolvedURL = (query.results.first as? NSMetadataItem)
+      .flatMap { $0.value(forAttribute: NSMetadataItemURLKey) as? URL }
+      ?? fileURL
     guard let values = try? resolvedURL.resourceValues(
       forKeys: [.ubiquitousItemDownloadingStatusKey, .ubiquitousItemDownloadingErrorKey]
     ) else {

--- a/macos/Classes/macOSICloudStoragePlugin.swift
+++ b/macos/Classes/macOSICloudStoragePlugin.swift
@@ -40,8 +40,12 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       downloadFile(call, result)
     case "readInPlace":
       readInPlace(call, result)
+    case "readInPlaceBytes":
+      readInPlaceBytes(call, result)
     case "writeInPlace":
       writeInPlace(call, result)
+    case "writeInPlaceBytes":
+      writeInPlaceBytes(call, result)
     case "delete":
       delete(call, result)
     case "move":
@@ -566,6 +570,108 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     }
 
     writeInPlaceDocument(at: fileURL, contents: contents) { [self] error in
+      if let error = error {
+        let mapped = mapFileNotFoundError(error) ?? nativeCodeError(error)
+        result(mapped)
+        return
+      }
+      result(nil)
+    }
+  }
+
+  /// Read a file in place as bytes from the iCloud container using coordinated access.
+  private func readInPlaceBytes(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+    guard let args = call.arguments as? Dictionary<String, Any>,
+          let containerId = args["containerId"] as? String,
+          let relativePath = args["relativePath"] as? String
+    else {
+      result(argumentError)
+      return
+    }
+
+    let idleTimeouts = (args["idleTimeoutSeconds"] as? [NSNumber])?
+      .map { $0.doubleValue } ?? []
+    let retryBackoff = (args["retryBackoffSeconds"] as? [NSNumber])?
+      .map { $0.doubleValue } ?? []
+
+    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
+    else {
+      result(containerError)
+      return
+    }
+
+    let fileURL = containerURL.appendingPathComponent(relativePath)
+
+    do {
+      try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
+    } catch {
+      result(nativeCodeError(error))
+      return
+    }
+
+    waitForDownloadCompletion(
+      fileURL: fileURL,
+      idleTimeouts: idleTimeouts,
+      retryBackoff: retryBackoff
+    ) { [self] error in
+      if let error {
+        if let timeoutError = mapTimeoutError(error) {
+          result(timeoutError)
+          return
+        }
+        result(nativeCodeError(error))
+        return
+      }
+
+      readInPlaceBinaryDocument(at: fileURL) { [self] contents, error in
+        if let error = error {
+          result(nativeCodeError(error))
+          return
+        }
+
+        if let contents {
+          result(FlutterStandardTypedData(bytes: contents))
+        } else {
+          result(nil)
+        }
+      }
+    }
+  }
+
+  /// Write a file in place as bytes inside the iCloud container using coordinated access.
+  private func writeInPlaceBytes(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+    guard let args = call.arguments as? Dictionary<String, Any>,
+          let containerId = args["containerId"] as? String,
+          let relativePath = args["relativePath"] as? String,
+          let contents = args["contents"] as? FlutterStandardTypedData
+    else {
+      result(argumentError)
+      return
+    }
+
+    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
+    else {
+      result(containerError)
+      return
+    }
+
+    let fileURL = containerURL.appendingPathComponent(relativePath)
+
+    do {
+      let dirURL = fileURL.deletingLastPathComponent()
+      if !FileManager.default.fileExists(atPath: dirURL.path) {
+        try FileManager.default.createDirectory(
+          at: dirURL,
+          withIntermediateDirectories: true,
+          attributes: nil
+        )
+      }
+    } catch {
+      result(nativeCodeError(error))
+      return
+    }
+
+    writeInPlaceBinaryDocument(at: fileURL, contents: contents.data) { [self] error in
       if let error = error {
         let mapped = mapFileNotFoundError(error) ?? nativeCodeError(error)
         result(mapped)

--- a/macos/Classes/macOSICloudStoragePlugin.swift
+++ b/macos/Classes/macOSICloudStoragePlugin.swift
@@ -487,6 +487,11 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
+    let idleTimeouts = (args["idleTimeoutSeconds"] as? [NSNumber])?
+      .map { $0.doubleValue } ?? []
+    let retryBackoff = (args["retryBackoffSeconds"] as? [NSNumber])?
+      .map { $0.doubleValue } ?? []
+
     guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
     else {
       result(containerError)
@@ -498,18 +503,18 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     do {
       try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
     } catch {
-      if mapFileNotFoundError(error) != nil {
-        result(nil)
-        return
-      }
       result(nativeCodeError(error))
       return
     }
 
-    waitForDownloadCompletion(fileURL: fileURL) { [self] error in
+    waitForDownloadCompletion(
+      fileURL: fileURL,
+      idleTimeouts: idleTimeouts,
+      retryBackoff: retryBackoff
+    ) { [self] error in
       if let error {
-        if mapFileNotFoundError(error) != nil {
-          result(nil)
+        if let timeoutError = mapTimeoutError(error) {
+          result(timeoutError)
           return
         }
         result(nativeCodeError(error))
@@ -518,10 +523,6 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
 
       readInPlaceDocument(at: fileURL) { [self] contents, error in
         if let error = error {
-          if mapFileNotFoundError(error) != nil {
-            result(nil)
-            return
-          }
           result(nativeCodeError(error))
           return
         }
@@ -614,13 +615,15 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     }
   }
 
-  /// Waits until an iCloud item reports download status "current".
   /// Waits for an iCloud download to reach "current" or fail.
   ///
-  /// Note: there is intentionally no timeout; this waits indefinitely unless
-  /// the download completes or an error is detected.
+  /// Uses an idle watchdog timer that resets only when download progress
+  /// advances. This avoids hard timeouts while still escaping stalled
+  /// downloads.
   private func waitForDownloadCompletion(
     fileURL: URL,
+    idleTimeouts: [TimeInterval],
+    retryBackoff: [TimeInterval],
     completion: @escaping (Error?) -> Void
   ) {
     if let values = try? fileURL.resourceValues(
@@ -636,6 +639,9 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       }
     }
 
+    let idleSchedule = idleTimeouts.isEmpty ? [60, 90, 180] : idleTimeouts
+    let backoffSchedule = retryBackoff.isEmpty ? [2, 4] : retryBackoff
+
     var didComplete = false
     let completeOnce: (Error?) -> Void = { error in
       if didComplete {
@@ -645,40 +651,79 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       completion(error)
     }
 
-    let query = NSMetadataQuery()
-    query.operationQueue = .main
-    query.searchScopes = querySearchScopes
-    query.predicate = NSPredicate(
-      format: "%K == %@",
-      NSMetadataItemPathKey,
-      fileURL.path
-    )
+    func startAttempt(index: Int) {
+      if didComplete { return }
+      let query = NSMetadataQuery()
+      query.operationQueue = .main
+      query.searchScopes = querySearchScopes
+      query.predicate = NSPredicate(
+        format: "%K == %@",
+        NSMetadataItemPathKey,
+        fileURL.path
+      )
 
-    addObserver(
-      for: query,
-      name: NSNotification.Name.NSMetadataQueryDidFinishGathering
-    ) { [self] _ in
-      let evaluation = evaluateDownloadStatus(query: query, fileURL: fileURL)
-      if evaluation.completed {
-        removeObservers(query)
-        query.stop()
-        completeOnce(evaluation.error)
+      var watchdogTimer: Timer?
+      var lastProgress = -1.0
+
+      let resetWatchdog: () -> Void = {
+        watchdogTimer?.invalidate()
+        watchdogTimer = Timer.scheduledTimer(
+          withTimeInterval: idleSchedule[index],
+          repeats: false
+        ) { [self] _ in
+          removeObservers(query)
+          query.stop()
+          if index < idleSchedule.count - 1 {
+            let delayIndex = min(index, backoffSchedule.count - 1)
+            let delay = backoffSchedule[delayIndex]
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+              startAttempt(index: index + 1)
+            }
+            return
+          }
+          completeOnce(timeoutNativeError())
+        }
       }
+
+      let handleEvaluation: () -> Void = { [self] in
+        let evaluation = evaluateDownloadStatus(query: query, fileURL: fileURL)
+        if evaluation.completed {
+          watchdogTimer?.invalidate()
+          removeObservers(query)
+          query.stop()
+          completeOnce(evaluation.error)
+          return
+        }
+
+        if let item = query.results.first as? NSMetadataItem,
+           let progress = item.value(
+             forAttribute: NSMetadataUbiquitousItemPercentDownloadedKey
+           ) as? Double,
+           progress > lastProgress {
+          lastProgress = progress
+          resetWatchdog()
+        }
+      }
+
+      addObserver(
+        for: query,
+        name: NSNotification.Name.NSMetadataQueryDidFinishGathering
+      ) { _ in
+        handleEvaluation()
+      }
+
+      addObserver(
+        for: query,
+        name: NSNotification.Name.NSMetadataQueryDidUpdate
+      ) { _ in
+        handleEvaluation()
+      }
+
+      resetWatchdog()
+      query.start()
     }
 
-    addObserver(
-      for: query,
-      name: NSNotification.Name.NSMetadataQueryDidUpdate
-    ) { [self] _ in
-      let evaluation = evaluateDownloadStatus(query: query, fileURL: fileURL)
-      if evaluation.completed {
-        removeObservers(query)
-        query.stop()
-        completeOnce(evaluation.error)
-      }
-    }
-
-    query.start()
+    startAttempt(index: 0)
   }
 
   /// Checks if the file is fully downloaded and available for access.
@@ -694,26 +739,20 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     let resolvedURL = (query.results.first as? NSMetadataItem)
       .flatMap { $0.value(forAttribute: NSMetadataItemURLKey) as? URL }
       ?? fileURL
-    do {
-      let values = try resolvedURL.resourceValues(
-        forKeys: [.ubiquitousItemDownloadingStatusKey, .ubiquitousItemDownloadingErrorKey]
-      )
-
-      if let error = values.ubiquitousItemDownloadingError {
-        return (true, error)
-      }
-
-      if values.ubiquitousItemDownloadingStatus == URLUbiquitousItemDownloadingStatus.current {
-        return (true, nil)
-      }
-      return (false, nil)
-    } catch {
-      let nsError = error as NSError
-      if nsError.domain == NSCocoaErrorDomain && nsError.code == NSFileNoSuchFileError {
-        return (true, fileNotFoundError)
-      }
+    guard let values = try? resolvedURL.resourceValues(
+      forKeys: [.ubiquitousItemDownloadingStatusKey, .ubiquitousItemDownloadingErrorKey]
+    ) else {
       return (false, nil)
     }
+
+    if let error = values.ubiquitousItemDownloadingError {
+      return (true, error)
+    }
+
+    if values.ubiquitousItemDownloadingStatus == URLUbiquitousItemDownloadingStatus.current {
+      return (true, nil)
+    }
+    return (false, nil)
   }
   
   /// Check if an item exists without downloading.
@@ -1014,6 +1053,11 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   let containerError = FlutterError(code: "E_CTR", message: "Invalid containerId, or user is not signed in, or user disabled iCloud permission", details: nil)
   let fileNotFoundError = FlutterError(code: "E_FNF", message: "The file does not exist", details: nil)
   let initializationError = FlutterError(code: "E_INIT", message: "Plugin not properly initialized", details: nil)
+  let timeoutError = FlutterError(
+    code: "E_TIMEOUT",
+    message: "The download did not make progress before timing out",
+    details: nil
+  )
 
   /// Maps file-not-found errors to specific Flutter error codes.
   private func mapFileNotFoundError(_ error: Error) -> FlutterError? {
@@ -1035,6 +1079,20 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   /// Wraps a native Error into a FlutterError.
   private func nativeCodeError(_ error: Error) -> FlutterError {
     return FlutterError(code: "E_NAT", message: "Native Code Error", details: "\(error)")
+  }
+
+  private func timeoutNativeError() -> NSError {
+    return NSError(
+      domain: "ICloudStorageTimeout",
+      code: 1,
+      userInfo: [NSLocalizedDescriptionKey: "Download idle timeout"]
+    )
+  }
+
+  private func mapTimeoutError(_ error: Error) -> FlutterError? {
+    let nsError = error as NSError
+    guard nsError.domain == "ICloudStorageTimeout" else { return nil }
+    return timeoutError
   }
 }
 

--- a/macos/Classes/macOSICloudStoragePlugin.swift
+++ b/macos/Classes/macOSICloudStoragePlugin.swift
@@ -506,8 +506,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
-    readInPlaceDocument(at: fileURL) { [self] contents, error in
-      if let error = error {
+    waitForDownloadCompletion(fileURL: fileURL) { [self] error in
+      if let error {
         if mapFileNotFoundError(error) != nil {
           result(nil)
           return
@@ -516,7 +516,18 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
         return
       }
 
-      result(contents)
+      readInPlaceDocument(at: fileURL) { [self] contents, error in
+        if let error = error {
+          if mapFileNotFoundError(error) != nil {
+            result(nil)
+            return
+          }
+          result(nativeCodeError(error))
+          return
+        }
+
+        result(contents)
+      }
     }
   }
 
@@ -597,11 +608,99 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     if !query.isStarted {
       return
     }
-    let streamHandler = self.streamHandlers[eventChannelName]
     guard let fileItem = query.results.first as? NSMetadataItem else { return }
     if let progress = fileItem.value(forAttribute: NSMetadataUbiquitousItemPercentDownloadedKey) as? Double {
       emitProgress(progress, eventChannelName: eventChannelName)
     }
+  }
+
+  /// Waits until an iCloud item reports download status "current".
+  private func waitForDownloadCompletion(
+    fileURL: URL,
+    completion: @escaping (Error?) -> Void
+  ) {
+    if let values = try? fileURL.resourceValues(
+      forKeys: [.ubiquitousItemDownloadingStatusKey, .ubiquitousItemDownloadingErrorKey]
+    ) {
+      if let error = values.ubiquitousItemDownloadingError {
+        completion(error)
+        return
+      }
+      if values.ubiquitousItemDownloadingStatus == URLUbiquitousItemDownloadingStatus.current {
+        completion(nil)
+        return
+      }
+    }
+
+    var didComplete = false
+    let completeOnce: (Error?) -> Void = { error in
+      if didComplete {
+        return
+      }
+      didComplete = true
+      completion(error)
+    }
+
+    let query = NSMetadataQuery()
+    query.operationQueue = .main
+    query.searchScopes = querySearchScopes
+    query.predicate = NSPredicate(
+      format: "%K == %@",
+      NSMetadataItemPathKey,
+      fileURL.path
+    )
+
+    addObserver(
+      for: query,
+      name: NSNotification.Name.NSMetadataQueryDidFinishGathering
+    ) { [self] _ in
+      let evaluation = evaluateDownloadStatus(query: query)
+      if evaluation.completed {
+        removeObservers(query)
+        query.stop()
+        completeOnce(evaluation.error)
+      }
+    }
+
+    addObserver(
+      for: query,
+      name: NSNotification.Name.NSMetadataQueryDidUpdate
+    ) { [self] _ in
+      let evaluation = evaluateDownloadStatus(query: query)
+      if evaluation.completed {
+        removeObservers(query)
+        query.stop()
+        completeOnce(evaluation.error)
+      }
+    }
+
+    query.start()
+  }
+
+  /// Evaluates download status for a metadata query result.
+  private func evaluateDownloadStatus(
+    query: NSMetadataQuery
+  ) -> (completed: Bool, error: Error?) {
+    guard let fileItem = query.results.first as? NSMetadataItem else {
+      return (false, nil)
+    }
+    guard let resolvedURL = fileItem.value(forAttribute: NSMetadataItemURLKey) as? URL else {
+      return (false, nil)
+    }
+    guard let values = try? resolvedURL.resourceValues(
+      forKeys: [.ubiquitousItemDownloadingStatusKey, .ubiquitousItemDownloadingErrorKey]
+    ) else {
+      return (false, nil)
+    }
+
+    if let error = values.ubiquitousItemDownloadingError {
+      return (true, error)
+    }
+
+    if values.ubiquitousItemDownloadingStatus == URLUbiquitousItemDownloadingStatus.current {
+      return (true, nil)
+    }
+    return (false, nil)
   }
   
   /// Check if an item exists without downloading.

--- a/macos/Classes/macOSICloudStoragePlugin.swift
+++ b/macos/Classes/macOSICloudStoragePlugin.swift
@@ -38,6 +38,10 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       uploadFile(call, result)
     case "downloadFile":
       downloadFile(call, result)
+    case "readInPlace":
+      readInPlace(call, result)
+    case "writeInPlace":
+      writeInPlace(call, result)
     case "delete":
       delete(call, result)
     case "move":
@@ -223,7 +227,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     return relative
   }
   
-  /// Uploads a local file into the iCloud container.
+  /// Copies a local file into the iCloud container (copy-in).
+  /// iCloud uploads the container file automatically in the background.
   private func uploadFile(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
     guard let args = call.arguments as? Dictionary<String, Any>,
           let containerId = args["containerId"] as? String,
@@ -365,7 +370,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     }
   }
   
-  /// Downloads a remote item to a local file, optionally reporting progress.
+  /// Downloads an iCloud item if needed, then copies it out to a local path.
   private func downloadFile(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
     guard let args = call.arguments as? Dictionary<String, Any>,
           let containerId = args["containerId"] as? String,
@@ -469,6 +474,92 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       }
       removeStreamHandler(eventChannelName)
       completeOnce(nil)
+    }
+  }
+
+  /// Read a file in place from the iCloud container using coordinated access.
+  private func readInPlace(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+    guard let args = call.arguments as? Dictionary<String, Any>,
+          let containerId = args["containerId"] as? String,
+          let relativePath = args["relativePath"] as? String
+    else {
+      result(argumentError)
+      return
+    }
+
+    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
+    else {
+      result(containerError)
+      return
+    }
+
+    let fileURL = containerURL.appendingPathComponent(relativePath)
+
+    do {
+      try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
+    } catch {
+      if mapFileNotFoundError(error) != nil {
+        result(nil)
+        return
+      }
+      result(nativeCodeError(error))
+      return
+    }
+
+    readInPlaceDocument(at: fileURL) { [self] contents, error in
+      if let error = error {
+        if mapFileNotFoundError(error) != nil {
+          result(nil)
+          return
+        }
+        result(nativeCodeError(error))
+        return
+      }
+
+      result(contents)
+    }
+  }
+
+  /// Write a file in place inside the iCloud container using coordinated access.
+  private func writeInPlace(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+    guard let args = call.arguments as? Dictionary<String, Any>,
+          let containerId = args["containerId"] as? String,
+          let relativePath = args["relativePath"] as? String,
+          let contents = args["contents"] as? String
+    else {
+      result(argumentError)
+      return
+    }
+
+    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
+    else {
+      result(containerError)
+      return
+    }
+
+    let fileURL = containerURL.appendingPathComponent(relativePath)
+
+    do {
+      let dirURL = fileURL.deletingLastPathComponent()
+      if !FileManager.default.fileExists(atPath: dirURL.path) {
+        try FileManager.default.createDirectory(
+          at: dirURL,
+          withIntermediateDirectories: true,
+          attributes: nil
+        )
+      }
+    } catch {
+      result(nativeCodeError(error))
+      return
+    }
+
+    writeInPlaceDocument(at: fileURL, contents: contents) { [self] error in
+      if let error = error {
+        let mapped = mapFileNotFoundError(error) ?? nativeCodeError(error)
+        result(mapped)
+        return
+      }
+      result(nil)
     }
   }
   

--- a/test/icloud_storage_method_channel_test.dart
+++ b/test/icloud_storage_method_channel_test.dart
@@ -57,6 +57,10 @@ void main() {
           };
         case 'getContainerPath':
           return '/container/path';
+        case 'readInPlace':
+          return 'contents';
+        case 'writeInPlace':
+          return null;
         default:
           return null;
       }
@@ -190,6 +194,33 @@ void main() {
       final eventChannelName = args['eventChannelName'] as String?;
       expect(eventChannelName, isNotNull);
       expect(eventChannelName, isNotEmpty);
+    });
+  });
+
+  group('readInPlace tests:', () {
+    test('readInPlace', () async {
+      final result = await platform.readInPlace(
+        containerId: containerId,
+        relativePath: 'Documents/test.json',
+      );
+      final args = mockArguments();
+      expect(args['containerId'], containerId);
+      expect(args['relativePath'], 'Documents/test.json');
+      expect(result, 'contents');
+    });
+  });
+
+  group('writeInPlace tests:', () {
+    test('writeInPlace', () async {
+      await platform.writeInPlace(
+        containerId: containerId,
+        relativePath: 'Documents/test.json',
+        contents: '{"ok":true}',
+      );
+      final args = mockArguments();
+      expect(args['containerId'], containerId);
+      expect(args['relativePath'], 'Documents/test.json');
+      expect(args['contents'], '{"ok":true}');
     });
   });
 

--- a/test/icloud_storage_method_channel_test.dart
+++ b/test/icloud_storage_method_channel_test.dart
@@ -59,7 +59,11 @@ void main() {
           return '/container/path';
         case 'readInPlace':
           return 'contents';
+        case 'readInPlaceBytes':
+          return Uint8List.fromList([1, 2, 3]);
         case 'writeInPlace':
+          return null;
+        case 'writeInPlaceBytes':
           return null;
         default:
           return null;
@@ -229,6 +233,38 @@ void main() {
     });
   });
 
+  group('readInPlaceBytes tests:', () {
+    test('readInPlaceBytes', () async {
+      final result = await platform.readInPlaceBytes(
+        containerId: containerId,
+        relativePath: 'Documents/data.bin',
+      );
+      final args = mockArguments();
+      expect(args['containerId'], containerId);
+      expect(args['relativePath'], 'Documents/data.bin');
+      expect(result, Uint8List.fromList([1, 2, 3]));
+    });
+
+    test('passes idle timeout and retry backoff settings', () async {
+      await platform.readInPlaceBytes(
+        containerId: containerId,
+        relativePath: 'Documents/data.bin',
+        idleTimeouts: const [
+          Duration(seconds: 60),
+          Duration(seconds: 90),
+          Duration(seconds: 180),
+        ],
+        retryBackoff: const [
+          Duration(seconds: 2),
+          Duration(seconds: 4),
+        ],
+      );
+      final args = mockArguments();
+      expect(args['idleTimeoutSeconds'], [60, 90, 180]);
+      expect(args['retryBackoffSeconds'], [2, 4]);
+    });
+  });
+
   group('writeInPlace tests:', () {
     test('writeInPlace', () async {
       await platform.writeInPlace(
@@ -240,6 +276,20 @@ void main() {
       expect(args['containerId'], containerId);
       expect(args['relativePath'], 'Documents/test.json');
       expect(args['contents'], '{"ok":true}');
+    });
+  });
+
+  group('writeInPlaceBytes tests:', () {
+    test('writeInPlaceBytes', () async {
+      await platform.writeInPlaceBytes(
+        containerId: containerId,
+        relativePath: 'Documents/data.bin',
+        contents: Uint8List.fromList([4, 5, 6]),
+      );
+      final args = mockArguments();
+      expect(args['containerId'], containerId);
+      expect(args['relativePath'], 'Documents/data.bin');
+      expect(args['contents'], Uint8List.fromList([4, 5, 6]));
     });
   });
 

--- a/test/icloud_storage_method_channel_test.dart
+++ b/test/icloud_storage_method_channel_test.dart
@@ -208,6 +208,25 @@ void main() {
       expect(args['relativePath'], 'Documents/test.json');
       expect(result, 'contents');
     });
+
+    test('passes idle timeout and retry backoff settings', () async {
+      await platform.readInPlace(
+        containerId: containerId,
+        relativePath: 'Documents/test.json',
+        idleTimeouts: const [
+          Duration(seconds: 60),
+          Duration(seconds: 90),
+          Duration(seconds: 180),
+        ],
+        retryBackoff: const [
+          Duration(seconds: 2),
+          Duration(seconds: 4),
+        ],
+      );
+      final args = mockArguments();
+      expect(args['idleTimeoutSeconds'], [60, 90, 180]);
+      expect(args['retryBackoffSeconds'], [2, 4]);
+    });
   });
 
   group('writeInPlace tests:', () {

--- a/test/icloud_storage_method_channel_test.dart
+++ b/test/icloud_storage_method_channel_test.dart
@@ -18,7 +18,7 @@ void main() {
 
   setUp(() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        .setMockMethodCallHandler(channel, (methodCall) async {
       mockMethodCall = methodCall;
       switch (methodCall.method) {
         case 'createEventChannel':
@@ -103,7 +103,7 @@ void main() {
 
     test('directory paths preserve trailing slashes', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+          .setMockMethodCallHandler(channel, (methodCall) async {
         if (methodCall.method == 'gather') {
           return [
             {
@@ -227,7 +227,7 @@ void main() {
   group('transfer progress stream tests:', () {
     test('maps numeric events and completion', () async {
       mockStreamHandler = MockStreamHandler.inline(
-        onListen: (Object? arguments, MockStreamHandlerEventSink events) {
+        onListen: (arguments, events) {
           events
             ..success(0.25)
             ..success(1.0)
@@ -257,7 +257,7 @@ void main() {
 
     test('maps error events to error progress', () async {
       mockStreamHandler = MockStreamHandler.inline(
-        onListen: (Object? arguments, MockStreamHandlerEventSink events) {
+        onListen: (arguments, events) {
           events.error(
             code: 'E_TEST',
             message: 'Boom',
@@ -288,7 +288,7 @@ void main() {
 
     test('delivers events after listener attaches', () async {
       mockStreamHandler = MockStreamHandler.inline(
-        onListen: (Object? arguments, MockStreamHandlerEventSink events) {
+        onListen: (arguments, events) {
           events
             ..success(0.1)
             ..endOfStream();

--- a/test/icloud_storage_test.dart
+++ b/test/icloud_storage_test.dart
@@ -92,6 +92,8 @@ class MockICloudStoragePlatform
   Future<String?> readInPlace({
     required String containerId,
     required String relativePath,
+    List<Duration>? idleTimeouts,
+    List<Duration>? retryBackoff,
   }) async {
     _readInPlaceRelativePath = relativePath;
     _calls.add('readInPlace');


### PR DESCRIPTION
## Summary
- add UIDocument/NSDocument in-place read/write for small text/JSON files
- remove file-existence precheck and map file-not-found to null for in-place reads
- clarify copy-in/copy-out semantics in README/CHANGELOG and internal docs
- add method-channel and API tests for in-place access

## Testing
- flutter analyze (log: analysis/icloud_storage_plus_flutter_analyze.log)
- flutter test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kingdomseed/icloud_storage_plus/pull/10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
