### PR TITLE
⚡ optimize listContents loop in iOS and macOS plugins

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -84,9 +84,29 @@ let endNew = CFAbsoluteTimeGetCurrent()
 print("New implementation time: \\(endNew - startNew) seconds")
 ```
 
+## Additional Optimization: Tight Loop Efficiency in listContents
+
+In the `listContents` method (both iOS and macOS), we further reduced redundant
+work inside the `for fileURL in contents` loop:
+
+1.  **Avoided Redundant Set Creation**: `Set(keys)` was moved outside the loop.
+    This prevents repeated allocations and hashing for every item in the
+    directory.
+2.  **Pre-calculated Parent Relative Path**: Since `listContents` enumerates a
+    single directory (`listURL`), the parent's relative path is constant for all
+    items. We now calculate `parentRelative` once before the loop using
+    `self.relativePath(for: listURL, containerPath: containerPath)`. This avoids
+    calling `standardizedFileURL.path` and the `relativePath` logic $O(N)$
+    times.
+3.  **Check Reordering**: We moved the hidden file skip check
+    (`resolvedName.hasPrefix(".")`) *before* the `resourceValues(forKeys:)` call.
+    This saves a system call for properties on every hidden file (like
+    `.DS_Store` or `.Trash`).
+
 ## Affected Methods
 - `relativePath(for:containerURL:)` -> `relativePath(for:containerPath:)`
 - `mapMetadataItem(_:containerURL:)` -> `mapMetadataItem(_:containerPath:)`
 - `mapResourceValues(fileURL:values:containerURL:)` -> `mapResourceValues(fileURL:values:containerPath:)`
 - `mapFileAttributesFromQuery(query:containerURL:)` (Implementation updated)
 - `getDocumentMetadata` (Implementation updated)
+- `listContents` (Loop optimized in both iOS and macOS plugins)

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
@@ -1067,13 +1067,13 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
         )
 
         let containerPath = containerURL.standardizedFileURL.path
+        let keysSet = Set(keys)
+        let parentRelative = self.relativePath(
+          for: listURL, containerPath: containerPath
+        )
         var items: [[String: Any?]] = []
 
         for fileURL in contents {
-          let values = try fileURL.resourceValues(
-            forKeys: Set(keys)
-          )
-
           let diskName = fileURL.lastPathComponent
           let resolvedName = self.resolveICloudPlaceholderName(diskName)
 
@@ -1082,12 +1082,12 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           // to their real name, so they pass through this filter.
           if resolvedName.hasPrefix(".") { continue }
 
+          let values = try fileURL.resourceValues(
+            forKeys: keysSet
+          )
+
           // Build relative path from the container root so the
           // result is usable with other plugin methods.
-          let parentURL = fileURL.deletingLastPathComponent()
-          let parentRelative = self.relativePath(
-            for: parentURL, containerPath: containerPath
-          )
           let itemRelativePath = parentRelative.isEmpty
             ? resolvedName
             : parentRelative + "/" + resolvedName

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
@@ -1028,13 +1028,13 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
         )
 
         let containerPath = containerURL.standardizedFileURL.path
+        let keysSet = Set(keys)
+        let parentRelative = self.relativePath(
+          for: listURL, containerPath: containerPath
+        )
         var items: [[String: Any?]] = []
 
         for fileURL in contents {
-          let values = try fileURL.resourceValues(
-            forKeys: Set(keys)
-          )
-
           let diskName = fileURL.lastPathComponent
           let resolvedName = self.resolveICloudPlaceholderName(diskName)
 
@@ -1043,12 +1043,12 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           // to their real name, so they pass through this filter.
           if resolvedName.hasPrefix(".") { continue }
 
+          let values = try fileURL.resourceValues(
+            forKeys: keysSet
+          )
+
           // Build relative path from the container root so the
           // result is usable with other plugin methods.
-          let parentURL = fileURL.deletingLastPathComponent()
-          let parentRelative = self.relativePath(
-            for: parentURL, containerPath: containerPath
-          )
           let itemRelativePath = parentRelative.isEmpty
             ? resolvedName
             : parentRelative + "/" + resolvedName

--- a/test/icloud_storage_method_channel_test.dart
+++ b/test/icloud_storage_method_channel_test.dart
@@ -65,6 +65,18 @@ void main() {
           return null;
         case 'writeInPlaceBytes':
           return null;
+        case 'listContents':
+          return [
+            {
+              'relativePath': 'file.txt',
+              'isDirectory': false,
+              'downloadStatus': 'current',
+              'isDownloading': false,
+              'isUploaded': true,
+              'isUploading': false,
+              'hasUnresolvedConflicts': false,
+            }
+          ];
         default:
           return null;
       }
@@ -436,5 +448,15 @@ void main() {
   test('getContainerPath', () async {
     final path = await platform.getContainerPath(containerId: containerId);
     expect(path, '/container/path');
+  });
+
+  test('listContents maps results correctly', () async {
+    final results = await platform.listContents(containerId: containerId);
+    expect(results, hasLength(1));
+    final item = results.first;
+    expect(item.relativePath, 'file.txt');
+    expect(item.isDirectory, false);
+    expect(item.isDownloaded, true);
+    expect(item.isUploaded, true);
   });
 }


### PR DESCRIPTION
💡 **What:** This optimization improves the performance of the `listContents` method by reducing redundant calculations and method calls within the file enumeration loop. Specifically:
- `Set(keys)` is now pre-calculated outside the loop to avoid repeated allocations and hashing.
- The `parentRelative` path for the current directory is pre-calculated once, avoiding repeated expensive `standardizedFileURL.path` filesystem calls and relative path logic for every child.
- The hidden file skip check is moved *before* the `resourceValues(forKeys:)` call to save overhead for files that are excluded from the results anyway.
- These optimizations were applied to both the iOS and macOS implementations for parity.

🎯 **Why:** The previous implementation performed $O(N)$ redundant operations inside the loop for every file in the directory, leading to unnecessary CPU cycles and memory allocations, especially in large folders.

📊 **Measured Improvement:** While environmental constraints (timeouts) prevented running a full benchmark suite, these optimizations eliminate $O(N)$ repeated path normalizations and $O(N)$ `Set` creations. Similar string/path normalization refactors in this codebase have shown measurable performance gains.

---
*PR created automatically by Jules for task [12452439657764278921](https://jules.google.com/task/12452439657764278921) started by @kingdomseed*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kingdomseed/icloud_storage_plus/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
