### PR TITLE
Fix ios crash

### DIFF
--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
@@ -1363,11 +1363,14 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     }
 
     let streamHandler = StreamHandler()
-    let eventChannel = FlutterEventChannel(name: eventChannelName, binaryMessenger: messenger)
-    eventChannel.setStreamHandler(streamHandler)
-    setStreamHandler(streamHandler, for: eventChannelName)
+    DispatchQueue.main.async {
+        let eventChannel = FlutterEventChannel(name: eventChannelName, binaryMessenger: messenger)
+        eventChannel.setStreamHandler(streamHandler)
+        
+        self.setStreamHandler(streamHandler, for: eventChannelName)
 
-    result(nil)
+        result(nil)
+    }
   }
   
   /// Removes a stream handler for the given event channel.


### PR DESCRIPTION
Hey,

I experienced an crash on iOS when I call uploadFile with a onProgress.
The XCode error was SIGABRT.

With this fix it works again. Please have a look.

Sample code:
`StreamSubscription? uploadProgressSub;
      await ICloudStorage.uploadFile(
          containerId: mediaContainerId,
          localPath: path,
          cloudRelativePath: destinationRelativePath,
          onProgress: (stream) {
            uploadProgressSub = stream.listen(
              (progress) => log.d('Upload File Progress: $progress'),
              onDone: () => log.d('Upload File Done'),
              onError: (err) => log.e('Upload File Error', error: err),
              cancelOnError: true,
            );
          },
        );`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kingdomseed/icloud_storage_plus/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the threading behavior of `createEventChannel`, which can affect call ordering/timing and could expose subtle race conditions, but the diff is small and isolated to event-channel setup.
> 
> **Overview**
> Fixes an iOS crash when using `uploadFile` progress callbacks by ensuring `FlutterEventChannel` creation and `setStreamHandler` registration happen on the main thread.
> 
> `createEventChannel` now wraps event-channel initialization, internal handler registration, and the `result(nil)` callback in `DispatchQueue.main.async`, aligning with Flutter/iOS thread expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 728933f7ba400c85d1e497d68b0628c63330b733. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->