### PR TITLE
fix(ios,macos): reset writeInPlace contract handling

### DIFF
--- a/docs/superpowers/plans/2026-04-18-icloud-write-path-reset-contract-audit.md
+++ b/docs/superpowers/plans/2026-04-18-icloud-write-path-reset-contract-audit.md
@@ -15,34 +15,22 @@ Scope: Part 1 contract lock for the reset worktree
   `E_DOWNLOAD_IN_PROGRESS` native branch. Part 1 does not keep that branch as a
   terminal write outcome.
 
-## Locked Write Outcomes
+## Part 1 Lock Summary
 
-| State | Native behavior target | Dart-visible category/code | Retryable | Contract note |
-|---|---|---|---|---|
-| Destination missing | Overwrite path reports `handled == false`; existing entrypoint falls back to its current create-or-not-found behavior | No new overwrite-only category | Existing behavior | Part 1 keeps the current entrypoint contract instead of inventing a new overwrite error |
-| Destination path resolves to an existing directory | Preserve the stable invalid-argument outcome | `invalidArgument` / `E_ARG` | No | This may use a minimal validation seam or a mapped OS failure; the dedicated helper is not locked |
-| Destination is a ubiquitous item that is not locally current | Attempt download and wait for localization before overwrite | No error if recovery succeeds | N/A | `downloadInProgress` becomes a transient internal state, not a final write result |
-| Destination download stalls | Surface stable timeout | `timeout` / `E_TIMEOUT` | Yes | Keep the idle-timeout contract |
-| Destination download cannot become current | Surface stable not-downloaded failure | `itemNotDownloaded` / `E_NOT_DOWNLOADED` | Yes | Keep the typed split between timeout and not-downloaded |
-| Destination has conflicts and recovery succeeds | Recover, then continue overwrite | No error if recovery succeeds | N/A | Recovery is allowed to be explicit write-path cleanup, not observer winner-selection |
-| Conflict recovery fails before replacement write | Surface stable conflict failure | `conflict` / `E_CONFLICT` | No | Include underlying native details |
-| Replacement write succeeds but post-write cleanup fails | The user's replacement remains the conceptual winner, but the operation still reports failure because cleanup is part of honest success | `conflict` / `E_CONFLICT` | No | Do not roll back to old-content-wins semantics or silently report success |
-| Coordination fails | Surface stable coordination failure | `coordination` / `E_COORDINATION` | No by default | Revisit retryability only if an existing stable mapping proves otherwise |
-| Unknown native write failure | Preserve structured fallback | `unknownNative` / `E_NAT` | No | Fallback only |
+The normative contract remains in
+`docs/superpowers/specs/2026-04-18-icloud-write-path-reset-design.md`.
 
-## Locked Behavioral Decisions
+This audit records the Part 1 locks that implementation must preserve:
 
-- `writeInPlace` and `writeInPlaceBytes` stay public API names.
-- The overwrite sequence is: detect existing destination, localize if needed,
-  write replacement, then run post-write conflict cleanup.
-- Post-write cleanup is part of honest success. A cleanup failure is visible to
-  Dart even if the replacement already won.
-- The write path does not reuse observer winner-selection semantics.
-- The reset keeps the current destination-missing behavior per entrypoint.
-- The reset keeps the current typed download failure split:
-  `E_NOT_DOWNLOADED` versus `E_TIMEOUT`.
-- The reset drops write-path-specific `E_DOWNLOAD_IN_PROGRESS` as a terminal
-  contract outcome.
+- public write API names stay stable where truthful
+- destination-missing behavior stays tied to the existing entrypoint contract
+- `invalidArgument` / `E_ARG` remains the locked directory-destination outcome
+- `itemNotDownloaded` / `E_NOT_DOWNLOADED` and `timeout` / `E_TIMEOUT`
+  remain the locked download failure split
+- post-write cleanup remains part of honest success, so cleanup failure stays
+  visible instead of silently succeeding
+- save-path conflict handling stays separate from observer winner-selection
+- `E_DOWNLOAD_IN_PROGRESS` does not survive as a terminal write-path outcome
 
 ## Method Inventory
 
@@ -66,7 +54,21 @@ Scope: Part 1 contract lock for the reset worktree
 
 ### `macos/.../icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift`
 
-- Mirror the iOS decisions exactly. Contract divergence is not allowed.
+- `overwriteExistingItem(at:prepareReplacementFile:)`: Keep, but simplify
+  around the locked overwrite sequence and post-write cleanup ordering.
+- `fileDestinationError(isDirectory:)`: Merge into the smallest honest
+  invalid-argument seam that preserves `E_ARG`.
+- `replaceReadyStateError(...)`: Simplify so it only models locked write-path
+  outcomes; remove the terminal `downloadInProgress` branch and stop treating
+  recoverable conflicts as a preflight refusal.
+- `verifyExistingDestinationCanBeReplaced(at:)`: Merge away from the overwrite
+  path. If copy-path behavior still needs a broader readiness check, keep that
+  logic in a copy-specific seam instead of the overwrite contract.
+- `verifyFileDestinationCanBeOverwritten(at:)`: Simplify to the minimum
+  directory-validation seam, or delete if mapped OS failure can honestly keep
+  `E_ARG`.
+- `live`: Keep, but simplify to a direct coordinator bridge plus replacement
+  staging and cleanup wiring.
 
 ### `ios/.../icloud_storage_plus/iOSICloudStoragePlugin.swift`
 
@@ -85,34 +87,49 @@ Scope: Part 1 contract lock for the reset worktree
 
 ### `macos/.../icloud_storage_plus/macOSICloudStoragePlugin.swift`
 
-- Mirror the iOS decisions exactly. Contract divergence is not allowed.
+- `writeInPlace(_:_: )`: Keep. Simplify only enough to preserve the current
+  destination-missing behavior and route overwrite failures through the locked
+  categories.
+- `writeInPlaceBytes(_:_: )`: Keep with the same contract as `writeInPlace`.
+- `mapFileNotFoundError(...)`: Keep to preserve the current write/read
+  not-found split.
+- `nativeCodeError(...)`: Keep, but simplify to the locked write outcomes.
+  Remove the write-path-specific `E_DOWNLOAD_IN_PROGRESS` mapping when the
+  writer stops emitting it.
+- `timeoutNativeError()`: Keep.
+- `mapTimeoutError(...)`: Keep.
+- `flutterError(...)`: Keep as the shared Flutter error envelope.
 
-### Conflict Helper Extraction Decision
+### Observer Conflict Extraction Scope
 
-- Part 2 should introduce `ConflictResolver.swift` on iOS and macOS by
-  extracting the observer-only winner-selection logic that currently lives in
-  `ICloudDocument.resolveConflicts()`.
-- The extracted observer helper should be kept as an observer-specific
-  resolver, not reused as the write-path winner-selection model.
-- The write path should get a separate cleanup helper that marks conflicts
-  resolved and removes other versions without restoring an older winner.
+- Part 2 should extract the observer-only conflict work that currently lives
+  inside `ICloudDocument.resolveConflicts()` into a dedicated foundation seam.
+- The extracted observer seam should remain observer-specific and should not
+  become the save-path winner-selection model.
+- The write path should use a separate cleanup seam whose job is cleanup, not
+  selecting an older winner.
 
-### `ios/.../icloud_storage_plus_foundation/ConflictResolver.swift`
+### `ios observer conflict extraction scope`
 
-- `resolvePresentedItemConflictsSync(at:)`: Keep as the observer-specific
-  winner-selection helper extracted from `ICloudDocument.resolveConflicts()`.
-- `resolvePresentedItemConflicts(at:)`: Keep as the async wrapper only if
-  observer call sites still need an async surface after extraction; otherwise
-  merge into the sync helper's call sites.
-- `cleanupConflictsAfterOverwrite(at:)`: Keep as a write-path-specific cleanup
-  helper that marks conflicts resolved and removes other versions without
-  restoring an older winner.
-- Any attempt to reuse observer winner-selection for save-path cleanup:
-  Delete.
+- current observer winner-selection logic in `ICloudDocument.resolveConflicts()`:
+  Extract and Keep as an observer-only foundation helper
+- any separate async wrapper around observer conflict resolution:
+  Merge unless surviving observer call sites require it
+- write-path post-overwrite conflict cleanup seam:
+  Add and Keep as a cleanup-only helper
+- any save-path helper that restores an older conflict version as the winner:
+  Delete
 
-### `macos/.../icloud_storage_plus_foundation/ConflictResolver.swift`
+### `macos observer conflict extraction scope`
 
-- Mirror the iOS decisions exactly. Contract divergence is not allowed.
+- current observer winner-selection logic in `ICloudDocument.resolveConflicts()`:
+  Extract and Keep as an observer-only foundation helper
+- any separate async wrapper around observer conflict resolution:
+  Merge unless surviving observer call sites require it
+- write-path post-overwrite conflict cleanup seam:
+  Add and Keep as a cleanup-only helper
+- any save-path helper that restores an older conflict version as the winner:
+  Delete
 
 ## Scope Guard
 

--- a/docs/superpowers/plans/2026-04-18-icloud-write-path-reset-contract-audit.md
+++ b/docs/superpowers/plans/2026-04-18-icloud-write-path-reset-contract-audit.md
@@ -97,6 +97,23 @@ Scope: Part 1 contract lock for the reset worktree
 - The write path should get a separate cleanup helper that marks conflicts
   resolved and removes other versions without restoring an older winner.
 
+### `ios/.../icloud_storage_plus_foundation/ConflictResolver.swift`
+
+- `resolvePresentedItemConflictsSync(at:)`: Keep as the observer-specific
+  winner-selection helper extracted from `ICloudDocument.resolveConflicts()`.
+- `resolvePresentedItemConflicts(at:)`: Keep as the async wrapper only if
+  observer call sites still need an async surface after extraction; otherwise
+  merge into the sync helper's call sites.
+- `cleanupConflictsAfterOverwrite(at:)`: Keep as a write-path-specific cleanup
+  helper that marks conflicts resolved and removes other versions without
+  restoring an older winner.
+- Any attempt to reuse observer winner-selection for save-path cleanup:
+  Delete.
+
+### `macos/.../icloud_storage_plus_foundation/ConflictResolver.swift`
+
+- Mirror the iOS decisions exactly. Contract divergence is not allowed.
+
 ## Scope Guard
 
 - This audit is doc-only and does not authorize Swift or Dart implementation

--- a/docs/superpowers/plans/2026-04-18-icloud-write-path-reset-contract-audit.md
+++ b/docs/superpowers/plans/2026-04-18-icloud-write-path-reset-contract-audit.md
@@ -1,0 +1,105 @@
+# iCloud Write Path Contract Audit
+
+Date: 2026-04-18
+Scope: Part 1 contract lock for the reset worktree
+
+## Baseline Notes
+
+- This worktree does not contain a standalone `ConflictResolver.swift` on iOS
+  or macOS.
+- Observer conflict winner-selection currently lives in the platform
+  `ICloudDocument.resolveConflicts()` implementations.
+- The current plugin already maps `E_CONFLICT`, `E_NOT_DOWNLOADED`, `E_ARG`,
+  `E_TIMEOUT`, and `E_NAT` at the Dart boundary.
+- The current write path also exposes a write-path-specific
+  `E_DOWNLOAD_IN_PROGRESS` native branch. Part 1 does not keep that branch as a
+  terminal write outcome.
+
+## Locked Write Outcomes
+
+| State | Native behavior target | Dart-visible category/code | Retryable | Contract note |
+|---|---|---|---|---|
+| Destination missing | Overwrite path reports `handled == false`; existing entrypoint falls back to its current create-or-not-found behavior | No new overwrite-only category | Existing behavior | Part 1 keeps the current entrypoint contract instead of inventing a new overwrite error |
+| Destination path resolves to an existing directory | Preserve the stable invalid-argument outcome | `invalidArgument` / `E_ARG` | No | This may use a minimal validation seam or a mapped OS failure; the dedicated helper is not locked |
+| Destination is a ubiquitous item that is not locally current | Attempt download and wait for localization before overwrite | No error if recovery succeeds | N/A | `downloadInProgress` becomes a transient internal state, not a final write result |
+| Destination download stalls | Surface stable timeout | `timeout` / `E_TIMEOUT` | Yes | Keep the idle-timeout contract |
+| Destination download cannot become current | Surface stable not-downloaded failure | `itemNotDownloaded` / `E_NOT_DOWNLOADED` | Yes | Keep the typed split between timeout and not-downloaded |
+| Destination has conflicts and recovery succeeds | Recover, then continue overwrite | No error if recovery succeeds | N/A | Recovery is allowed to be explicit write-path cleanup, not observer winner-selection |
+| Conflict recovery fails before replacement write | Surface stable conflict failure | `conflict` / `E_CONFLICT` | No | Include underlying native details |
+| Replacement write succeeds but post-write cleanup fails | The user's replacement remains the conceptual winner, but the operation still reports failure because cleanup is part of honest success | `conflict` / `E_CONFLICT` | No | Do not roll back to old-content-wins semantics or silently report success |
+| Coordination fails | Surface stable coordination failure | `coordination` / `E_COORDINATION` | No by default | Revisit retryability only if an existing stable mapping proves otherwise |
+| Unknown native write failure | Preserve structured fallback | `unknownNative` / `E_NAT` | No | Fallback only |
+
+## Locked Behavioral Decisions
+
+- `writeInPlace` and `writeInPlaceBytes` stay public API names.
+- The overwrite sequence is: detect existing destination, localize if needed,
+  write replacement, then run post-write conflict cleanup.
+- Post-write cleanup is part of honest success. A cleanup failure is visible to
+  Dart even if the replacement already won.
+- The write path does not reuse observer winner-selection semantics.
+- The reset keeps the current destination-missing behavior per entrypoint.
+- The reset keeps the current typed download failure split:
+  `E_NOT_DOWNLOADED` versus `E_TIMEOUT`.
+- The reset drops write-path-specific `E_DOWNLOAD_IN_PROGRESS` as a terminal
+  contract outcome.
+
+## Method Inventory
+
+### `ios/.../icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift`
+
+- `overwriteExistingItem(at:prepareReplacementFile:)`: Keep, but simplify
+  around the locked overwrite sequence and post-write cleanup ordering.
+- `fileDestinationError(isDirectory:)`: Merge into the smallest honest
+  invalid-argument seam that preserves `E_ARG`.
+- `replaceReadyStateError(...)`: Simplify so it only models locked write-path
+  outcomes; remove the terminal `downloadInProgress` branch and stop treating
+  recoverable conflicts as a preflight refusal.
+- `verifyExistingDestinationCanBeReplaced(at:)`: Merge away from the overwrite
+  path. If copy-path behavior still needs a broader readiness check, keep that
+  logic in a copy-specific seam instead of the overwrite contract.
+- `verifyFileDestinationCanBeOverwritten(at:)`: Simplify to the minimum
+  directory-validation seam, or delete if mapped OS failure can honestly keep
+  `E_ARG`.
+- `live`: Keep, but simplify to a direct coordinator bridge plus replacement
+  staging and cleanup wiring.
+
+### `macos/.../icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift`
+
+- Mirror the iOS decisions exactly. Contract divergence is not allowed.
+
+### `ios/.../icloud_storage_plus/iOSICloudStoragePlugin.swift`
+
+- `writeInPlace(_:_: )`: Keep. Simplify only enough to preserve the current
+  destination-missing behavior and route overwrite failures through the locked
+  categories.
+- `writeInPlaceBytes(_:_: )`: Keep with the same contract as `writeInPlace`.
+- `mapFileNotFoundError(...)`: Keep to preserve the current write/read
+  not-found split.
+- `nativeCodeError(...)`: Keep, but simplify to the locked write outcomes.
+  Remove the write-path-specific `E_DOWNLOAD_IN_PROGRESS` mapping when the
+  writer stops emitting it.
+- `timeoutNativeError()`: Keep.
+- `mapTimeoutError(...)`: Keep.
+- `flutterError(...)`: Keep as the shared Flutter error envelope.
+
+### `macos/.../icloud_storage_plus/macOSICloudStoragePlugin.swift`
+
+- Mirror the iOS decisions exactly. Contract divergence is not allowed.
+
+### Conflict Helper Extraction Decision
+
+- Part 2 should introduce `ConflictResolver.swift` on iOS and macOS by
+  extracting the observer-only winner-selection logic that currently lives in
+  `ICloudDocument.resolveConflicts()`.
+- The extracted observer helper should be kept as an observer-specific
+  resolver, not reused as the write-path winner-selection model.
+- The write path should get a separate cleanup helper that marks conflicts
+  resolved and removes other versions without restoring an older winner.
+
+## Scope Guard
+
+- This audit is doc-only and does not authorize Swift or Dart implementation
+  edits.
+- Part 2 may touch only the write-path files already named in the approved
+  reset design unless a new design decision explicitly expands scope.

--- a/docs/superpowers/specs/2026-04-18-icloud-write-path-reset-design.md
+++ b/docs/superpowers/specs/2026-04-18-icloud-write-path-reset-design.md
@@ -1,0 +1,505 @@
+# iCloud Write Path Reset Design
+
+Date: 2026-04-18
+Repo: `icloud_storage_plus`
+Status: Approved for implementation, Part 1 contract locked
+
+## Purpose
+
+Reset the `writeInPlace` rewrite from first principles.
+
+The current branch mixed together feature work, architecture repair,
+error shaping, test churn, and packaging drift. That made it hard to tell
+which changes express real plugin contracts and which changes only defend
+against imagined misuse or preserve branch-local abstractions.
+
+This reset adopts a strict contract-first standard:
+
+- keep public plugin names unless the name no longer describes the truth
+- prefer direct Foundation behavior over speculative native preflight
+- treat Swift Package Manager as the primary source of truth
+- keep CocoaPods working while it remains supported, but do not let it
+  dictate architecture
+- review nearly every touched native method with a senior Swift standard:
+  keep, simplify, merge, or delete
+
+## Problem Statement
+
+The production problem is clear.
+
+`writeInPlace` still turns recoverable iCloud states into failures. The
+rewrite branch tried to fix that, but it also introduced design drift.
+
+The core drift looks like this:
+
+- preflight guards expanded beyond real plugin contracts
+- observer-path conflict logic was reused for write-path save semantics
+- helper structure became more important than clear boundaries
+- shipping concerns drifted away from the actual source of truth
+
+The reset does not start from "how do we save the branch?" It starts from
+"what does the plugin actually promise, and what is the smallest honest
+Swift design that delivers it?"
+
+## Reset Scope
+
+This reset covers the native Swift surface involved in overwriting an
+existing item and the boundaries that shape that behavior for Dart.
+
+In scope:
+
+- `writeInPlace` overwrite behavior
+- download-before-write behavior for non-current ubiquitous items
+- conflict handling for write-path saves
+- observer-path conflict handling only where the write-path reset must keep
+  existing observer call sites compiling and semantically separate
+- native error shaping that Dart relies on
+- SPM layout and tests
+- CocoaPods compatibility validation
+
+Concrete native file scope for the method audit and semantic rewrite:
+
+- `ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/`
+  `CoordinatedReplaceWriter.swift`
+- `macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/`
+  `CoordinatedReplaceWriter.swift`
+- `ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/`
+  `ConflictResolver.swift`
+- `macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/`
+  `ConflictResolver.swift`
+- the iOS and macOS plugin entrypoints only at the call sites that invoke the
+  overwrite path and map native errors to Dart-visible failures
+
+The `ConflictResolver.swift` twins are target extraction files for the reset.
+In the current baseline worktree, the observer conflict winner-selection logic
+still lives inside the platform `ICloudDocument` implementations.
+
+The reset does not authorize a broad repo-wide Swift cleanup.
+
+Out of scope unless a later design change requires it:
+
+- consumer app behavior outside the plugin
+- unrelated plugin cleanup
+- broad API redesign of public Dart method names
+- architecture changes driven only by CocoaPods convenience
+
+## Design Principles
+
+### 1. Contract First
+
+Every behavior in the native layer must justify itself as a real plugin
+contract.
+
+A valid contract must satisfy all of these:
+
+- it describes something the plugin explicitly promises to callers
+- Foundation, Flutter, or the packaging layer does not already own it
+- it can be tested at the plugin boundary
+- a consumer would care if it broke in production
+
+If a behavior does not pass that test, it should not anchor design.
+
+### 2. Public Stability, Internal Freedom
+
+Preserve public plugin method names and Dart-facing behavior when the names
+still describe the truth.
+
+Internal Swift helpers are free to change, merge, split, or disappear.
+
+The reset favors consumer stability. It does not preserve internal names or
+shapes for sentimental reasons.
+
+### 3. No Speculative Preflight By Default
+
+The native layer should not proactively guard against every strange input.
+
+Preflight checks survive only if they protect a real plugin promise that the
+OS layer would not protect in a consumer-meaningful way.
+
+"This yields a slightly nicer earlier error" is not enough.
+
+### 4. Different Flows Stay Different
+
+Observer conflict handling and explicit overwrite handling start as separate
+flows.
+
+They may share code only if they have the same winner, the same failure
+semantics, and the same cleanup semantics.
+
+Until that is proven, they remain separate.
+
+### 5. SPM Is Primary
+
+Swift Package Manager is the primary source of truth for source layout,
+native tests, and module organization.
+
+CocoaPods remains a supported compatibility path while the plugin still
+declares it, but it does not control architecture.
+
+### 6. Fresh Branch Is The Default
+
+The default execution mode for this reset is a fresh branch from `main`.
+
+Reuse from the current rewrite branch requires explicit justification on a
+case-by-case basis. The current branch is reference material, not trusted
+architecture.
+
+## Working Definitions
+
+### Valid Helper
+
+A helper survives only if it does at least one of these:
+
+- encodes a real domain rule
+- preserves a meaningful boundary such as error mapping or coordinator
+  bridging
+- reduces duplication that would otherwise obscure correctness
+- makes a real system workflow easier to reason about
+
+A helper should be deleted if it is mainly:
+
+- a one-line wrapper over Foundation with no semantic value
+- a place to park speculative checks
+- a seam created to support a branch-local abstraction
+- a wrapper that is less clear than inline code
+
+### Acceptable Preflight
+
+A preflight check is acceptable only if:
+
+- it prevents a known bad operation the plugin wants to shape differently
+  from the OS
+- it produces a stable, consumer-meaningful outcome
+- that outcome belongs in the plugin contract
+
+Otherwise, let the underlying coordinated file operation fail naturally.
+
+### Valid Test
+
+A test survives only if it proves one of these:
+
+- a public or Dart-visible contract
+- a critical native boundary
+- a real production regression
+- a concurrency or packaging invariant that could hurt users
+
+Tests that mainly prove helper existence or preserve branch structure should
+be rewritten or deleted.
+
+## Known Example: File vs Directory Guard
+
+The current branch contains a helper that checks whether the destination URL
+is a directory before the overwrite path proceeds.
+
+That kind of check is a good example of the reset rule.
+
+The condition can happen. A caller can point at a directory path. The real
+question is whether the plugin should own that distinction as part of its
+contract.
+
+Under this reset, the answer is "no" unless we can name a concrete
+Dart-facing promise that depends on it. A helper that exists only to be more
+protective than the OS should be removed.
+
+This document therefore treats directory/file guards as presumptively
+invalid until justified.
+
+The contract question is not whether directory destinations can exist. They
+can. The question is whether the plugin must detect that case proactively or
+whether it can map the resulting failure into a stable Dart-visible category
+without preserving a dedicated speculative preflight helper.
+
+Part 1 resolves this by locking the Dart-visible `invalidArgument` / `E_ARG`
+outcome while leaving the implementation free to use either a minimal
+validation seam or a mapped OS failure, whichever stays more honest.
+
+## Target Contracts
+
+### `writeInPlace`
+
+`writeInPlace` should preserve its public name and public API shape if the
+name remains truthful.
+
+Its contract should be:
+
+- if the destination does not exist, the overwrite path reports that and
+  exits without pretending work happened
+- if the destination is a ubiquitous item that is not locally current, the
+  plugin attempts to make it locally available before writing
+- if the destination is in a recoverable conflict state, the plugin attempts
+  to recover instead of refusing immediately
+- if the overwrite still cannot complete, the plugin surfaces a typed error
+  that Dart can map reliably
+
+This contract deliberately says nothing about speculative native preflight.
+
+`writeInPlaceBytes` shares the same overwrite contract and differs only in the
+replacement payload type.
+
+### Write-Path Outcome Table
+
+The reset must lock these Dart-visible outcomes before implementation.
+
+| State | Native behavior target | Dart-visible category/code | Retryable |
+|---|---|---|---|
+| Destination missing | Overwrite path reports no handled existing destination; caller falls back to normal create/write path or typed not-found behavior, depending on the entrypoint's existing contract | No new overwrite-only category; preserve existing plugin behavior per entrypoint | Existing behavior |
+| Destination path is file-centric but resolves to an existing directory | Preserve a stable invalid-argument outcome; do not allow this to degrade into opaque unknown-native noise | `invalidArgument` / `E_ARG` | No |
+| Destination is a ubiquitous item that is not locally current | Attempt download/localization before overwrite | No error if recovery succeeds | N/A |
+| Destination download cannot complete before write | Surface stable not-downloaded or timeout outcome based on the actual failing condition | `itemNotDownloaded` / `E_NOT_DOWNLOADED` or `timeout` / `E_TIMEOUT` | Yes |
+| Destination has unresolved conflicts but recovery succeeds | Attempt recovery, then continue overwrite | No error if recovery succeeds | N/A |
+| Conflict recovery fails before replacement write | Surface conflict failure with stable mapping and underlying native details | `conflict` / `E_CONFLICT` | No |
+| Coordination fails | Surface stable coordination failure | `coordination` / `E_COORDINATION` | No by default; revisit only if an existing stable mapping proves otherwise |
+| Replacement write succeeds but post-write cleanup fails | The user's replacement remains the conceptual winner, but cleanup remains part of honest success so the operation still reports a stable failure | `conflict` / `E_CONFLICT` | No |
+| Unclassified native failure | Preserve structured fallback behavior | `unknownNative` / `E_NAT` | No |
+
+Notes:
+
+- This table intentionally locks the category/code pairs already exposed by
+  `lib/models/exceptions.dart` and the current native `FlutterError` mapping.
+- The destination-directory row preserves Dart-visible stability without
+  committing the implementation to a dedicated native preflight helper.
+- The destination-missing row stays tied to the existing entrypoint contract;
+  the implementation plan must state that exact behavior explicitly instead of
+  inventing a new overwrite-specific category.
+- `downloadInProgress` does not survive Part 1 as a terminal write-path
+  outcome. The write path should wait for localization and surface only the
+  locked `E_TIMEOUT` or `E_NOT_DOWNLOADED` failures if recovery does not
+  complete.
+
+### Observer Conflict Handling
+
+The observer path may still use a "pick a winner among existing versions"
+strategy if that remains correct for document-presentation callbacks.
+
+That does not make it the right model for a user save.
+
+The reset does not redesign observer behavior beyond keeping the surviving
+observer call sites correct if a shared helper changes shape.
+
+### Copy Over Existing Destination
+
+Copy-path behavior remains separate unless a later design explicitly proves
+that it should converge with overwrite behavior.
+
+The reset assumes separation by default.
+
+## Platform Alignment
+
+iOS and macOS must preserve the same write-path contract and Dart-visible
+error outcomes for any behavior changed by this reset.
+
+Implementation details may differ only when platform APIs force the
+difference. Contract divergence is not allowed.
+
+## Architectural Correction
+
+### The Write Path Must Treat The User's Replacement As The Winner
+
+This is the central design rule.
+
+In an explicit overwrite/save operation, the user's replacement content is
+the intended winner. Conflict handling exists to make that write possible and
+to clean up the state around it. Conflict handling does not define the final
+content.
+
+This is why the branch's current design is not trusted. A flow that first
+restores the latest conflict version into the destination and only then tries
+to apply the user's replacement is not conceptually right for a save. It can
+also create bad failure modes if cleanup fails after an old conflict version
+has already been restored.
+
+The write path must therefore be re-derived from first principles, not
+patched.
+
+Part 1 locks the ordering explicitly: replacement write first, post-write
+conflict cleanup second. If cleanup fails after the replacement write, the
+operation still reports `conflict` / `E_CONFLICT`, but the user's replacement
+remains the conceptual winner.
+
+### The Coordinator Bridge Must Be Honest
+
+If `NSFileCoordinator.coordinate(...)` is blocking and synchronous, the
+design must admit that. The native bridge should not pretend a true async
+accessor exists if the underlying work must complete inline.
+
+The outer API may remain async if it is bridging a blocking native operation
+back to the caller. The inner accessor should reflect the actual Foundation
+contract.
+
+### Error Mapping Must Stay Minimal And Stable
+
+The Dart layer depends on stable error categories. That is a real boundary.
+
+The reset should keep native error shaping only where Dart actually needs a
+stable domain, code, or marker. It should not expand error shaping into a new
+source of speculative behavior.
+
+## Method Audit Standard
+
+For each touched Swift method in the scoped native files above, apply this
+audit:
+
+1. Why does this method exist?
+2. Is that responsibility real?
+3. Is the signature honest about sync, async, and throwing behavior?
+4. Is the abstraction clearer than inline code?
+5. Is it preserving accidental architecture?
+6. Would a senior Swift engineer write this today from an empty file?
+
+Each method gets one classification:
+
+- Keep
+- Simplify
+- Merge
+- Delete
+
+No method survives by inertia.
+
+## Reset Map
+
+### Discard By Default
+
+- speculative native preflight guards that do not protect a real contract
+- helper structure created mainly to support branch-local abstractions
+- tests whose primary job is preserving helper existence
+- the assumption that observer conflict resolution is the right save-path
+  model
+
+### Keep Only After Revalidation
+
+- the extracted download waiter concept
+- the deadlock-free coordination bridge direction
+- narrow NSError shaping that Dart actually depends on
+- separation between copy-path behavior and overwrite behavior
+
+### Re-Derive From First Principles
+
+- write-path conflict semantics
+- method-level keep/delete decisions
+- exact failure semantics for overwrite, coordination, cleanup, and recovery
+- packaging verification order with SPM primary and CocoaPods secondary
+
+## Replacement Slices
+
+The implementation should not follow the old branch phases. It should follow
+these slices.
+
+### Part 1 / Slice 1: Contract Lock And Method Audit
+
+Write plain-language contracts for each touched public operation and each
+critical Dart-visible error category.
+
+Produce a method inventory for the scoped files and classify each touched
+method as Keep, Simplify, Merge, or Delete.
+
+Gate:
+
+- no code changes until the contracts are explicit and consistent
+- no semantic rewrite until the Dart-visible category/code table is final
+- no scope expansion beyond the explicit file inventory without a new design
+  decision
+
+### Part 2 / Slice 2: Native Write-Path Reset
+
+Define overwrite semantics from first principles:
+
+- destination missing
+- destination nonlocal
+- destination conflicted
+- coordination failure
+- cleanup failure
+
+Gate:
+
+- the user's replacement content remains the conceptual winner for save
+  operations
+- copy-path behavior remains separate
+- observer-path behavior remains out of scope except for compatibility with
+  surviving call sites
+
+### Part 2 / Slice 3: Minimal Native Rebuild
+
+Implement only the methods needed to satisfy the contracts.
+
+Gate:
+
+- the Swift code reads like direct, honest Foundation coordination code
+
+### Part 3 / Slice 4: Packaging And Integration Validation
+
+Validate the real shipping paths in this order:
+
+- SPM build and native tests
+- Flutter plugin integration and Dart tests
+- CocoaPods compatibility while still supported
+
+Gate:
+
+- SPM is the primary success path; CocoaPods remains compatible support
+
+### Part 3 / Slice 5: Behavior Verification
+
+Keep tests that prove contracts, real regressions, concurrency invariants,
+and packaging compatibility. Rewrite or delete the rest.
+
+Gate:
+
+- coverage demonstrates behavior, not helper trivia
+
+## Execution Mode
+
+This reset should execute on a fresh branch from `main` by default.
+
+The current rewrite branch remains historical reference only. Reuse from that
+branch is allowed only when a specific artifact passes the contract-first
+audit and is cheaper to import than to re-derive.
+
+## Success Criteria
+
+The reset is successful when all of these are true:
+
+- public plugin names remain stable unless a name would be dishonest
+- `writeInPlace` recovers from recoverable iCloud states instead of refusing
+  too early
+- write-path save semantics treat the user's replacement as the winner
+- speculative native preflight has been removed unless explicitly justified
+- touched Swift methods have been audited with keep/simplify/merge/delete
+- the touched native file inventory stayed within the scoped write-path
+  boundary
+- SPM is clean and remains the primary truth
+- Flutter integration is clean
+- CocoaPods remains compatible while supported
+- the surviving tests prove behavior, not branch residue
+
+## Part 1 Resolutions
+
+Part 1 locks these decisions before any Swift rewrite:
+
+- the method-by-method classifications for the scoped write-path files live in
+  `docs/superpowers/plans/2026-04-18-icloud-write-path-reset-contract-audit.md`
+- the write-path cleanup sequence is replacement write first, conflict cleanup
+  second
+- post-write cleanup failure remains a visible `conflict` / `E_CONFLICT`
+  failure rather than a silent success or rollback into old-content-wins
+  semantics
+- `downloadInProgress` is not a surviving terminal write-path outcome
+
+Remaining execution details belong in the implementation plan:
+
+- the minimum end-to-end integration test needed to prove Dart-visible error
+  mapping
+- the exact CocoaPods compatibility command set to retain while support
+  remains declared
+
+The execution mode is resolved by design default: fresh branch from `main`.
+The implementation plan may override that only if it gives a specific reuse
+justification.
+
+## Summary
+
+This reset rejects speculative native design and branch-driven inertia.
+
+It preserves public stability where the public truth still matches the
+existing names. It treats SPM as primary. It keeps CocoaPods compatible but
+secondary. Most of all, it demands a senior Swift audit of the touched native
+surface before more code is allowed to accumulate.

--- a/docs/superpowers/specs/2026-04-18-icloud-write-path-reset-design.md
+++ b/docs/superpowers/specs/2026-04-18-icloud-write-path-reset-design.md
@@ -70,9 +70,10 @@ Concrete native file scope for the method audit and semantic rewrite:
 - the iOS and macOS plugin entrypoints only at the call sites that invoke the
   overwrite path and map native errors to Dart-visible failures
 
-The `ConflictResolver.swift` twins are target extraction files for the reset.
-In the current baseline worktree, the observer conflict winner-selection logic
-still lives inside the platform `ICloudDocument` implementations.
+If Part 2 extracts dedicated foundation conflict helpers, they are target
+extraction files for the reset rather than baseline requirements. In the
+current baseline worktree, the observer conflict winner-selection logic still
+lives inside the platform `ICloudDocument` implementations.
 
 The reset does not authorize a broad repo-wide Swift cleanup.
 
@@ -475,7 +476,8 @@ The reset is successful when all of these are true:
 
 Part 1 locks these decisions before any Swift rewrite:
 
-- the method-by-method classifications for the scoped write-path files live in
+- the detailed method inventory and keep/simplify/merge/delete
+  classifications live in
   `docs/superpowers/plans/2026-04-18-icloud-write-path-reset-contract-audit.md`
 - the write-path cleanup sequence is replacement write first, conflict cleanup
   second

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus/WriteEntrypointPreflight.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus/WriteEntrypointPreflight.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+@available(macOS 10.15, iOS 13.0, *)
+struct WriteEntrypointPreflight {
+  typealias Execute = (@escaping @Sendable () throws -> URL) async throws -> URL
+  typealias ResolveContainerURL = (String) -> URL?
+  typealias CreateDirectory = (URL) throws -> Void
+
+  let execute: Execute
+  let resolveContainerURL: ResolveContainerURL
+  let createDirectory: CreateDirectory
+
+  func containerURL(containerId: String) async throws -> URL {
+    try await execute {
+      guard let containerURL = resolveContainerURL(containerId) else {
+        throw Self.containerUnavailableError()
+      }
+
+      return containerURL
+    }
+  }
+
+  func itemURL(
+    containerId: String,
+    relativePath: String,
+    createParentDirectory: Bool
+  ) async throws -> URL {
+    let containerURL = try await containerURL(containerId: containerId)
+    let fileURL = containerURL.appendingPathComponent(relativePath)
+
+    if createParentDirectory {
+      try createDirectory(fileURL.deletingLastPathComponent())
+    }
+
+    return fileURL
+  }
+
+  func prepare(
+    containerId: String,
+    relativePath: String
+  ) async throws -> URL {
+    try await execute {
+      guard let containerURL = resolveContainerURL(containerId) else {
+        throw Self.containerUnavailableError()
+      }
+
+      let fileURL = containerURL.appendingPathComponent(relativePath)
+      try createDirectory(fileURL.deletingLastPathComponent())
+      return fileURL
+    }
+  }
+}
+
+@available(macOS 10.15, iOS 13.0, *)
+extension WriteEntrypointPreflight {
+  static let errorDomain = "ICloudStoragePlusWriteEntrypointPreflight"
+  static let containerUnavailableErrorCode = 1
+
+  static func containerUnavailableError() -> NSError {
+    NSError(
+      domain: errorDomain,
+      code: containerUnavailableErrorCode,
+      userInfo: [
+        NSLocalizedDescriptionKey:
+          "Unable to access the requested iCloud container.",
+      ]
+    )
+  }
+
+  static func isContainerUnavailableError(_ error: Error) -> Bool {
+    let nsError = error as NSError
+    return nsError.domain == errorDomain
+      && nsError.code == containerUnavailableErrorCode
+  }
+
+  static let live = WriteEntrypointPreflight(
+    execute: { work in
+      try await withCheckedThrowingContinuation {
+        (continuation: CheckedContinuation<URL, Error>) in
+        DispatchQueue.global(qos: .userInitiated).async {
+          do {
+            continuation.resume(returning: try work())
+          } catch {
+            continuation.resume(throwing: error)
+          }
+        }
+      }
+    },
+    resolveContainerURL: {
+      FileManager.default.url(forUbiquityContainerIdentifier: $0)
+    },
+    createDirectory: { directoryURL in
+      try FileManager.default.createDirectory(
+        at: directoryURL,
+        withIntermediateDirectories: true,
+        attributes: nil
+      )
+    }
+  )
+}

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
@@ -715,8 +715,12 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
-    writeInPlaceDocument(at: fileURL, contents: contents) { [self] error in
-      if let error = error {
+    Task { [self] in
+      do {
+        try await ensureWriteDestinationDownloaded(fileURL)
+        try await writeInPlaceDocument(at: fileURL, contents: contents)
+        result(nil)
+      } catch {
         let mapped = mapFileNotFoundError(
           error,
           operation: "writeInPlace",
@@ -727,9 +731,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           relativePath: relativePath
         )
         result(mapped)
-        return
       }
-      result(nil)
     }
   }
 
@@ -855,8 +857,12 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
-    writeInPlaceBinaryDocument(at: fileURL, contents: contents.data) { [self] error in
-      if let error = error {
+    Task { [self] in
+      do {
+        try await ensureWriteDestinationDownloaded(fileURL)
+        try await writeInPlaceBinaryDocument(at: fileURL, contents: contents.data)
+        result(nil)
+      } catch {
         let mapped = mapFileNotFoundError(
           error,
           operation: "writeInPlaceBytes",
@@ -867,9 +873,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           relativePath: relativePath
         )
         result(mapped)
-        return
       }
-      result(nil)
     }
   }
   
@@ -1028,6 +1032,89 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     }
 
     startAttempt(index: 0)
+  }
+
+  private func waitForDownloadCompletion(
+    at fileURL: URL,
+    idleTimeouts: [TimeInterval],
+    retryBackoff: [TimeInterval]
+  ) async throws {
+    try await withCheckedThrowingContinuation { continuation in
+      waitForDownloadCompletion(
+        fileURL: fileURL,
+        idleTimeouts: idleTimeouts,
+        retryBackoff: retryBackoff
+      ) { error in
+        if let error {
+          continuation.resume(throwing: error)
+          return
+        }
+        continuation.resume(returning: ())
+      }
+    }
+  }
+
+  private func ensureWriteDestinationDownloaded(_ fileURL: URL) async throws {
+    guard FileManager.default.fileExists(atPath: fileURL.path) else {
+      return
+    }
+
+    let values = try fileURL.resourceValues(
+      forKeys: [
+        .isUbiquitousItemKey,
+        .ubiquitousItemDownloadingStatusKey,
+        .ubiquitousItemDownloadingErrorKey,
+      ]
+    )
+
+    guard values.isUbiquitousItem == true else {
+      return
+    }
+
+    if let downloadError = values.ubiquitousItemDownloadingError {
+      throw downloadError
+    }
+
+    guard values.ubiquitousItemDownloadingStatus != .current else {
+      return
+    }
+
+    try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
+    try await waitForDownloadCompletion(
+      at: fileURL,
+      idleTimeouts: [10.0, 20.0],
+      retryBackoff: [2.0]
+    )
+  }
+
+  private func writeInPlaceDocument(
+    at fileURL: URL,
+    contents: String
+  ) async throws {
+    try await withCheckedThrowingContinuation { continuation in
+      writeInPlaceDocument(at: fileURL, contents: contents) { error in
+        if let error {
+          continuation.resume(throwing: error)
+          return
+        }
+        continuation.resume(returning: ())
+      }
+    }
+  }
+
+  private func writeInPlaceBinaryDocument(
+    at fileURL: URL,
+    contents: Data
+  ) async throws {
+    try await withCheckedThrowingContinuation { continuation in
+      writeInPlaceBinaryDocument(at: fileURL, contents: contents) { error in
+        if let error {
+          continuation.resume(throwing: error)
+          return
+        }
+        continuation.resume(returning: ())
+      }
+    }
   }
 
   /// Checks if the file is fully downloaded and available for access.

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
@@ -715,10 +715,16 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
+    let writer = makeWriteEntrypointWriter()
+
     Task { [self] in
       do {
-        try await ensureWriteDestinationDownloaded(fileURL)
-        try await writeInPlaceDocument(at: fileURL, contents: contents)
+        let handled = try await writer.overwriteExistingItem(at: fileURL) {
+          try writeTextToURL(contents, to: $0)
+        }
+        if !handled {
+          try await createWriteInPlaceDocument(at: fileURL, contents: contents)
+        }
         result(nil)
       } catch {
         let mapped = mapFileNotFoundError(
@@ -857,10 +863,19 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
+    let writer = makeWriteEntrypointWriter()
+
     Task { [self] in
       do {
-        try await ensureWriteDestinationDownloaded(fileURL)
-        try await writeInPlaceBinaryDocument(at: fileURL, contents: contents.data)
+        let handled = try await writer.overwriteExistingItem(at: fileURL) {
+          try writeDataToURL(contents.data, to: $0)
+        }
+        if !handled {
+          try await createWriteInPlaceBinaryDocument(
+            at: fileURL,
+            contents: contents.data
+          )
+        }
         result(nil)
       } catch {
         let mapped = mapFileNotFoundError(
@@ -1054,40 +1069,51 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     }
   }
 
-  private func ensureWriteDestinationDownloaded(_ fileURL: URL) async throws {
-    guard FileManager.default.fileExists(atPath: fileURL.path) else {
-      return
-    }
-
-    let values = try fileURL.resourceValues(
-      forKeys: [
-        .isUbiquitousItemKey,
-        .ubiquitousItemDownloadingStatusKey,
-        .ubiquitousItemDownloadingErrorKey,
-      ]
+  private func makeWriteEntrypointWriter() -> WriteEntrypointWriter {
+    let live = CoordinatedReplaceWriter.live
+    let writer = CoordinatedReplaceWriter(
+      fileExists: live.fileExists,
+      verifyDestination: live.verifyDestination,
+      createReplacementDirectory: live.createReplacementDirectory,
+      coordinateReplace: live.coordinateReplace,
+      replaceItem: live.replaceItem,
+      removeItem: live.removeItem
     )
 
-    guard values.isUbiquitousItem == true else {
-      return
-    }
+    return WriteEntrypointWriter(
+      writer: writer,
+      ensureDownloaded: { [self] fileURL in
+        let values = try fileURL.resourceValues(
+          forKeys: [
+            .isUbiquitousItemKey,
+            .ubiquitousItemDownloadingStatusKey,
+            .ubiquitousItemDownloadingErrorKey,
+          ]
+        )
 
-    if let downloadError = values.ubiquitousItemDownloadingError {
-      throw downloadError
-    }
+        guard values.isUbiquitousItem == true else {
+          return
+        }
 
-    guard values.ubiquitousItemDownloadingStatus != .current else {
-      return
-    }
+        if let downloadError = values.ubiquitousItemDownloadingError {
+          throw downloadError
+        }
 
-    try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
-    try await waitForDownloadCompletion(
-      at: fileURL,
-      idleTimeouts: [10.0, 20.0],
-      retryBackoff: [2.0]
+        guard values.ubiquitousItemDownloadingStatus != .current else {
+          return
+        }
+
+        try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
+        try await waitForDownloadCompletion(
+          at: fileURL,
+          idleTimeouts: [10.0, 20.0],
+          retryBackoff: [2.0]
+        )
+      }
     )
   }
 
-  private func writeInPlaceDocument(
+  private func createWriteInPlaceDocument(
     at fileURL: URL,
     contents: String
   ) async throws {
@@ -1102,7 +1128,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     }
   }
 
-  private func writeInPlaceBinaryDocument(
+  private func createWriteInPlaceBinaryDocument(
     at fileURL: URL,
     contents: Data
   ) async throws {
@@ -2029,6 +2055,26 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       operation: operation,
       relativePath: relativePath,
       nativeError: nsError
+    )
+  }
+}
+
+private struct WriteEntrypointWriter {
+  let writer: CoordinatedReplaceWriter
+  let ensureDownloaded: (URL) async throws -> Void
+
+  func overwriteExistingItem(
+    at destinationURL: URL,
+    prepareReplacementFile: (URL) throws -> Void
+  ) async throws -> Bool {
+    guard writer.fileExists(destinationURL.path) else {
+      return false
+    }
+
+    try await ensureDownloaded(destinationURL)
+    return try writer.overwriteExistingItem(
+      at: destinationURL,
+      prepareReplacementFile: prepareReplacementFile
     )
   }
 }

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
@@ -25,7 +25,6 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   /// Registers the plugin with the Flutter registrar.
   public static func register(with registrar: FlutterPluginRegistrar) {
     let messenger = registrar.messenger()
-    #if os(iOS)
     let taskQueue = messenger.makeBackgroundTaskQueue?()
     let channel = FlutterMethodChannel(
       name: "icloud_storage_plus",
@@ -33,12 +32,6 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       codec: FlutterStandardMethodCodec.sharedInstance(),
       taskQueue: taskQueue
     )
-    #else
-    let channel = FlutterMethodChannel(
-      name: "icloud_storage_plus",
-      binaryMessenger: messenger
-    )
-    #endif
     let instance = ICloudStoragePlugin()
     registrar.addMethodCallDelegate(instance, channel: channel)
     instance.messenger = messenger
@@ -103,13 +96,18 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
     
-    guard let containerURL = FileManager.default.url(
-      forUbiquityContainerIdentifier: containerId
-    ) else {
-      result(containerAccessError(operation: "getContainerPath"))
-      return
+    let preflight = WriteEntrypointPreflight.live
+
+    Task {
+      do {
+        let containerURL = try await preflight.containerURL(
+          containerId: containerId
+        )
+        result(containerURL.path)
+      } catch {
+        result(containerAccessError(operation: "getContainerPath"))
+      }
     }
-    result(containerURL.path)
   }
   
   /// Lists all items in the container using NSMetadataQuery.
@@ -612,55 +610,19 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     let retryBackoff = (args["retryBackoffSeconds"] as? [NSNumber])?
       .map { $0.doubleValue } ?? []
 
-    guard let containerURL = FileManager.default.url(
-      forUbiquityContainerIdentifier: containerId
-    ) else {
-      result(containerAccessError(operation: "readInPlace", relativePath: relativePath))
-      return
-    }
+    let preflight = WriteEntrypointPreflight.live
 
-    let fileURL = containerURL.appendingPathComponent(relativePath)
+    Task { [self] in
+      do {
+        let fileURL = try await preflight.itemURL(
+          containerId: containerId,
+          relativePath: relativePath,
+          createParentDirectory: false
+        )
 
-    do {
-      try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
-    } catch {
-      let mapped = mapFileNotFoundError(
-        error,
-        operation: "readInPlace",
-        relativePath: relativePath
-      ) ?? nativeCodeError(
-        error,
-        operation: "readInPlace",
-        relativePath: relativePath
-      )
-      result(mapped)
-      return
-    }
-
-    waitForDownloadCompletion(
-      fileURL: fileURL,
-      idleTimeouts: idleTimeouts,
-      retryBackoff: retryBackoff
-    ) { [self] error in
-      if let error {
-        if let timeoutError = mapTimeoutError(
-          error,
-          operation: "readInPlace",
-          relativePath: relativePath
-        ) {
-          result(timeoutError)
-          return
-        }
-        result(nativeCodeError(
-          error,
-          operation: "readInPlace",
-          relativePath: relativePath
-        ))
-        return
-      }
-
-      readInPlaceDocument(at: fileURL) { [self] contents, error in
-        if let error = error {
+        do {
+          try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
+        } catch {
           let mapped = mapFileNotFoundError(
             error,
             operation: "readInPlace",
@@ -674,7 +636,60 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           return
         }
 
-        result(contents)
+        waitForDownloadCompletion(
+          fileURL: fileURL,
+          idleTimeouts: idleTimeouts,
+          retryBackoff: retryBackoff
+        ) { [self] error in
+          if let error {
+            if let timeoutError = mapTimeoutError(
+              error,
+              operation: "readInPlace",
+              relativePath: relativePath
+            ) {
+              result(timeoutError)
+              return
+            }
+            result(nativeCodeError(
+              error,
+              operation: "readInPlace",
+              relativePath: relativePath
+            ))
+            return
+          }
+
+          readInPlaceDocument(at: fileURL) { [self] contents, error in
+            if let error = error {
+              let mapped = mapFileNotFoundError(
+                error,
+                operation: "readInPlace",
+                relativePath: relativePath
+              ) ?? nativeCodeError(
+                error,
+                operation: "readInPlace",
+                relativePath: relativePath
+              )
+              result(mapped)
+              return
+            }
+
+            result(contents)
+          }
+        }
+      } catch {
+        if let mapped = mapWriteEntrypointPreflightError(
+          error,
+          operation: "readInPlace",
+          relativePath: relativePath
+        ) {
+          result(mapped)
+          return
+        }
+        result(nativeCodeError(
+          error,
+          operation: "readInPlace",
+          relativePath: relativePath
+        ))
       }
     }
   }
@@ -690,35 +705,15 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
-    guard let containerURL = FileManager.default.url(
-      forUbiquityContainerIdentifier: containerId
-    ) else {
-      result(containerAccessError(operation: "writeInPlace", relativePath: relativePath))
-      return
-    }
-
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-
-    do {
-      let dirURL = fileURL.deletingLastPathComponent()
-      try FileManager.default.createDirectory(
-        at: dirURL,
-        withIntermediateDirectories: true,
-        attributes: nil
-      )
-    } catch {
-      result(nativeCodeError(
-        error,
-        operation: "writeInPlace",
-        relativePath: relativePath
-      ))
-      return
-    }
-
     let writer = makeWriteEntrypointWriter()
+    let preflight = WriteEntrypointPreflight.live
 
     Task { [self] in
       do {
+        let fileURL = try await preflight.prepare(
+          containerId: containerId,
+          relativePath: relativePath
+        )
         let handled = try await writer.overwriteExistingItem(at: fileURL) {
           try writeTextToURL(contents, to: $0)
         }
@@ -727,7 +722,11 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
         }
         result(nil)
       } catch {
-        let mapped = mapFileNotFoundError(
+        let mapped = mapWriteEntrypointPreflightError(
+          error,
+          operation: "writeInPlace",
+          relativePath: relativePath
+        ) ?? mapFileNotFoundError(
           error,
           operation: "writeInPlace",
           relativePath: relativePath
@@ -756,54 +755,19 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     let retryBackoff = (args["retryBackoffSeconds"] as? [NSNumber])?
       .map { $0.doubleValue } ?? []
 
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(operation: "readInPlaceBytes", relativePath: relativePath))
-      return
-    }
+    let preflight = WriteEntrypointPreflight.live
 
-    let fileURL = containerURL.appendingPathComponent(relativePath)
+    Task { [self] in
+      do {
+        let fileURL = try await preflight.itemURL(
+          containerId: containerId,
+          relativePath: relativePath,
+          createParentDirectory: false
+        )
 
-    do {
-      try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
-    } catch {
-      let mapped = mapFileNotFoundError(
-        error,
-        operation: "readInPlaceBytes",
-        relativePath: relativePath
-      ) ?? nativeCodeError(
-        error,
-        operation: "readInPlaceBytes",
-        relativePath: relativePath
-      )
-      result(mapped)
-      return
-    }
-
-    waitForDownloadCompletion(
-      fileURL: fileURL,
-      idleTimeouts: idleTimeouts,
-      retryBackoff: retryBackoff
-    ) { [self] error in
-      if let error {
-        if let timeoutError = mapTimeoutError(
-          error,
-          operation: "readInPlaceBytes",
-          relativePath: relativePath
-        ) {
-          result(timeoutError)
-          return
-        }
-        result(nativeCodeError(
-          error,
-          operation: "readInPlaceBytes",
-          relativePath: relativePath
-        ))
-        return
-      }
-
-      readInPlaceBinaryDocument(at: fileURL) { [self] contents, error in
-        if let error = error {
+        do {
+          try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
+        } catch {
           let mapped = mapFileNotFoundError(
             error,
             operation: "readInPlaceBytes",
@@ -817,11 +781,64 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           return
         }
 
-        if let contents {
-          result(FlutterStandardTypedData(bytes: contents))
-        } else {
-          result(nil)
+        waitForDownloadCompletion(
+          fileURL: fileURL,
+          idleTimeouts: idleTimeouts,
+          retryBackoff: retryBackoff
+        ) { [self] error in
+          if let error {
+            if let timeoutError = mapTimeoutError(
+              error,
+              operation: "readInPlaceBytes",
+              relativePath: relativePath
+            ) {
+              result(timeoutError)
+              return
+            }
+            result(nativeCodeError(
+              error,
+              operation: "readInPlaceBytes",
+              relativePath: relativePath
+            ))
+            return
+          }
+
+          readInPlaceBinaryDocument(at: fileURL) { [self] contents, error in
+            if let error = error {
+              let mapped = mapFileNotFoundError(
+                error,
+                operation: "readInPlaceBytes",
+                relativePath: relativePath
+              ) ?? nativeCodeError(
+                error,
+                operation: "readInPlaceBytes",
+                relativePath: relativePath
+              )
+              result(mapped)
+              return
+            }
+
+            if let contents {
+              result(FlutterStandardTypedData(bytes: contents))
+            } else {
+              result(nil)
+            }
+          }
         }
+      } catch {
+        if let mapped = mapWriteEntrypointPreflightError(
+          error,
+          operation: "readInPlaceBytes",
+          relativePath: relativePath
+        ) {
+          result(mapped)
+          return
+        }
+        result(nativeCodeError(
+          error,
+          operation: "readInPlaceBytes",
+          relativePath: relativePath
+        ))
       }
     }
   }
@@ -837,36 +854,15 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(operation: "writeInPlaceBytes", relativePath: relativePath))
-      return
-    }
-
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-
-    do {
-      let dirURL = fileURL.deletingLastPathComponent()
-      if !FileManager.default.fileExists(atPath: dirURL.path) {
-        try FileManager.default.createDirectory(
-          at: dirURL,
-          withIntermediateDirectories: true,
-          attributes: nil
-        )
-      }
-    } catch {
-      result(nativeCodeError(
-        error,
-        operation: "writeInPlaceBytes",
-        relativePath: relativePath
-      ))
-      return
-    }
-
     let writer = makeWriteEntrypointWriter()
+    let preflight = WriteEntrypointPreflight.live
 
     Task { [self] in
       do {
+        let fileURL = try await preflight.prepare(
+          containerId: containerId,
+          relativePath: relativePath
+        )
         let handled = try await writer.overwriteExistingItem(at: fileURL) {
           try writeDataToURL(contents.data, to: $0)
         }
@@ -878,7 +874,11 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
         }
         result(nil)
       } catch {
-        let mapped = mapFileNotFoundError(
+        let mapped = mapWriteEntrypointPreflightError(
+          error,
+          operation: "writeInPlaceBytes",
+          relativePath: relativePath
+        ) ?? mapFileNotFoundError(
           error,
           operation: "writeInPlaceBytes",
           relativePath: relativePath
@@ -1054,7 +1054,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     idleTimeouts: [TimeInterval],
     retryBackoff: [TimeInterval]
   ) async throws {
-    try await withCheckedThrowingContinuation { continuation in
+    try await withCheckedThrowingContinuation {
+      (continuation: CheckedContinuation<Void, Error>) in
       waitForDownloadCompletion(
         fileURL: fileURL,
         idleTimeouts: idleTimeouts,
@@ -1117,7 +1118,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     at fileURL: URL,
     contents: String
   ) async throws {
-    try await withCheckedThrowingContinuation { continuation in
+    try await withCheckedThrowingContinuation {
+      (continuation: CheckedContinuation<Void, Error>) in
       writeInPlaceDocument(at: fileURL, contents: contents) { error in
         if let error {
           continuation.resume(throwing: error)
@@ -1132,7 +1134,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     at fileURL: URL,
     contents: Data
   ) async throws {
-    try await withCheckedThrowingContinuation { continuation in
+    try await withCheckedThrowingContinuation {
+      (continuation: CheckedContinuation<Void, Error>) in
       writeInPlaceBinaryDocument(at: fileURL, contents: contents) { error in
         if let error {
           continuation.resume(throwing: error)
@@ -1183,14 +1186,20 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
     
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(operation: "documentExists", relativePath: relativePath))
-      return
-    }
+    let preflight = WriteEntrypointPreflight.live
 
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-    result(FileManager.default.fileExists(atPath: fileURL.path))
+    Task {
+      do {
+        let fileURL = try await preflight.itemURL(
+          containerId: containerId,
+          relativePath: relativePath,
+          createParentDirectory: false
+        )
+        result(FileManager.default.fileExists(atPath: fileURL.path))
+      } catch {
+        result(containerAccessError(operation: "documentExists", relativePath: relativePath))
+      }
+    }
   }
   
   /// Get file or directory metadata without downloading content.
@@ -1204,38 +1213,45 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
     
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(operation: "getDocumentMetadata", relativePath: relativePath))
-      return
-    }
+    let preflight = WriteEntrypointPreflight.live
 
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-    guard FileManager.default.fileExists(atPath: fileURL.path) else {
-      result(nil)
-      return
-    }
+    Task {
+      do {
+        let containerURL = try await preflight.containerURL(containerId: containerId)
+        let fileURL = containerURL.appendingPathComponent(relativePath)
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+          result(nil)
+          return
+        }
 
-    do {
-      let values = try fileURL.resourceValues(forKeys: [
-        .isDirectoryKey,
-        .fileSizeKey,
-        .creationDateKey,
-        .contentModificationDateKey,
-        .ubiquitousItemDownloadingStatusKey,
-        .ubiquitousItemIsDownloadingKey,
-        .ubiquitousItemIsUploadedKey,
-        .ubiquitousItemIsUploadingKey,
-        .ubiquitousItemHasUnresolvedConflictsKey,
-      ])
-      let containerPath = containerURL.standardizedFileURL.path
-      result(mapResourceValues(
-        fileURL: fileURL,
-        values: values,
-        containerPath: containerPath
-      ))
-    } catch {
-      result(nativeCodeError(error, operation: "getDocumentMetadata", relativePath: relativePath))
+        let values = try fileURL.resourceValues(forKeys: [
+          .isDirectoryKey,
+          .fileSizeKey,
+          .creationDateKey,
+          .contentModificationDateKey,
+          .ubiquitousItemDownloadingStatusKey,
+          .ubiquitousItemIsDownloadingKey,
+          .ubiquitousItemIsUploadedKey,
+          .ubiquitousItemIsUploadingKey,
+          .ubiquitousItemHasUnresolvedConflictsKey,
+        ])
+        let containerPath = containerURL.standardizedFileURL.path
+        result(mapResourceValues(
+          fileURL: fileURL,
+          values: values,
+          containerPath: containerPath
+        ))
+      } catch {
+        if let mapped = mapWriteEntrypointPreflightError(
+          error,
+          operation: "getDocumentMetadata",
+          relativePath: relativePath
+        ) {
+          result(mapped)
+          return
+        }
+        result(nativeCodeError(error, operation: "getDocumentMetadata", relativePath: relativePath))
+      }
     }
   }
 
@@ -1253,50 +1269,53 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
-    guard let containerURL = FileManager.default.url(
-      forUbiquityContainerIdentifier: containerId
-    ) else {
-      result(containerAccessError(
-        operation: "getItemMetadata",
-        relativePath: relativePath
-      ))
-      return
-    }
+    let preflight = WriteEntrypointPreflight.live
 
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-    guard FileManager.default.fileExists(atPath: fileURL.path) else {
-      result(nil)
-      return
-    }
+    Task {
+      do {
+        let containerURL = try await preflight.containerURL(containerId: containerId)
+        let fileURL = containerURL.appendingPathComponent(relativePath)
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+          result(nil)
+          return
+        }
 
-    do {
-      let values = try fileURL.resourceValues(forKeys: [
-        .isDirectoryKey,
-        .fileSizeKey,
-        .creationDateKey,
-        .contentModificationDateKey,
-        .ubiquitousItemDownloadingStatusKey,
-        .ubiquitousItemIsDownloadingKey,
-        .ubiquitousItemIsUploadedKey,
-        .ubiquitousItemIsUploadingKey,
-        .ubiquitousItemHasUnresolvedConflictsKey,
-      ])
-      let containerPath = containerURL.standardizedFileURL.path
-      var metadata = mapResourceValues(
-        fileURL: fileURL,
-        values: values,
-        containerPath: containerPath
-      )
-      metadata["downloadStatus"] = normalizeDownloadStatus(
-        values.ubiquitousItemDownloadingStatus
-      ) ?? values.ubiquitousItemDownloadingStatus?.rawValue
-      result(metadata)
-    } catch {
-      result(nativeCodeError(
-        error,
-        operation: "getItemMetadata",
-        relativePath: relativePath
-      ))
+        let values = try fileURL.resourceValues(forKeys: [
+          .isDirectoryKey,
+          .fileSizeKey,
+          .creationDateKey,
+          .contentModificationDateKey,
+          .ubiquitousItemDownloadingStatusKey,
+          .ubiquitousItemIsDownloadingKey,
+          .ubiquitousItemIsUploadedKey,
+          .ubiquitousItemIsUploadingKey,
+          .ubiquitousItemHasUnresolvedConflictsKey,
+        ])
+        let containerPath = containerURL.standardizedFileURL.path
+        var metadata = mapResourceValues(
+          fileURL: fileURL,
+          values: values,
+          containerPath: containerPath
+        )
+        metadata["downloadStatus"] = normalizeDownloadStatus(
+          values.ubiquitousItemDownloadingStatus
+        ) ?? values.ubiquitousItemDownloadingStatus?.rawValue
+        result(metadata)
+      } catch {
+        if let mapped = mapWriteEntrypointPreflightError(
+          error,
+          operation: "getItemMetadata",
+          relativePath: relativePath
+        ) {
+          result(mapped)
+          return
+        }
+        result(nativeCodeError(
+          error,
+          operation: "getItemMetadata",
+          relativePath: relativePath
+        ))
+      }
     }
   }
 
@@ -1319,17 +1338,6 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
 
     let subdir = args["relativePath"] as? String
 
-    guard let containerURL = FileManager.default
-      .url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(operation: "listContents", relativePath: subdir))
-      return
-    }
-
-    let listURL = subdir != nil
-      ? containerURL.appendingPathComponent(subdir!)
-      : containerURL
-
     let keys: [URLResourceKey] = [
       .isDirectoryKey,
       .ubiquitousItemDownloadingStatusKey,
@@ -1339,8 +1347,15 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       .ubiquitousItemHasUnresolvedConflictsKey,
     ]
 
-    DispatchQueue.global(qos: .userInitiated).async {
+    let preflight = WriteEntrypointPreflight.live
+
+    Task {
       do {
+        let containerURL = try await preflight.containerURL(containerId: containerId)
+        let listURL = subdir != nil
+          ? containerURL.appendingPathComponent(subdir!)
+          : containerURL
+
         let contents = try FileManager.default.contentsOfDirectory(
           at: listURL,
           includingPropertiesForKeys: keys,
@@ -1392,8 +1407,16 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           ])
         }
 
-        DispatchQueue.main.async { result(items) }
+        result(items)
       } catch {
+        if let mapped = mapWriteEntrypointPreflightError(
+          error,
+          operation: "listContents",
+          relativePath: subdir
+        ) {
+          result(mapped)
+          return
+        }
         DispatchQueue.main.async {
           result(self.nativeCodeError(
             error,
@@ -1760,7 +1783,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     for token in tokens {
       NotificationCenter.default.removeObserver(token)
     }
-    queryObserversQueue.sync {
+    _ = queryObserversQueue.sync {
       queryObservers.removeValue(forKey: key)
     }
   }
@@ -1931,6 +1954,21 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     )
   }
 
+  private func mapWriteEntrypointPreflightError(
+    _ error: Error,
+    operation: String,
+    relativePath: String?
+  ) -> FlutterError? {
+    guard WriteEntrypointPreflight.isContainerUnavailableError(error) else {
+      return nil
+    }
+
+    return containerAccessError(
+      operation: operation,
+      relativePath: relativePath
+    )
+  }
+
   /// Maps file-not-found errors to specific Flutter error codes.
   private func mapFileNotFoundError(
     _ error: Error,
@@ -2079,7 +2117,7 @@ private struct WriteEntrypointWriter {
   }
 }
 
-private final class CompletionGate {
+private final class CompletionGate: @unchecked Sendable {
   private let queue = DispatchQueue(
     label: "icloud_storage_plus.completion_gate"
   )

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/ConflictResolver.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/ConflictResolver.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+func resolvePresentedItemConflictsSync(at url: URL) throws {
+    guard let conflicts = NSFileVersion.unresolvedConflictVersionsOfItem(at: url),
+          !conflicts.isEmpty else {
+        return
+    }
+
+    let sorted = conflicts.sorted {
+        ($0.modificationDate ?? .distantPast) >
+            ($1.modificationDate ?? .distantPast)
+    }
+
+    if let latest = sorted.first {
+        try latest.replaceItem(at: url, options: [])
+    }
+
+    for version in conflicts {
+        version.isResolved = true
+    }
+
+    try NSFileVersion.removeOtherVersionsOfItem(at: url)
+}
+
+func resolvePresentedItemConflicts(at url: URL) async throws {
+    try resolvePresentedItemConflictsSync(at: url)
+}
+
+func cleanupConflictsAfterOverwrite(at url: URL) throws {
+    guard let conflicts = NSFileVersion.unresolvedConflictVersionsOfItem(at: url),
+          !conflicts.isEmpty else {
+        return
+    }
+
+    for version in conflicts {
+        version.isResolved = true
+    }
+
+    try NSFileVersion.removeOtherVersionsOfItem(at: url)
+}

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/ConflictResolver.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/ConflictResolver.swift
@@ -1,11 +1,16 @@
 import Foundation
 
+// Keep this mirrored with the macOS foundation package until the reset work
+// intentionally consolidates Darwin sources in a later task.
+
 func resolvePresentedItemConflictsSync(at url: URL) throws {
     guard let conflicts = NSFileVersion.unresolvedConflictVersionsOfItem(at: url),
           !conflicts.isEmpty else {
         return
     }
 
+    // Observer recovery restores the newest known file version so the
+    // presented item converges on the latest iCloud winner.
     let sorted = conflicts.sorted {
         ($0.modificationDate ?? .distantPast) >
             ($1.modificationDate ?? .distantPast)

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
@@ -2,14 +2,16 @@ import Foundation
 
 struct CoordinatedReplaceWriter {
     typealias FileExists = (String) -> Bool
+    typealias EnsureDownloaded = (URL) async throws -> Void
     typealias VerifyDestination = (URL) throws -> Void
     typealias CreateReplacementDirectory = (URL) throws -> URL
-    typealias CoordinateReplace = (URL, (URL) throws -> Void) throws -> Void
+    typealias CoordinateReplace = (URL, (URL) throws -> Void) async throws -> Void
     typealias CleanupConflicts = (URL) throws -> Void
     typealias ReplaceItem = (URL, URL) throws -> Void
     typealias RemoveItem = (URL) throws -> Void
 
     let fileExists: FileExists
+    let ensureDownloaded: EnsureDownloaded
     let verifyDestination: VerifyDestination
     let createReplacementDirectory: CreateReplacementDirectory
     let coordinateReplace: CoordinateReplace
@@ -20,11 +22,12 @@ struct CoordinatedReplaceWriter {
     func overwriteExistingItem(
         at destinationURL: URL,
         prepareReplacementFile: (URL) throws -> Void
-    ) throws -> Bool {
+    ) async throws -> Bool {
         guard fileExists(destinationURL.path) else {
             return false
         }
 
+        try await ensureDownloaded(destinationURL)
         try verifyDestination(destinationURL)
 
         let replacementDirectory = try createReplacementDirectory(destinationURL)
@@ -35,7 +38,7 @@ struct CoordinatedReplaceWriter {
             try prepareReplacementFile(replacementURL)
             let cleanupConflicts = self.cleanupConflicts
             let replaceItem = self.replaceItem
-            try coordinateReplace(destinationURL) { coordinatedURL in
+            try await coordinateReplace(destinationURL) { coordinatedURL in
                 try replaceItem(coordinatedURL, replacementURL)
                 do {
                     try cleanupConflicts(coordinatedURL)
@@ -150,6 +153,7 @@ extension CoordinatedReplaceWriter {
 
     static let live = CoordinatedReplaceWriter(
         fileExists: { FileManager.default.fileExists(atPath: $0) },
+        ensureDownloaded: { _ in },
         verifyDestination: { destinationURL in
             let values = try destinationURL.resourceValues(forKeys: [.isDirectoryKey])
 

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
@@ -51,6 +51,7 @@ struct CoordinatedReplaceWriter {
 
 extension CoordinatedReplaceWriter {
     static let replaceStateErrorDomain = "ICloudStoragePlusErrorDomain"
+    static let conflictReplaceStateCode = 1
     static let itemNotDownloadedReplaceStateCode = 2
     static let directoryReplaceStateCode = 4
 
@@ -99,6 +100,24 @@ extension CoordinatedReplaceWriter {
     static func verifyExistingDestinationCanBeReplaced(
         at destinationURL: URL
     ) throws {
+        let hasConflicts = if let conflictVersions =
+            NSFileVersion.unresolvedConflictVersionsOfItem(at: destinationURL) {
+            !conflictVersions.isEmpty
+        } else {
+            false
+        }
+
+        if hasConflicts {
+            throw NSError(
+                domain: replaceStateErrorDomain,
+                code: conflictReplaceStateCode,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Cannot replace an iCloud item with unresolved conflict versions.",
+                ]
+            )
+        }
+
         let values = try destinationURL.resourceValues(forKeys: [
             .isUbiquitousItemKey,
             .ubiquitousItemDownloadingStatusKey,

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
@@ -62,6 +62,10 @@ extension CoordinatedReplaceWriter {
     static let itemNotDownloadedReplaceStateCode = 2
     static let directoryReplaceStateCode = 4
 
+    // Task 4 keeps foundation self-contained for tests. Task 5 replaces this
+    // placeholder at the plugin boundary with the real download/wait behavior.
+    static let foundationDefaultEnsureDownloaded: EnsureDownloaded = { _ in }
+
     static func cleanupConflictError(underlying: Error) -> NSError {
         NSError(
             domain: replaceStateErrorDomain,
@@ -153,7 +157,7 @@ extension CoordinatedReplaceWriter {
 
     static let live = CoordinatedReplaceWriter(
         fileExists: { FileManager.default.fileExists(atPath: $0) },
-        ensureDownloaded: { _ in },
+        ensureDownloaded: foundationDefaultEnsureDownloaded,
         verifyDestination: { destinationURL in
             let values = try destinationURL.resourceValues(forKeys: [.isDirectoryKey])
 

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
@@ -5,6 +5,7 @@ struct CoordinatedReplaceWriter {
     typealias VerifyDestination = (URL) throws -> Void
     typealias CreateReplacementDirectory = (URL) throws -> URL
     typealias CoordinateReplace = (URL, (URL) throws -> Void) throws -> Void
+    typealias CleanupConflicts = (URL) throws -> Void
     typealias ReplaceItem = (URL, URL) throws -> Void
     typealias RemoveItem = (URL) throws -> Void
 
@@ -12,6 +13,7 @@ struct CoordinatedReplaceWriter {
     let verifyDestination: VerifyDestination
     let createReplacementDirectory: CreateReplacementDirectory
     let coordinateReplace: CoordinateReplace
+    let cleanupConflicts: CleanupConflicts
     let replaceItem: ReplaceItem
     let removeItem: RemoveItem
 
@@ -31,8 +33,11 @@ struct CoordinatedReplaceWriter {
 
         do {
             try prepareReplacementFile(replacementURL)
+            let cleanupConflicts = self.cleanupConflicts
+            let replaceItem = self.replaceItem
             try coordinateReplace(destinationURL) { coordinatedURL in
                 try replaceItem(coordinatedURL, replacementURL)
+                try cleanupConflicts(coordinatedURL)
             }
         } catch {
             try? removeItem(replacementDirectory)
@@ -46,9 +51,7 @@ struct CoordinatedReplaceWriter {
 
 extension CoordinatedReplaceWriter {
     static let replaceStateErrorDomain = "ICloudStoragePlusErrorDomain"
-    static let conflictReplaceStateCode = 1
     static let itemNotDownloadedReplaceStateCode = 2
-    static let downloadInProgressReplaceStateCode = 3
     static let directoryReplaceStateCode = 4
 
     static func fileDestinationError(isDirectory: Bool) -> NSError? {
@@ -72,16 +75,8 @@ extension CoordinatedReplaceWriter {
         downloadStatus: URLUbiquitousItemDownloadingStatus?,
         isDownloading: Bool
     ) -> NSError? {
-        if hasConflicts {
-            return NSError(
-                domain: replaceStateErrorDomain,
-                code: conflictReplaceStateCode,
-                userInfo: [
-                    NSLocalizedDescriptionKey:
-                        "Cannot replace an iCloud item with unresolved conflict versions.",
-                ]
-            )
-        }
+        _ = hasConflicts
+        _ = isDownloading
 
         guard isUbiquitousItem else {
             return nil
@@ -89,17 +84,6 @@ extension CoordinatedReplaceWriter {
 
         if downloadStatus == .current {
             return nil
-        }
-
-        if isDownloading {
-            return NSError(
-                domain: replaceStateErrorDomain,
-                code: downloadInProgressReplaceStateCode,
-                userInfo: [
-                    NSLocalizedDescriptionKey:
-                        "Cannot replace an iCloud item while it is downloading.",
-                ]
-            )
         }
 
         return NSError(
@@ -115,13 +99,6 @@ extension CoordinatedReplaceWriter {
     static func verifyExistingDestinationCanBeReplaced(
         at destinationURL: URL
     ) throws {
-        let hasConflicts = if let conflictVersions =
-            NSFileVersion.unresolvedConflictVersionsOfItem(at: destinationURL) {
-            !conflictVersions.isEmpty
-        } else {
-            false
-        }
-
         let values = try destinationURL.resourceValues(forKeys: [
             .isUbiquitousItemKey,
             .ubiquitousItemDownloadingStatusKey,
@@ -134,7 +111,7 @@ extension CoordinatedReplaceWriter {
         }
 
         if let replaceStateError = replaceReadyStateError(
-            hasConflicts: hasConflicts,
+            hasConflicts: false,
             isUbiquitousItem: values.isUbiquitousItem == true,
             downloadStatus: values.ubiquitousItemDownloadingStatus,
             isDownloading: values.ubiquitousItemIsDownloading == true
@@ -143,24 +120,16 @@ extension CoordinatedReplaceWriter {
         }
     }
 
-    private static func verifyFileDestinationCanBeOverwritten(
-        at destinationURL: URL
-    ) throws {
-        let values = try destinationURL.resourceValues(forKeys: [.isDirectoryKey])
-
-        if let destinationError = fileDestinationError(
-            isDirectory: values.isDirectory == true
-        ) {
-            throw destinationError
-        }
-
-        try verifyExistingDestinationCanBeReplaced(at: destinationURL)
-    }
-
     static let live = CoordinatedReplaceWriter(
         fileExists: { FileManager.default.fileExists(atPath: $0) },
         verifyDestination: { destinationURL in
-            try verifyFileDestinationCanBeOverwritten(at: destinationURL)
+            let values = try destinationURL.resourceValues(forKeys: [.isDirectoryKey])
+
+            if let destinationError = fileDestinationError(
+                isDirectory: values.isDirectory == true
+            ) {
+                throw destinationError
+            }
         },
         createReplacementDirectory: { destinationURL in
             try FileManager.default.url(
@@ -195,6 +164,7 @@ extension CoordinatedReplaceWriter {
                 throw accessError
             }
         },
+        cleanupConflicts: cleanupConflictsAfterOverwrite,
         replaceItem: { destinationURL, replacementURL in
             _ = try FileManager.default.replaceItemAt(
                 destinationURL,

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
@@ -37,7 +37,11 @@ struct CoordinatedReplaceWriter {
             let replaceItem = self.replaceItem
             try coordinateReplace(destinationURL) { coordinatedURL in
                 try replaceItem(coordinatedURL, replacementURL)
-                try cleanupConflicts(coordinatedURL)
+                do {
+                    try cleanupConflicts(coordinatedURL)
+                } catch {
+                    throw Self.cleanupConflictError(underlying: error)
+                }
             }
         } catch {
             try? removeItem(replacementDirectory)
@@ -55,6 +59,18 @@ extension CoordinatedReplaceWriter {
     static let itemNotDownloadedReplaceStateCode = 2
     static let directoryReplaceStateCode = 4
 
+    static func cleanupConflictError(underlying: Error) -> NSError {
+        NSError(
+            domain: replaceStateErrorDomain,
+            code: conflictReplaceStateCode,
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "Cannot replace an iCloud item: auto-resolution failed.",
+                NSUnderlyingErrorKey: underlying as NSError,
+            ]
+        )
+    }
+
     static func fileDestinationError(isDirectory: Bool) -> NSError? {
         guard isDirectory else {
             return nil
@@ -70,15 +86,10 @@ extension CoordinatedReplaceWriter {
         )
     }
 
-    static func replaceReadyStateError(
-        hasConflicts: Bool,
+    static func copyDestinationReadyStateError(
         isUbiquitousItem: Bool,
-        downloadStatus: URLUbiquitousItemDownloadingStatus?,
-        isDownloading: Bool
+        downloadStatus: URLUbiquitousItemDownloadingStatus?
     ) -> NSError? {
-        _ = hasConflicts
-        _ = isDownloading
-
         guard isUbiquitousItem else {
             return nil
         }
@@ -129,11 +140,9 @@ extension CoordinatedReplaceWriter {
             throw downloadError
         }
 
-        if let replaceStateError = replaceReadyStateError(
-            hasConflicts: false,
+        if let replaceStateError = copyDestinationReadyStateError(
             isUbiquitousItem: values.isUbiquitousItem == true,
-            downloadStatus: values.ubiquitousItemDownloadingStatus,
-            isDownloading: values.ubiquitousItemIsDownloading == true
+            downloadStatus: values.ubiquitousItemDownloadingStatus
         ) {
             throw replaceStateError
         }

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -28,14 +28,14 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         )
     }
 
-    func testLiveWriterReplacesExistingLocalFile() throws {
+    func testLiveWriterReplacesExistingLocalFile() async throws {
         let temporaryDirectory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
 
         let destinationURL = temporaryDirectory.appendingPathComponent("file.json")
         try Data("old".utf8).write(to: destinationURL)
 
-        let handled = try CoordinatedReplaceWriter.live.overwriteExistingItem(
+        let handled = try await CoordinatedReplaceWriter.live.overwriteExistingItem(
             at: destinationURL
         ) { replacementURL in
             try Data("new".utf8).write(to: replacementURL)
@@ -45,7 +45,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         XCTAssertEqual(try String(contentsOf: destinationURL), "new")
     }
 
-    func testLiveWriterRejectsExistingDirectoryDestination() throws {
+    func testLiveWriterRejectsExistingDirectoryDestination() async throws {
         let temporaryDirectory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
 
@@ -58,13 +58,14 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             withIntermediateDirectories: true
         )
 
-        XCTAssertThrowsError(
-            try CoordinatedReplaceWriter.live.overwriteExistingItem(
+        do {
+            _ = try await CoordinatedReplaceWriter.live.overwriteExistingItem(
                 at: destinationURL
             ) { replacementURL in
                 try Data("new".utf8).write(to: replacementURL)
             }
-        ) { error in
+            XCTFail("expected overwrite to throw")
+        } catch {
             XCTAssertEqual(
                 error.localizedDescription,
                 "Cannot replace an existing directory with file content."
@@ -72,12 +73,13 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         }
     }
 
-    func testOverwriteExistingItemThrowsWhenDestinationHasUnresolvedConflicts() {
+    func testOverwriteExistingItemThrowsWhenDestinationHasUnresolvedConflicts() async {
         let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
         var preparedReplacement = false
 
         let writer = CoordinatedReplaceWriter(
             fileExists: { _ in true },
+            ensureDownloaded: { _ in },
             verifyDestination: { _ in
                 throw NSError(
                     domain: "ICloudStoragePlusErrorDomain",
@@ -102,11 +104,12 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             removeItem: { _ in }
         )
 
-        XCTAssertThrowsError(
-            try writer.overwriteExistingItem(at: destinationURL) { _ in
+        do {
+            _ = try await writer.overwriteExistingItem(at: destinationURL) { _ in
                 preparedReplacement = true
             }
-        ) { error in
+            XCTFail("expected overwrite to throw")
+        } catch {
             XCTAssertEqual(
                 error.localizedDescription,
                 "Cannot replace an iCloud item with unresolved conflict versions."
@@ -116,12 +119,13 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         XCTAssertFalse(preparedReplacement)
     }
 
-    func testOverwriteExistingItemThrowsWhenDestinationIsNotFullyLocal() {
+    func testOverwriteExistingItemThrowsWhenDestinationIsNotFullyLocal() async {
         let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
         var preparedReplacement = false
 
         let writer = CoordinatedReplaceWriter(
             fileExists: { _ in true },
+            ensureDownloaded: { _ in },
             verifyDestination: { _ in
                 throw NSError(
                     domain: "ICloudStoragePlusErrorDomain",
@@ -146,11 +150,12 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             removeItem: { _ in }
         )
 
-        XCTAssertThrowsError(
-            try writer.overwriteExistingItem(at: destinationURL) { _ in
+        do {
+            _ = try await writer.overwriteExistingItem(at: destinationURL) { _ in
                 preparedReplacement = true
             }
-        ) { error in
+            XCTFail("expected overwrite to throw")
+        } catch {
             XCTAssertEqual(
                 error.localizedDescription,
                 "Cannot replace a nonlocal iCloud item until it is fully downloaded."
@@ -174,12 +179,15 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         )
     }
 
-    func testOverwriteExistingItemReturnsFalseWhenDestinationDoesNotExist() throws {
+    func testOverwriteExistingItemReturnsFalseWhenDestinationDoesNotExist() async throws {
         var preparedReplacement = false
         var verifiedDestinationState = false
 
         let writer = CoordinatedReplaceWriter(
             fileExists: { _ in false },
+            ensureDownloaded: { _ in
+                XCTFail("should not ensure download")
+            },
             verifyDestination: { _ in
                 verifiedDestinationState = true
             },
@@ -197,7 +205,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             removeItem: { _ in }
         )
 
-        let handled = try writer.overwriteExistingItem(
+        let handled = try await writer.overwriteExistingItem(
             at: URL(fileURLWithPath: "/tmp/file.json")
         ) { _ in
             preparedReplacement = true
@@ -208,7 +216,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         XCTAssertFalse(verifiedDestinationState)
     }
 
-    func testOverwriteExistingItemCleansUpReplacementArtifactWhenReplaceFails() {
+    func testOverwriteExistingItemCleansUpReplacementArtifactWhenReplaceFails() async {
         let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
         let replacementDirectory = URL(fileURLWithPath: "/tmp/replacement")
         let expectedError = NSError(domain: NSCocoaErrorDomain, code: 512)
@@ -216,6 +224,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
 
         let writer = CoordinatedReplaceWriter(
             fileExists: { _ in true },
+            ensureDownloaded: { _ in },
             verifyDestination: { _ in },
             createReplacementDirectory: { _ in replacementDirectory },
             coordinateReplace: { url, accessor in try accessor(url) },
@@ -224,25 +233,27 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             removeItem: { cleanedURL = $0 }
         )
 
-        XCTAssertThrowsError(
-            try writer.overwriteExistingItem(at: destinationURL) { url in
+        do {
+            _ = try await writer.overwriteExistingItem(at: destinationURL) { url in
                 XCTAssertEqual(
                     url.deletingLastPathComponent().path,
                     replacementDirectory.path
                 )
             }
-        ) { error in
+            XCTFail("expected overwrite to throw")
+        } catch {
             XCTAssertEqual((error as NSError).code, expectedError.code)
         }
 
         XCTAssertNotNil(cleanedURL)
     }
 
-    func testOverwriteExistingItemReplacesBeforeConflictCleanup() throws {
+    func testOverwriteExistingItemReplacesBeforeConflictCleanup() async throws {
         var events: [String] = []
 
         let writer = CoordinatedReplaceWriter(
             fileExists: { _ in true },
+            ensureDownloaded: { _ in },
             verifyDestination: { _ in },
             createReplacementDirectory: { _ in
                 URL(fileURLWithPath: "/tmp/replacement")
@@ -255,14 +266,14 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             removeItem: { _ in }
         )
 
-        _ = try writer.overwriteExistingItem(
+        _ = try await writer.overwriteExistingItem(
             at: URL(fileURLWithPath: "/tmp/file.json")
         ) { _ in }
 
         XCTAssertEqual(events, ["replaceItem", "cleanupConflicts"])
     }
 
-    func testOverwriteExistingItemMapsCleanupFailureToConflictError() {
+    func testOverwriteExistingItemMapsCleanupFailureToConflictError() async {
         let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
         let replacementDirectory = URL(fileURLWithPath: "/tmp/replacement")
         let underlyingError = NSError(domain: NSCocoaErrorDomain, code: 512)
@@ -270,6 +281,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
 
         let writer = CoordinatedReplaceWriter(
             fileExists: { _ in true },
+            ensureDownloaded: { _ in },
             verifyDestination: { _ in },
             createReplacementDirectory: { _ in replacementDirectory },
             coordinateReplace: { url, accessor in try accessor(url) },
@@ -278,9 +290,10 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             removeItem: { cleanedURL = $0 }
         )
 
-        XCTAssertThrowsError(
-            try writer.overwriteExistingItem(at: destinationURL) { _ in }
-        ) { error in
+        do {
+            _ = try await writer.overwriteExistingItem(at: destinationURL) { _ in }
+            XCTFail("expected overwrite to throw")
+        } catch {
             let nsError = error as NSError
             XCTAssertEqual(
                 nsError.domain,
@@ -301,6 +314,31 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         }
 
         XCTAssertEqual(cleanedURL, replacementDirectory)
+    }
+
+    func testOverwriteExistingItemEnsuresDownloadBeforeValidation() async throws {
+        var events: [String] = []
+
+        let writer = CoordinatedReplaceWriter(
+            fileExists: { _ in true },
+            ensureDownloaded: { _ in events.append("ensureDownloaded") },
+            verifyDestination: { _ in events.append("verifyDestination") },
+            createReplacementDirectory: { _ in
+                URL(fileURLWithPath: "/tmp/replacement")
+            },
+            coordinateReplace: { _, accessor in
+                try accessor(URL(fileURLWithPath: "/tmp/file.json"))
+            },
+            cleanupConflicts: { _ in },
+            replaceItem: { _, _ in },
+            removeItem: { _ in }
+        )
+
+        _ = try await writer.overwriteExistingItem(
+            at: URL(fileURLWithPath: "/tmp/file.json")
+        ) { _ in }
+
+        XCTAssertEqual(events, ["ensureDownloaded", "verifyDestination"])
     }
 
     private func makeTemporaryDirectory() throws -> URL {

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -248,6 +248,36 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         XCTAssertNotNil(cleanedURL)
     }
 
+    func testOverwriteExistingItemCleanupSeesReplacementContent() async throws {
+        let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
+        let replacementDirectory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: replacementDirectory) }
+        var destinationContents = "old"
+        var cleanupSawContents: String?
+
+        let writer = CoordinatedReplaceWriter(
+            fileExists: { _ in true },
+            ensureDownloaded: { _ in },
+            verifyDestination: { _ in },
+            createReplacementDirectory: { _ in replacementDirectory },
+            coordinateReplace: { url, accessor in try accessor(url) },
+            cleanupConflicts: { _ in
+                cleanupSawContents = destinationContents
+            },
+            replaceItem: { _, replacementURL in
+                destinationContents = try String(contentsOf: replacementURL)
+            },
+            removeItem: { _ in }
+        )
+
+        _ = try await writer.overwriteExistingItem(at: destinationURL) { url in
+            try "new".write(to: url, atomically: true, encoding: .utf8)
+        }
+
+        XCTAssertEqual(destinationContents, "new")
+        XCTAssertEqual(cleanupSawContents, "new")
+    }
+
     func testOverwriteExistingItemMapsCleanupFailureToConflictError() async {
         let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
         let replacementDirectory = URL(fileURLWithPath: "/tmp/replacement")

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -219,6 +219,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
     func testOverwriteExistingItemVerifiesDestinationAfterEnsuringDownload() async throws {
         var downloadPrepared = false
         var verifySawPreparedDownload = false
+        let fileManager = FileManager.default
 
         let writer = CoordinatedReplaceWriter(
             fileExists: { _ in true },
@@ -233,7 +234,11 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             coordinateReplace: { url, accessor in try accessor(url) },
             cleanupConflicts: { _ in },
             replaceItem: { _, _ in },
-            removeItem: { _ in }
+            removeItem: { url in
+                if fileManager.fileExists(atPath: url.path) {
+                    try fileManager.removeItem(at: url)
+                }
+            }
         )
 
         _ = try await writer.overwriteExistingItem(
@@ -280,6 +285,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         var destinationContents = "old"
         var cleanupSawContents: String?
         let replacementContents = "new"
+        let fileManager = FileManager.default
 
         let writer = CoordinatedReplaceWriter(
             fileExists: { _ in true },
@@ -293,7 +299,11 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             replaceItem: { _, _ in
                 destinationContents = replacementContents
             },
-            removeItem: { _ in }
+            removeItem: { url in
+                if fileManager.fileExists(atPath: url.path) {
+                    try fileManager.removeItem(at: url)
+                }
+            }
         )
 
         _ = try await writer.overwriteExistingItem(at: destinationURL) { _ in

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -248,31 +248,6 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         XCTAssertNotNil(cleanedURL)
     }
 
-    func testOverwriteExistingItemReplacesBeforeConflictCleanup() async throws {
-        var events: [String] = []
-
-        let writer = CoordinatedReplaceWriter(
-            fileExists: { _ in true },
-            ensureDownloaded: { _ in },
-            verifyDestination: { _ in },
-            createReplacementDirectory: { _ in
-                URL(fileURLWithPath: "/tmp/replacement")
-            },
-            coordinateReplace: { _, accessor in
-                try accessor(URL(fileURLWithPath: "/tmp/file.json"))
-            },
-            cleanupConflicts: { _ in events.append("cleanupConflicts") },
-            replaceItem: { _, _ in events.append("replaceItem") },
-            removeItem: { _ in }
-        )
-
-        _ = try await writer.overwriteExistingItem(
-            at: URL(fileURLWithPath: "/tmp/file.json")
-        ) { _ in }
-
-        XCTAssertEqual(events, ["replaceItem", "cleanupConflicts"])
-    }
-
     func testOverwriteExistingItemMapsCleanupFailureToConflictError() async {
         let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
         let replacementDirectory = URL(fileURLWithPath: "/tmp/replacement")
@@ -314,31 +289,6 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         }
 
         XCTAssertEqual(cleanedURL, replacementDirectory)
-    }
-
-    func testOverwriteExistingItemEnsuresDownloadBeforeValidation() async throws {
-        var events: [String] = []
-
-        let writer = CoordinatedReplaceWriter(
-            fileExists: { _ in true },
-            ensureDownloaded: { _ in events.append("ensureDownloaded") },
-            verifyDestination: { _ in events.append("verifyDestination") },
-            createReplacementDirectory: { _ in
-                URL(fileURLWithPath: "/tmp/replacement")
-            },
-            coordinateReplace: { _, accessor in
-                try accessor(URL(fileURLWithPath: "/tmp/file.json"))
-            },
-            cleanupConflicts: { _ in },
-            replaceItem: { _, _ in },
-            removeItem: { _ in }
-        )
-
-        _ = try await writer.overwriteExistingItem(
-            at: URL(fileURLWithPath: "/tmp/file.json")
-        ) { _ in }
-
-        XCTAssertEqual(events, ["ensureDownloaded", "verifyDestination"])
     }
 
     private func makeTemporaryDirectory() throws -> URL {

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -43,51 +43,6 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         )
     }
 
-    func testIOSCopyPropagatesSourceReadCoordinationErrors() throws {
-        let pluginSource = try String(
-            contentsOfFile: #filePath
-                .replacingOccurrences(
-                    of: "/Sources/icloud_storage_plus_foundation/Tests/"
-                        + "icloud_storage_plus_foundationTests/"
-                        + "CoordinatedReplaceWriterTests.swift",
-                    with: "/Sources/icloud_storage_plus/"
-                        + "iOSICloudStoragePlugin.swift"
-                ),
-            encoding: .utf8
-        )
-
-        XCTAssertTrue(
-            pluginSource.contains("var sourceCoordinationError: NSError?"),
-            "copy() should capture read coordination failures before "
-                + "falling through to destination handling."
-        )
-        XCTAssertTrue(
-            pluginSource.contains("error: &sourceCoordinationError"),
-            "copy() should pass a read coordination error pointer instead "
-                + "of discarding coordination failures."
-        )
-        XCTAssertTrue(
-            pluginSource.contains("if let sourceCoordinationError"),
-            "copy() should surface a failed source read coordination "
-                + "instead of continuing silently."
-        )
-        XCTAssertTrue(
-            pluginSource.contains("var copyCoordinationError: NSError?"),
-            "copy() should also capture read/write coordination failures in "
-                + "the non-overwrite path."
-        )
-        XCTAssertTrue(
-            pluginSource.contains("error: &copyCoordinationError"),
-            "copy() should not discard the combined read/write "
-                + "coordination error."
-        )
-        XCTAssertTrue(
-            pluginSource.contains("if let copyCoordinationError"),
-            "copy() should surface a failed combined coordination instead "
-                + "of leaving the Flutter call without a result."
-        )
-    }
-
     func testLiveWriterReplacesExistingLocalFile() throws {
         let temporaryDirectory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
@@ -216,22 +171,6 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         }
 
         XCTAssertFalse(preparedReplacement)
-    }
-
-    func testReplaceReadyStateErrorReturnsDistinctDownloadInProgressCode() {
-        let error = CoordinatedReplaceWriter.replaceReadyStateError(
-            hasConflicts: false,
-            isUbiquitousItem: true,
-            downloadStatus: URLUbiquitousItemDownloadingStatus.downloaded,
-            isDownloading: true
-        ) as NSError?
-
-        XCTAssertEqual(error?.domain, "ICloudStoragePlusErrorDomain")
-        XCTAssertEqual(error?.code, 3)
-        XCTAssertEqual(
-            error?.localizedDescription,
-            "Cannot replace an iCloud item while it is downloading."
-        )
     }
 
     func testReplaceReadyStateErrorRejectsDownloadedButNotCurrentItems() {

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -3,34 +3,19 @@ import XCTest
 @testable import icloud_storage_plus_foundation
 
 final class CoordinatedReplaceWriterTests: XCTestCase {
-    func testReplaceReadyStateErrorAllowsCurrentItemsWithoutConflicts() {
-        let error = CoordinatedReplaceWriter.replaceReadyStateError(
-            hasConflicts: false,
+    func testCopyDestinationReadyStateErrorAllowsCurrentItems() {
+        let error = CoordinatedReplaceWriter.copyDestinationReadyStateError(
             isUbiquitousItem: true,
-            downloadStatus: .current,
-            isDownloading: false
+            downloadStatus: .current
         )
 
         XCTAssertNil(error)
     }
 
-    func testReplaceReadyStateErrorAllowsConflictedCurrentItemsToProceed() {
-        let error = CoordinatedReplaceWriter.replaceReadyStateError(
-            hasConflicts: true,
+    func testCopyDestinationReadyStateErrorRejectsNotDownloadedItems() {
+        let error = CoordinatedReplaceWriter.copyDestinationReadyStateError(
             isUbiquitousItem: true,
-            downloadStatus: .current,
-            isDownloading: false
-        )
-
-        XCTAssertNil(error)
-    }
-
-    func testReplaceReadyStateErrorTreatsDownloadingItemsAsNotDownloaded() {
-        let error = CoordinatedReplaceWriter.replaceReadyStateError(
-            hasConflicts: false,
-            isUbiquitousItem: true,
-            downloadStatus: .downloaded,
-            isDownloading: true
+            downloadStatus: .notDownloaded
         ) as NSError?
 
         XCTAssertEqual(
@@ -175,12 +160,10 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         XCTAssertFalse(preparedReplacement)
     }
 
-    func testReplaceReadyStateErrorRejectsDownloadedButNotCurrentItems() {
-        let error = CoordinatedReplaceWriter.replaceReadyStateError(
-            hasConflicts: false,
+    func testCopyDestinationReadyStateErrorRejectsDownloadedButNotCurrentItems() {
+        let error = CoordinatedReplaceWriter.copyDestinationReadyStateError(
             isUbiquitousItem: true,
-            downloadStatus: URLUbiquitousItemDownloadingStatus.downloaded,
-            isDownloading: false
+            downloadStatus: .downloaded
         ) as NSError?
 
         XCTAssertEqual(error?.domain, "ICloudStoragePlusErrorDomain")
@@ -277,6 +260,47 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         ) { _ in }
 
         XCTAssertEqual(events, ["replaceItem", "cleanupConflicts"])
+    }
+
+    func testOverwriteExistingItemMapsCleanupFailureToConflictError() {
+        let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
+        let replacementDirectory = URL(fileURLWithPath: "/tmp/replacement")
+        let underlyingError = NSError(domain: NSCocoaErrorDomain, code: 512)
+        var cleanedURL: URL?
+
+        let writer = CoordinatedReplaceWriter(
+            fileExists: { _ in true },
+            verifyDestination: { _ in },
+            createReplacementDirectory: { _ in replacementDirectory },
+            coordinateReplace: { url, accessor in try accessor(url) },
+            cleanupConflicts: { _ in throw underlyingError },
+            replaceItem: { _, _ in },
+            removeItem: { cleanedURL = $0 }
+        )
+
+        XCTAssertThrowsError(
+            try writer.overwriteExistingItem(at: destinationURL) { _ in }
+        ) { error in
+            let nsError = error as NSError
+            XCTAssertEqual(
+                nsError.domain,
+                CoordinatedReplaceWriter.replaceStateErrorDomain
+            )
+            XCTAssertEqual(
+                nsError.code,
+                CoordinatedReplaceWriter.conflictReplaceStateCode
+            )
+            XCTAssertEqual(
+                nsError.localizedDescription,
+                "Cannot replace an iCloud item: auto-resolution failed."
+            )
+            XCTAssertEqual(
+                (nsError.userInfo[NSUnderlyingErrorKey] as? NSError)?.code,
+                underlyingError.code
+            )
+        }
+
+        XCTAssertEqual(cleanedURL, replacementDirectory)
     }
 
     private func makeTemporaryDirectory() throws -> URL {

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -3,60 +3,43 @@ import XCTest
 @testable import icloud_storage_plus_foundation
 
 final class CoordinatedReplaceWriterTests: XCTestCase {
-    func testHelperSourceMatchesProductionSource() throws {
-        let helperSource = try String(
-            contentsOfFile: #filePath
-                .replacingOccurrences(
-                    of: "/Tests/icloud_storage_plus_foundationTests/"
-                        + "CoordinatedReplaceWriterTests.swift",
-                    with: "/CoordinatedReplaceWriter.swift"
-                ),
-            encoding: .utf8
-        )
-        let productionSource = try String(
-            contentsOfFile: #filePath
-                .replacingOccurrences(
-                    of: "/Sources/icloud_storage_plus_foundation/Tests/"
-                        + "icloud_storage_plus_foundationTests/"
-                        + "CoordinatedReplaceWriterTests.swift",
-                    with: "/Sources/icloud_storage_plus/"
-                        + "CoordinatedReplaceWriter.swift"
-                ),
-            encoding: .utf8
+    func testReplaceReadyStateErrorAllowsCurrentItemsWithoutConflicts() {
+        let error = CoordinatedReplaceWriter.replaceReadyStateError(
+            hasConflicts: false,
+            isUbiquitousItem: true,
+            downloadStatus: .current,
+            isDownloading: false
         )
 
-        XCTAssertEqual(helperSource, productionSource)
+        XCTAssertNil(error)
     }
 
-    func testHelperSourceDoesNotExposeCopyOverwriteEntryPoint() throws {
-        let helperSource = try String(
-            contentsOfFile: #filePath
-                .replacingOccurrences(
-                    of: "/Tests/icloud_storage_plus_foundationTests/"
-                        + "CoordinatedReplaceWriterTests.swift",
-                    with: "/CoordinatedReplaceWriter.swift"
-                ),
-            encoding: .utf8
+    func testReplaceReadyStateErrorAllowsConflictedCurrentItemsToProceed() {
+        let error = CoordinatedReplaceWriter.replaceReadyStateError(
+            hasConflicts: true,
+            isUbiquitousItem: true,
+            downloadStatus: .current,
+            isDownloading: false
         )
 
-        XCTAssertFalse(helperSource.contains("copyItemOverwritingExistingItem"))
+        XCTAssertNil(error)
     }
 
-    func testHelperSourceDoesNotKeepRedundantNonCurrentGuard() throws {
-        let helperSource = try String(
-            contentsOfFile: #filePath
-                .replacingOccurrences(
-                    of: "/Tests/icloud_storage_plus_foundationTests/"
-                        + "CoordinatedReplaceWriterTests.swift",
-                    with: "/CoordinatedReplaceWriter.swift"
-                ),
-            encoding: .utf8
-        )
+    func testReplaceReadyStateErrorTreatsDownloadingItemsAsNotDownloaded() {
+        let error = CoordinatedReplaceWriter.replaceReadyStateError(
+            hasConflicts: false,
+            isUbiquitousItem: true,
+            downloadStatus: .downloaded,
+            isDownloading: true
+        ) as NSError?
 
-        XCTAssertFalse(
-            helperSource.contains("if downloadStatus != .current"),
-            "replaceReadyStateError should not keep a non-current guard after "
-                + "the earlier .current return."
+        XCTAssertEqual(
+            error?.code,
+            CoordinatedReplaceWriter.itemNotDownloadedReplaceStateCode
+        )
+        XCTAssertEqual(
+            error?.localizedDescription,
+            "Cannot replace a nonlocal iCloud item until it is fully downloaded."
         )
     }
 
@@ -149,49 +132,6 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         }
     }
 
-    func testOverwriteExistingItemThrowsWhenDestinationHasUnresolvedConflicts() {
-        let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
-        var preparedReplacement = false
-
-        let writer = CoordinatedReplaceWriter(
-            fileExists: { _ in true },
-            verifyDestination: { _ in
-                throw NSError(
-                    domain: "ICloudStoragePlusErrorDomain",
-                    code: 1,
-                    userInfo: [
-                        NSLocalizedDescriptionKey:
-                            "Cannot replace an iCloud item with unresolved conflict versions.",
-                    ]
-                )
-            },
-            createReplacementDirectory: { _ in
-                XCTFail("should not create replacement directory")
-                return URL(fileURLWithPath: "/tmp/replacement")
-            },
-            coordinateReplace: { _, _ in
-                XCTFail("should not coordinate replace")
-            },
-            replaceItem: { _, _ in
-                XCTFail("should not replace item")
-            },
-            removeItem: { _ in }
-        )
-
-        XCTAssertThrowsError(
-            try writer.overwriteExistingItem(at: destinationURL) { _ in
-                preparedReplacement = true
-            }
-        ) { error in
-            XCTAssertEqual(
-                error.localizedDescription,
-                "Cannot replace an iCloud item with unresolved conflict versions."
-            )
-        }
-
-        XCTAssertFalse(preparedReplacement)
-    }
-
     func testOverwriteExistingItemThrowsWhenDestinationIsNotFullyLocal() {
         let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
         var preparedReplacement = false
@@ -233,22 +173,6 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         }
 
         XCTAssertFalse(preparedReplacement)
-    }
-
-    func testReplaceReadyStateErrorReturnsDistinctDownloadInProgressCode() {
-        let error = CoordinatedReplaceWriter.replaceReadyStateError(
-            hasConflicts: false,
-            isUbiquitousItem: true,
-            downloadStatus: URLUbiquitousItemDownloadingStatus.downloaded,
-            isDownloading: true
-        ) as NSError?
-
-        XCTAssertEqual(error?.domain, "ICloudStoragePlusErrorDomain")
-        XCTAssertEqual(error?.code, 3)
-        XCTAssertEqual(
-            error?.localizedDescription,
-            "Cannot replace an iCloud item while it is downloading."
-        )
     }
 
     func testReplaceReadyStateErrorRejectsDownloadedButNotCurrentItems() {

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -110,6 +110,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             coordinateReplace: { _, _ in
                 XCTFail("should not coordinate replace")
             },
+            cleanupConflicts: { _ in },
             replaceItem: { _, _ in
                 XCTFail("should not replace item")
             },
@@ -153,6 +154,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             coordinateReplace: { _, _ in
                 XCTFail("should not coordinate replace")
             },
+            cleanupConflicts: { _ in },
             replaceItem: { _, _ in
                 XCTFail("should not replace item")
             },
@@ -205,6 +207,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             coordinateReplace: { _, _ in
                 XCTFail("should not coordinate replace")
             },
+            cleanupConflicts: { _ in },
             replaceItem: { _, _ in
                 XCTFail("should not replace item")
             },
@@ -233,6 +236,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             verifyDestination: { _ in },
             createReplacementDirectory: { _ in replacementDirectory },
             coordinateReplace: { url, accessor in try accessor(url) },
+            cleanupConflicts: { _ in },
             replaceItem: { _, _ in throw expectedError },
             removeItem: { cleanedURL = $0 }
         )
@@ -249,6 +253,30 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         }
 
         XCTAssertNotNil(cleanedURL)
+    }
+
+    func testOverwriteExistingItemReplacesBeforeConflictCleanup() throws {
+        var events: [String] = []
+
+        let writer = CoordinatedReplaceWriter(
+            fileExists: { _ in true },
+            verifyDestination: { _ in },
+            createReplacementDirectory: { _ in
+                URL(fileURLWithPath: "/tmp/replacement")
+            },
+            coordinateReplace: { _, accessor in
+                try accessor(URL(fileURLWithPath: "/tmp/file.json"))
+            },
+            cleanupConflicts: { _ in events.append("cleanupConflicts") },
+            replaceItem: { _, _ in events.append("replaceItem") },
+            removeItem: { _ in }
+        )
+
+        _ = try writer.overwriteExistingItem(
+            at: URL(fileURLWithPath: "/tmp/file.json")
+        ) { _ in }
+
+        XCTAssertEqual(events, ["replaceItem", "cleanupConflicts"])
     }
 
     private func makeTemporaryDirectory() throws -> URL {

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -14,33 +14,35 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         XCTAssertNil(error)
     }
 
-    func testReplaceReadyStateErrorAllowsConflictedCurrentItemsToProceed() {
-        let error = CoordinatedReplaceWriter.replaceReadyStateError(
-            hasConflicts: true,
-            isUbiquitousItem: true,
-            downloadStatus: .current,
-            isDownloading: false
+    func testHelperSourceCleansUpConflictsAfterReplacementWrite() throws {
+        let helperSource = try String(
+            contentsOfFile: #filePath
+                .replacingOccurrences(
+                    of: "/Tests/icloud_storage_plus_foundationTests/"
+                        + "CoordinatedReplaceWriterTests.swift",
+                    with: "/CoordinatedReplaceWriter.swift"
+                ),
+            encoding: .utf8
         )
 
-        XCTAssertNil(error)
-    }
+        let replaceSnippet = "try replaceItem(coordinatedURL, replacementURL)"
+        let cleanupSnippet = "try cleanupConflicts(coordinatedURL)"
 
-    func testReplaceReadyStateErrorTreatsDownloadingItemsAsNotDownloaded() {
-        let error = CoordinatedReplaceWriter.replaceReadyStateError(
-            hasConflicts: false,
-            isUbiquitousItem: true,
-            downloadStatus: .downloaded,
-            isDownloading: true
-        ) as NSError?
+        let replaceRange = helperSource.range(of: replaceSnippet)
+        let cleanupRange = helperSource.range(of: cleanupSnippet)
 
-        XCTAssertEqual(
-            error?.code,
-            CoordinatedReplaceWriter.itemNotDownloadedReplaceStateCode
+        XCTAssertNotNil(replaceRange)
+        XCTAssertNotNil(
+            cleanupRange,
+            "overwrite path should clean up conflicts after replacement write"
         )
-        XCTAssertEqual(
-            error?.localizedDescription,
-            "Cannot replace a nonlocal iCloud item until it is fully downloaded."
-        )
+
+        if let replaceRange, let cleanupRange {
+            XCTAssertLessThan(
+                replaceRange.lowerBound.utf16Offset(in: helperSource),
+                cleanupRange.lowerBound.utf16Offset(in: helperSource)
+            )
+        }
     }
 
     func testIOSCopyPropagatesSourceReadCoordinationErrors() throws {
@@ -132,6 +134,49 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         }
     }
 
+    func testOverwriteExistingItemThrowsWhenDestinationHasUnresolvedConflicts() {
+        let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
+        var preparedReplacement = false
+
+        let writer = CoordinatedReplaceWriter(
+            fileExists: { _ in true },
+            verifyDestination: { _ in
+                throw NSError(
+                    domain: "ICloudStoragePlusErrorDomain",
+                    code: 1,
+                    userInfo: [
+                        NSLocalizedDescriptionKey:
+                            "Cannot replace an iCloud item with unresolved conflict versions.",
+                    ]
+                )
+            },
+            createReplacementDirectory: { _ in
+                XCTFail("should not create replacement directory")
+                return URL(fileURLWithPath: "/tmp/replacement")
+            },
+            coordinateReplace: { _, _ in
+                XCTFail("should not coordinate replace")
+            },
+            replaceItem: { _, _ in
+                XCTFail("should not replace item")
+            },
+            removeItem: { _ in }
+        )
+
+        XCTAssertThrowsError(
+            try writer.overwriteExistingItem(at: destinationURL) { _ in
+                preparedReplacement = true
+            }
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Cannot replace an iCloud item with unresolved conflict versions."
+            )
+        }
+
+        XCTAssertFalse(preparedReplacement)
+    }
+
     func testOverwriteExistingItemThrowsWhenDestinationIsNotFullyLocal() {
         let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
         var preparedReplacement = false
@@ -173,6 +218,22 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         }
 
         XCTAssertFalse(preparedReplacement)
+    }
+
+    func testReplaceReadyStateErrorReturnsDistinctDownloadInProgressCode() {
+        let error = CoordinatedReplaceWriter.replaceReadyStateError(
+            hasConflicts: false,
+            isUbiquitousItem: true,
+            downloadStatus: URLUbiquitousItemDownloadingStatus.downloaded,
+            isDownloading: true
+        ) as NSError?
+
+        XCTAssertEqual(error?.domain, "ICloudStoragePlusErrorDomain")
+        XCTAssertEqual(error?.code, 3)
+        XCTAssertEqual(
+            error?.localizedDescription,
+            "Cannot replace an iCloud item while it is downloading."
+        )
     }
 
     func testReplaceReadyStateErrorRejectsDownloadedButNotCurrentItems() {

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -216,6 +216,33 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         XCTAssertFalse(verifiedDestinationState)
     }
 
+    func testOverwriteExistingItemVerifiesDestinationAfterEnsuringDownload() async throws {
+        var downloadPrepared = false
+        var verifySawPreparedDownload = false
+
+        let writer = CoordinatedReplaceWriter(
+            fileExists: { _ in true },
+            ensureDownloaded: { _ in
+                downloadPrepared = true
+            },
+            verifyDestination: { _ in
+                verifySawPreparedDownload = downloadPrepared
+                XCTAssertTrue(downloadPrepared)
+            },
+            createReplacementDirectory: { _ in try self.makeTemporaryDirectory() },
+            coordinateReplace: { url, accessor in try accessor(url) },
+            cleanupConflicts: { _ in },
+            replaceItem: { _, _ in },
+            removeItem: { _ in }
+        )
+
+        _ = try await writer.overwriteExistingItem(
+            at: URL(fileURLWithPath: "/tmp/file.json")
+        ) { _ in }
+
+        XCTAssertTrue(verifySawPreparedDownload)
+    }
+
     func testOverwriteExistingItemCleansUpReplacementArtifactWhenReplaceFails() async {
         let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
         let replacementDirectory = URL(fileURLWithPath: "/tmp/replacement")
@@ -248,34 +275,32 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         XCTAssertNotNil(cleanedURL)
     }
 
-    func testOverwriteExistingItemCleanupSeesReplacementContent() async throws {
+    func testOverwriteExistingItemCleanupSeesUpdatedDestinationState() async throws {
         let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
-        let replacementDirectory = try makeTemporaryDirectory()
-        defer { try? FileManager.default.removeItem(at: replacementDirectory) }
         var destinationContents = "old"
         var cleanupSawContents: String?
+        let replacementContents = "new"
 
         let writer = CoordinatedReplaceWriter(
             fileExists: { _ in true },
             ensureDownloaded: { _ in },
             verifyDestination: { _ in },
-            createReplacementDirectory: { _ in replacementDirectory },
+            createReplacementDirectory: { _ in try self.makeTemporaryDirectory() },
             coordinateReplace: { url, accessor in try accessor(url) },
             cleanupConflicts: { _ in
                 cleanupSawContents = destinationContents
             },
-            replaceItem: { _, replacementURL in
-                destinationContents = try String(contentsOf: replacementURL)
+            replaceItem: { _, _ in
+                destinationContents = replacementContents
             },
             removeItem: { _ in }
         )
 
-        _ = try await writer.overwriteExistingItem(at: destinationURL) { url in
-            try "new".write(to: url, atomically: true, encoding: .utf8)
+        _ = try await writer.overwriteExistingItem(at: destinationURL) { _ in
         }
 
-        XCTAssertEqual(destinationContents, "new")
-        XCTAssertEqual(cleanupSawContents, "new")
+        XCTAssertEqual(destinationContents, replacementContents)
+        XCTAssertEqual(cleanupSawContents, replacementContents)
     }
 
     func testOverwriteExistingItemMapsCleanupFailureToConflictError() async {

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -14,35 +14,33 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         XCTAssertNil(error)
     }
 
-    func testHelperSourceCleansUpConflictsAfterReplacementWrite() throws {
-        let helperSource = try String(
-            contentsOfFile: #filePath
-                .replacingOccurrences(
-                    of: "/Tests/icloud_storage_plus_foundationTests/"
-                        + "CoordinatedReplaceWriterTests.swift",
-                    with: "/CoordinatedReplaceWriter.swift"
-                ),
-            encoding: .utf8
+    func testReplaceReadyStateErrorAllowsConflictedCurrentItemsToProceed() {
+        let error = CoordinatedReplaceWriter.replaceReadyStateError(
+            hasConflicts: true,
+            isUbiquitousItem: true,
+            downloadStatus: .current,
+            isDownloading: false
         )
 
-        let replaceSnippet = "try replaceItem(coordinatedURL, replacementURL)"
-        let cleanupSnippet = "try cleanupConflicts(coordinatedURL)"
+        XCTAssertNil(error)
+    }
 
-        let replaceRange = helperSource.range(of: replaceSnippet)
-        let cleanupRange = helperSource.range(of: cleanupSnippet)
+    func testReplaceReadyStateErrorTreatsDownloadingItemsAsNotDownloaded() {
+        let error = CoordinatedReplaceWriter.replaceReadyStateError(
+            hasConflicts: false,
+            isUbiquitousItem: true,
+            downloadStatus: .downloaded,
+            isDownloading: true
+        ) as NSError?
 
-        XCTAssertNotNil(replaceRange)
-        XCTAssertNotNil(
-            cleanupRange,
-            "overwrite path should clean up conflicts after replacement write"
+        XCTAssertEqual(
+            error?.code,
+            CoordinatedReplaceWriter.itemNotDownloadedReplaceStateCode
         )
-
-        if let replaceRange, let cleanupRange {
-            XCTAssertLessThan(
-                replaceRange.lowerBound.utf16Offset(in: helperSource),
-                cleanupRange.lowerBound.utf16Offset(in: helperSource)
-            )
-        }
+        XCTAssertEqual(
+            error?.localizedDescription,
+            "Cannot replace a nonlocal iCloud item until it is fully downloaded."
+        )
     }
 
     func testIOSCopyPropagatesSourceReadCoordinationErrors() throws {

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/WriteEntrypointPreflightTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/WriteEntrypointPreflightTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import XCTest
+@testable import icloud_storage_plus_foundation
+
+final class WriteEntrypointPreflightTests: XCTestCase {
+    func testLivePrepareRunsBlockingWorkOffMainThread() async throws {
+        let temporaryDirectory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let expectedDirectory = temporaryDirectory
+            .appendingPathComponent("nested", isDirectory: true)
+        let expectedFileURL = expectedDirectory.appendingPathComponent("file.txt")
+        let expectation = expectation(description: "preflight work ran")
+        expectation.expectedFulfillmentCount = 2
+        let lock = NSLock()
+        var observedMainThreadStates: [Bool] = []
+
+        let preflight = WriteEntrypointPreflight(
+            execute: WriteEntrypointPreflight.live.execute,
+            resolveContainerURL: { _ in
+                lock.lock()
+                observedMainThreadStates.append(Thread.isMainThread)
+                lock.unlock()
+                expectation.fulfill()
+                return temporaryDirectory
+            },
+            createDirectory: { directoryURL in
+                lock.lock()
+                observedMainThreadStates.append(Thread.isMainThread)
+                lock.unlock()
+                expectation.fulfill()
+                XCTAssertEqual(directoryURL.path, expectedDirectory.path)
+                try FileManager.default.createDirectory(
+                    at: directoryURL,
+                    withIntermediateDirectories: true
+                )
+            }
+        )
+
+        let fileURL = try await preflight.prepare(
+            containerId: "container",
+            relativePath: "nested/file.txt"
+        )
+
+        await fulfillment(of: [expectation], timeout: 1.0)
+        XCTAssertEqual(fileURL.path, expectedFileURL.path)
+        XCTAssertEqual(observedMainThreadStates, [false, false])
+    }
+
+    func testPrepareThrowsTypedContainerUnavailableError() async {
+        let preflight = WriteEntrypointPreflight(
+            execute: { work in try work() },
+            resolveContainerURL: { _ in nil },
+            createDirectory: { _ in XCTFail("should not create directory") }
+        )
+
+        do {
+            _ = try await preflight.prepare(
+                containerId: "missing",
+                relativePath: "nested/file.txt"
+            )
+            XCTFail("expected prepare to throw")
+        } catch {
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.domain, WriteEntrypointPreflight.errorDomain)
+            XCTAssertEqual(
+                nsError.code,
+                WriteEntrypointPreflight.containerUnavailableErrorCode
+            )
+        }
+    }
+
+    func testItemURLWithoutParentDirectoryCreationSkipsCreateDirectory() async throws {
+        let temporaryDirectory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        var createDirectoryCalled = false
+        let preflight = WriteEntrypointPreflight(
+            execute: { work in try work() },
+            resolveContainerURL: { _ in temporaryDirectory },
+            createDirectory: { _ in createDirectoryCalled = true }
+        )
+
+        let fileURL = try await preflight.itemURL(
+            containerId: "container",
+            relativePath: "nested/file.txt",
+            createParentDirectory: false
+        )
+
+        XCTAssertEqual(
+            fileURL.path,
+            temporaryDirectory
+                .appendingPathComponent("nested/file.txt")
+                .path
+        )
+        XCTAssertFalse(createDirectoryCalled)
+    }
+
+    func testContainerURLRunsOffMainThread() async throws {
+        let temporaryDirectory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let expectation = expectation(description: "container lookup ran")
+        var observedMainThreadState: Bool?
+        let preflight = WriteEntrypointPreflight(
+            execute: WriteEntrypointPreflight.live.execute,
+            resolveContainerURL: { _ in
+                observedMainThreadState = Thread.isMainThread
+                expectation.fulfill()
+                return temporaryDirectory
+            },
+            createDirectory: { _ in XCTFail("should not create directory") }
+        )
+
+        let containerURL = try await preflight.containerURL(containerId: "container")
+
+        await fulfillment(of: [expectation], timeout: 1.0)
+        XCTAssertEqual(containerURL.path, temporaryDirectory.path)
+        XCTAssertEqual(observedMainThreadState, false)
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: temporaryDirectory,
+            withIntermediateDirectories: true
+        )
+        return temporaryDirectory
+    }
+}

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/WriteEntrypointPreflight.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/WriteEntrypointPreflight.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+@available(macOS 10.15, iOS 13.0, *)
+struct WriteEntrypointPreflight {
+    typealias Execute = (@escaping @Sendable () throws -> URL) async throws -> URL
+    typealias ResolveContainerURL = (String) -> URL?
+    typealias CreateDirectory = (URL) throws -> Void
+
+    let execute: Execute
+    let resolveContainerURL: ResolveContainerURL
+    let createDirectory: CreateDirectory
+
+    func containerURL(containerId: String) async throws -> URL {
+        try await execute {
+            guard let containerURL = resolveContainerURL(containerId) else {
+                throw Self.containerUnavailableError()
+            }
+
+            return containerURL
+        }
+    }
+
+    func itemURL(
+        containerId: String,
+        relativePath: String,
+        createParentDirectory: Bool
+    ) async throws -> URL {
+        let containerURL = try await containerURL(containerId: containerId)
+        let fileURL = containerURL.appendingPathComponent(relativePath)
+
+        if createParentDirectory {
+            try createDirectory(fileURL.deletingLastPathComponent())
+        }
+
+        return fileURL
+    }
+
+    func prepare(
+        containerId: String,
+        relativePath: String
+    ) async throws -> URL {
+        try await execute {
+            guard let containerURL = resolveContainerURL(containerId) else {
+                throw Self.containerUnavailableError()
+            }
+
+            let fileURL = containerURL.appendingPathComponent(relativePath)
+            try createDirectory(fileURL.deletingLastPathComponent())
+            return fileURL
+        }
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, *)
+extension WriteEntrypointPreflight {
+    static let errorDomain = "ICloudStoragePlusWriteEntrypointPreflight"
+    static let containerUnavailableErrorCode = 1
+
+    static func containerUnavailableError() -> NSError {
+        NSError(
+            domain: errorDomain,
+            code: containerUnavailableErrorCode,
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "Unable to access the requested iCloud container.",
+            ]
+        )
+    }
+
+    static func isContainerUnavailableError(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        return nsError.domain == errorDomain
+            && nsError.code == containerUnavailableErrorCode
+    }
+
+    static let live = WriteEntrypointPreflight(
+        execute: { work in
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<URL, Error>) in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    do {
+                        continuation.resume(returning: try work())
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
+        },
+        resolveContainerURL: {
+            FileManager.default.url(forUbiquityContainerIdentifier: $0)
+        },
+        createDirectory: { directoryURL in
+            try FileManager.default.createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+        }
+    )
+}

--- a/lib/models/exceptions.dart
+++ b/lib/models/exceptions.dart
@@ -236,6 +236,23 @@ class ICloudCoordinationException extends ICloudOperationException {
         );
 }
 
+/// Thrown when native code reports invalid write-path arguments.
+class ICloudInvalidArgumentException extends ICloudOperationException {
+  /// Creates an invalid-argument exception.
+  ICloudInvalidArgumentException._(_ICloudOperationExceptionData data)
+      : super(
+          category: data.category,
+          operation: data.operation,
+          retryable: data.retryable,
+          message: data.message,
+          relativePath: data.relativePath,
+          nativeDomain: data.nativeDomain,
+          nativeCode: data.nativeCode,
+          nativeDescription: data.nativeDescription,
+          underlying: data.underlying,
+        );
+}
+
 /// Thrown when native code reports an unknown structured failure.
 class ICloudUnknownNativeException extends ICloudOperationException {
   /// Creates an unknown native exception.
@@ -277,6 +294,7 @@ ICloudOperationException mapICloudPlatformException(PlatformException error) {
     'downloadInProgress' => ICloudDownloadInProgressException._(data),
     'timeout' => ICloudTimeoutException._(data),
     'coordination' => ICloudCoordinationException._(data),
+    'invalidArgument' => ICloudInvalidArgumentException._(data),
     _ => ICloudUnknownNativeException._(data),
   };
 }

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus/WriteEntrypointPreflight.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus/WriteEntrypointPreflight.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+@available(macOS 10.15, iOS 13.0, *)
+struct WriteEntrypointPreflight {
+  typealias Execute = (@escaping @Sendable () throws -> URL) async throws -> URL
+  typealias ResolveContainerURL = (String) -> URL?
+  typealias CreateDirectory = (URL) throws -> Void
+
+  let execute: Execute
+  let resolveContainerURL: ResolveContainerURL
+  let createDirectory: CreateDirectory
+
+  func containerURL(containerId: String) async throws -> URL {
+    try await execute {
+      guard let containerURL = resolveContainerURL(containerId) else {
+        throw Self.containerUnavailableError()
+      }
+
+      return containerURL
+    }
+  }
+
+  func itemURL(
+    containerId: String,
+    relativePath: String,
+    createParentDirectory: Bool
+  ) async throws -> URL {
+    let containerURL = try await containerURL(containerId: containerId)
+    let fileURL = containerURL.appendingPathComponent(relativePath)
+
+    if createParentDirectory {
+      try createDirectory(fileURL.deletingLastPathComponent())
+    }
+
+    return fileURL
+  }
+
+  func prepare(
+    containerId: String,
+    relativePath: String
+  ) async throws -> URL {
+    try await execute {
+      guard let containerURL = resolveContainerURL(containerId) else {
+        throw Self.containerUnavailableError()
+      }
+
+      let fileURL = containerURL.appendingPathComponent(relativePath)
+      try createDirectory(fileURL.deletingLastPathComponent())
+      return fileURL
+    }
+  }
+}
+
+@available(macOS 10.15, iOS 13.0, *)
+extension WriteEntrypointPreflight {
+  static let errorDomain = "ICloudStoragePlusWriteEntrypointPreflight"
+  static let containerUnavailableErrorCode = 1
+
+  static func containerUnavailableError() -> NSError {
+    NSError(
+      domain: errorDomain,
+      code: containerUnavailableErrorCode,
+      userInfo: [
+        NSLocalizedDescriptionKey:
+          "Unable to access the requested iCloud container.",
+      ]
+    )
+  }
+
+  static func isContainerUnavailableError(_ error: Error) -> Bool {
+    let nsError = error as NSError
+    return nsError.domain == errorDomain
+      && nsError.code == containerUnavailableErrorCode
+  }
+
+  static let live = WriteEntrypointPreflight(
+    execute: { work in
+      try await withCheckedThrowingContinuation {
+        (continuation: CheckedContinuation<URL, Error>) in
+        DispatchQueue.global(qos: .userInitiated).async {
+          do {
+            continuation.resume(returning: try work())
+          } catch {
+            continuation.resume(throwing: error)
+          }
+        }
+      }
+    },
+    resolveContainerURL: {
+      FileManager.default.url(forUbiquityContainerIdentifier: $0)
+    },
+    createDirectory: { directoryURL in
+      try FileManager.default.createDirectory(
+        at: directoryURL,
+        withIntermediateDirectories: true,
+        attributes: nil
+      )
+    }
+  )
+}

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
@@ -689,10 +689,16 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
+    let writer = makeWriteEntrypointWriter()
+
     Task { [self] in
       do {
-        try await ensureWriteDestinationDownloaded(fileURL)
-        try await writeInPlaceDocument(at: fileURL, contents: contents)
+        let handled = try await writer.overwriteExistingItem(at: fileURL) {
+          try writeTextToURL(contents, to: $0)
+        }
+        if !handled {
+          try await createWriteInPlaceDocument(at: fileURL, contents: contents)
+        }
         result(nil)
       } catch {
         let mapped = mapFileNotFoundError(
@@ -837,10 +843,19 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
+    let writer = makeWriteEntrypointWriter()
+
     Task { [self] in
       do {
-        try await ensureWriteDestinationDownloaded(fileURL)
-        try await writeInPlaceBinaryDocument(at: fileURL, contents: contents.data)
+        let handled = try await writer.overwriteExistingItem(at: fileURL) {
+          try writeDataToURL(contents.data, to: $0)
+        }
+        if !handled {
+          try await createWriteInPlaceBinaryDocument(
+            at: fileURL,
+            contents: contents.data
+          )
+        }
         result(nil)
       } catch {
         let mapped = mapFileNotFoundError(
@@ -1034,40 +1049,51 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     }
   }
 
-  private func ensureWriteDestinationDownloaded(_ fileURL: URL) async throws {
-    guard FileManager.default.fileExists(atPath: fileURL.path) else {
-      return
-    }
-
-    let values = try fileURL.resourceValues(
-      forKeys: [
-        .isUbiquitousItemKey,
-        .ubiquitousItemDownloadingStatusKey,
-        .ubiquitousItemDownloadingErrorKey,
-      ]
+  private func makeWriteEntrypointWriter() -> WriteEntrypointWriter {
+    let live = CoordinatedReplaceWriter.live
+    let writer = CoordinatedReplaceWriter(
+      fileExists: live.fileExists,
+      verifyDestination: live.verifyDestination,
+      createReplacementDirectory: live.createReplacementDirectory,
+      coordinateReplace: live.coordinateReplace,
+      replaceItem: live.replaceItem,
+      removeItem: live.removeItem
     )
 
-    guard values.isUbiquitousItem == true else {
-      return
-    }
+    return WriteEntrypointWriter(
+      writer: writer,
+      ensureDownloaded: { [self] fileURL in
+        let values = try fileURL.resourceValues(
+          forKeys: [
+            .isUbiquitousItemKey,
+            .ubiquitousItemDownloadingStatusKey,
+            .ubiquitousItemDownloadingErrorKey,
+          ]
+        )
 
-    if let downloadError = values.ubiquitousItemDownloadingError {
-      throw downloadError
-    }
+        guard values.isUbiquitousItem == true else {
+          return
+        }
 
-    guard values.ubiquitousItemDownloadingStatus != .current else {
-      return
-    }
+        if let downloadError = values.ubiquitousItemDownloadingError {
+          throw downloadError
+        }
 
-    try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
-    try await waitForDownloadCompletion(
-      at: fileURL,
-      idleTimeouts: [10.0, 20.0],
-      retryBackoff: [2.0]
+        guard values.ubiquitousItemDownloadingStatus != .current else {
+          return
+        }
+
+        try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
+        try await waitForDownloadCompletion(
+          at: fileURL,
+          idleTimeouts: [10.0, 20.0],
+          retryBackoff: [2.0]
+        )
+      }
     )
   }
 
-  private func writeInPlaceDocument(
+  private func createWriteInPlaceDocument(
     at fileURL: URL,
     contents: String
   ) async throws {
@@ -1082,7 +1108,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     }
   }
 
-  private func writeInPlaceBinaryDocument(
+  private func createWriteInPlaceBinaryDocument(
     at fileURL: URL,
     contents: Data
   ) async throws {
@@ -2023,6 +2049,26 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       operation: operation,
       relativePath: relativePath,
       nativeError: nsError
+    )
+  }
+}
+
+private struct WriteEntrypointWriter {
+  let writer: CoordinatedReplaceWriter
+  let ensureDownloaded: (URL) async throws -> Void
+
+  func overwriteExistingItem(
+    at destinationURL: URL,
+    prepareReplacementFile: (URL) throws -> Void
+  ) async throws -> Bool {
+    guard writer.fileExists(destinationURL.path) else {
+      return false
+    }
+
+    try await ensureDownloaded(destinationURL)
+    return try writer.overwriteExistingItem(
+      at: destinationURL,
+      prepareReplacementFile: prepareReplacementFile
     )
   }
 }

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
@@ -689,8 +689,12 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
-    writeInPlaceDocument(at: fileURL, contents: contents) { [self] error in
-      if let error = error {
+    Task { [self] in
+      do {
+        try await ensureWriteDestinationDownloaded(fileURL)
+        try await writeInPlaceDocument(at: fileURL, contents: contents)
+        result(nil)
+      } catch {
         let mapped = mapFileNotFoundError(
           error,
           operation: "writeInPlace",
@@ -701,9 +705,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           relativePath: relativePath
         )
         result(mapped)
-        return
       }
-      result(nil)
     }
   }
 
@@ -835,8 +837,12 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
-    writeInPlaceBinaryDocument(at: fileURL, contents: contents.data) { [self] error in
-      if let error = error {
+    Task { [self] in
+      do {
+        try await ensureWriteDestinationDownloaded(fileURL)
+        try await writeInPlaceBinaryDocument(at: fileURL, contents: contents.data)
+        result(nil)
+      } catch {
         let mapped = mapFileNotFoundError(
           error,
           operation: "writeInPlaceBytes",
@@ -847,9 +853,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           relativePath: relativePath
         )
         result(mapped)
-        return
       }
-      result(nil)
     }
   }
   
@@ -1008,6 +1012,89 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     }
 
     startAttempt(index: 0)
+  }
+
+  private func waitForDownloadCompletion(
+    at fileURL: URL,
+    idleTimeouts: [TimeInterval],
+    retryBackoff: [TimeInterval]
+  ) async throws {
+    try await withCheckedThrowingContinuation { continuation in
+      waitForDownloadCompletion(
+        fileURL: fileURL,
+        idleTimeouts: idleTimeouts,
+        retryBackoff: retryBackoff
+      ) { error in
+        if let error {
+          continuation.resume(throwing: error)
+          return
+        }
+        continuation.resume(returning: ())
+      }
+    }
+  }
+
+  private func ensureWriteDestinationDownloaded(_ fileURL: URL) async throws {
+    guard FileManager.default.fileExists(atPath: fileURL.path) else {
+      return
+    }
+
+    let values = try fileURL.resourceValues(
+      forKeys: [
+        .isUbiquitousItemKey,
+        .ubiquitousItemDownloadingStatusKey,
+        .ubiquitousItemDownloadingErrorKey,
+      ]
+    )
+
+    guard values.isUbiquitousItem == true else {
+      return
+    }
+
+    if let downloadError = values.ubiquitousItemDownloadingError {
+      throw downloadError
+    }
+
+    guard values.ubiquitousItemDownloadingStatus != .current else {
+      return
+    }
+
+    try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
+    try await waitForDownloadCompletion(
+      at: fileURL,
+      idleTimeouts: [10.0, 20.0],
+      retryBackoff: [2.0]
+    )
+  }
+
+  private func writeInPlaceDocument(
+    at fileURL: URL,
+    contents: String
+  ) async throws {
+    try await withCheckedThrowingContinuation { continuation in
+      writeInPlaceDocument(at: fileURL, contents: contents) { error in
+        if let error {
+          continuation.resume(throwing: error)
+          return
+        }
+        continuation.resume(returning: ())
+      }
+    }
+  }
+
+  private func writeInPlaceBinaryDocument(
+    at fileURL: URL,
+    contents: Data
+  ) async throws {
+    try await withCheckedThrowingContinuation { continuation in
+      writeInPlaceBinaryDocument(at: fileURL, contents: contents) { error in
+        if let error {
+          continuation.resume(throwing: error)
+          return
+        }
+        continuation.resume(returning: ())
+      }
+    }
   }
 
   /// Checks if the file is fully downloaded and available for access.

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
@@ -89,12 +89,18 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
     
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(operation: "getContainerPath"))
-      return
+    let preflight = WriteEntrypointPreflight.live
+
+    Task {
+      do {
+        let containerURL = try await preflight.containerURL(
+          containerId: containerId
+        )
+        result(containerURL.path)
+      } catch {
+        result(containerAccessError(operation: "getContainerPath"))
+      }
     }
-    result(containerURL.path)
   }
   
   /// Lists all items in the container using NSMetadataQuery.
@@ -580,57 +586,19 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     let retryBackoff = (args["retryBackoffSeconds"] as? [NSNumber])?
       .map { $0.doubleValue } ?? []
 
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(
-        operation: "readInPlace",
-        relativePath: relativePath
-      ))
-      return
-    }
+    let preflight = WriteEntrypointPreflight.live
 
-    let fileURL = containerURL.appendingPathComponent(relativePath)
+    Task { [self] in
+      do {
+        let fileURL = try await preflight.itemURL(
+          containerId: containerId,
+          relativePath: relativePath,
+          createParentDirectory: false
+        )
 
-    do {
-      try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
-    } catch {
-      let mapped = mapFileNotFoundError(
-        error,
-        operation: "readInPlace",
-        relativePath: relativePath
-      ) ?? nativeCodeError(
-        error,
-        operation: "readInPlace",
-        relativePath: relativePath
-      )
-      result(mapped)
-      return
-    }
-
-    waitForDownloadCompletion(
-      fileURL: fileURL,
-      idleTimeouts: idleTimeouts,
-      retryBackoff: retryBackoff
-    ) { [self] error in
-      if let error {
-        if let timeoutError = mapTimeoutError(
-          error,
-          operation: "readInPlace",
-          relativePath: relativePath
-        ) {
-          result(timeoutError)
-          return
-        }
-        result(nativeCodeError(
-          error,
-          operation: "readInPlace",
-          relativePath: relativePath
-        ))
-        return
-      }
-
-      readInPlaceDocument(at: fileURL) { [self] contents, error in
-        if let error = error {
+        do {
+          try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
+        } catch {
           let mapped = mapFileNotFoundError(
             error,
             operation: "readInPlace",
@@ -644,7 +612,60 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           return
         }
 
-        result(contents)
+        waitForDownloadCompletion(
+          fileURL: fileURL,
+          idleTimeouts: idleTimeouts,
+          retryBackoff: retryBackoff
+        ) { [self] error in
+          if let error {
+            if let timeoutError = mapTimeoutError(
+              error,
+              operation: "readInPlace",
+              relativePath: relativePath
+            ) {
+              result(timeoutError)
+              return
+            }
+            result(nativeCodeError(
+              error,
+              operation: "readInPlace",
+              relativePath: relativePath
+            ))
+            return
+          }
+
+          readInPlaceDocument(at: fileURL) { [self] contents, error in
+            if let error = error {
+              let mapped = mapFileNotFoundError(
+                error,
+                operation: "readInPlace",
+                relativePath: relativePath
+              ) ?? nativeCodeError(
+                error,
+                operation: "readInPlace",
+                relativePath: relativePath
+              )
+              result(mapped)
+              return
+            }
+
+            result(contents)
+          }
+        }
+      } catch {
+        if let mapped = mapWriteEntrypointPreflightError(
+          error,
+          operation: "readInPlace",
+          relativePath: relativePath
+        ) {
+          result(mapped)
+          return
+        }
+        result(nativeCodeError(
+          error,
+          operation: "readInPlace",
+          relativePath: relativePath
+        ))
       }
     }
   }
@@ -660,39 +681,15 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(
-        operation: "writeInPlace",
-        relativePath: relativePath
-      ))
-      return
-    }
-
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-
-    do {
-      let dirURL = fileURL.deletingLastPathComponent()
-      if !FileManager.default.fileExists(atPath: dirURL.path) {
-        try FileManager.default.createDirectory(
-          at: dirURL,
-          withIntermediateDirectories: true,
-          attributes: nil
-        )
-      }
-    } catch {
-      result(nativeCodeError(
-        error,
-        operation: "writeInPlace",
-        relativePath: relativePath
-      ))
-      return
-    }
-
     let writer = makeWriteEntrypointWriter()
+    let preflight = WriteEntrypointPreflight.live
 
     Task { [self] in
       do {
+        let fileURL = try await preflight.prepare(
+          containerId: containerId,
+          relativePath: relativePath
+        )
         let handled = try await writer.overwriteExistingItem(at: fileURL) {
           try writeTextToURL(contents, to: $0)
         }
@@ -701,7 +698,11 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
         }
         result(nil)
       } catch {
-        let mapped = mapFileNotFoundError(
+        let mapped = mapWriteEntrypointPreflightError(
+          error,
+          operation: "writeInPlace",
+          relativePath: relativePath
+        ) ?? mapFileNotFoundError(
           error,
           operation: "writeInPlace",
           relativePath: relativePath
@@ -730,57 +731,19 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     let retryBackoff = (args["retryBackoffSeconds"] as? [NSNumber])?
       .map { $0.doubleValue } ?? []
 
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(
-        operation: "readInPlaceBytes",
-        relativePath: relativePath
-      ))
-      return
-    }
+    let preflight = WriteEntrypointPreflight.live
 
-    let fileURL = containerURL.appendingPathComponent(relativePath)
+    Task { [self] in
+      do {
+        let fileURL = try await preflight.itemURL(
+          containerId: containerId,
+          relativePath: relativePath,
+          createParentDirectory: false
+        )
 
-    do {
-      try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
-    } catch {
-      let mapped = mapFileNotFoundError(
-        error,
-        operation: "readInPlaceBytes",
-        relativePath: relativePath
-      ) ?? nativeCodeError(
-        error,
-        operation: "readInPlaceBytes",
-        relativePath: relativePath
-      )
-      result(mapped)
-      return
-    }
-
-    waitForDownloadCompletion(
-      fileURL: fileURL,
-      idleTimeouts: idleTimeouts,
-      retryBackoff: retryBackoff
-    ) { [self] error in
-      if let error {
-        if let timeoutError = mapTimeoutError(
-          error,
-          operation: "readInPlaceBytes",
-          relativePath: relativePath
-        ) {
-          result(timeoutError)
-          return
-        }
-        result(nativeCodeError(
-          error,
-          operation: "readInPlaceBytes",
-          relativePath: relativePath
-        ))
-        return
-      }
-
-      readInPlaceBinaryDocument(at: fileURL) { [self] contents, error in
-        if let error = error {
+        do {
+          try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
+        } catch {
           let mapped = mapFileNotFoundError(
             error,
             operation: "readInPlaceBytes",
@@ -794,11 +757,64 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           return
         }
 
-        if let contents {
-          result(FlutterStandardTypedData(bytes: contents))
-        } else {
-          result(nil)
+        waitForDownloadCompletion(
+          fileURL: fileURL,
+          idleTimeouts: idleTimeouts,
+          retryBackoff: retryBackoff
+        ) { [self] error in
+          if let error {
+            if let timeoutError = mapTimeoutError(
+              error,
+              operation: "readInPlaceBytes",
+              relativePath: relativePath
+            ) {
+              result(timeoutError)
+              return
+            }
+            result(nativeCodeError(
+              error,
+              operation: "readInPlaceBytes",
+              relativePath: relativePath
+            ))
+            return
+          }
+
+          readInPlaceBinaryDocument(at: fileURL) { [self] contents, error in
+            if let error = error {
+              let mapped = mapFileNotFoundError(
+                error,
+                operation: "readInPlaceBytes",
+                relativePath: relativePath
+              ) ?? nativeCodeError(
+                error,
+                operation: "readInPlaceBytes",
+                relativePath: relativePath
+              )
+              result(mapped)
+              return
+            }
+
+            if let contents {
+              result(FlutterStandardTypedData(bytes: contents))
+            } else {
+              result(nil)
+            }
+          }
         }
+      } catch {
+        if let mapped = mapWriteEntrypointPreflightError(
+          error,
+          operation: "readInPlaceBytes",
+          relativePath: relativePath
+        ) {
+          result(mapped)
+          return
+        }
+        result(nativeCodeError(
+          error,
+          operation: "readInPlaceBytes",
+          relativePath: relativePath
+        ))
       }
     }
   }
@@ -814,39 +830,15 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(
-        operation: "writeInPlaceBytes",
-        relativePath: relativePath
-      ))
-      return
-    }
-
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-
-    do {
-      let dirURL = fileURL.deletingLastPathComponent()
-      if !FileManager.default.fileExists(atPath: dirURL.path) {
-        try FileManager.default.createDirectory(
-          at: dirURL,
-          withIntermediateDirectories: true,
-          attributes: nil
-        )
-      }
-    } catch {
-      result(nativeCodeError(
-        error,
-        operation: "writeInPlaceBytes",
-        relativePath: relativePath
-      ))
-      return
-    }
-
     let writer = makeWriteEntrypointWriter()
+    let preflight = WriteEntrypointPreflight.live
 
     Task { [self] in
       do {
+        let fileURL = try await preflight.prepare(
+          containerId: containerId,
+          relativePath: relativePath
+        )
         let handled = try await writer.overwriteExistingItem(at: fileURL) {
           try writeDataToURL(contents.data, to: $0)
         }
@@ -858,7 +850,11 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
         }
         result(nil)
       } catch {
-        let mapped = mapFileNotFoundError(
+        let mapped = mapWriteEntrypointPreflightError(
+          error,
+          operation: "writeInPlaceBytes",
+          relativePath: relativePath
+        ) ?? mapFileNotFoundError(
           error,
           operation: "writeInPlaceBytes",
           relativePath: relativePath
@@ -1034,7 +1030,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     idleTimeouts: [TimeInterval],
     retryBackoff: [TimeInterval]
   ) async throws {
-    try await withCheckedThrowingContinuation { continuation in
+    try await withCheckedThrowingContinuation {
+      (continuation: CheckedContinuation<Void, Error>) in
       waitForDownloadCompletion(
         fileURL: fileURL,
         idleTimeouts: idleTimeouts,
@@ -1097,7 +1094,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     at fileURL: URL,
     contents: String
   ) async throws {
-    try await withCheckedThrowingContinuation { continuation in
+    try await withCheckedThrowingContinuation {
+      (continuation: CheckedContinuation<Void, Error>) in
       writeInPlaceDocument(at: fileURL, contents: contents) { error in
         if let error {
           continuation.resume(throwing: error)
@@ -1112,7 +1110,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     at fileURL: URL,
     contents: Data
   ) async throws {
-    try await withCheckedThrowingContinuation { continuation in
+    try await withCheckedThrowingContinuation {
+      (continuation: CheckedContinuation<Void, Error>) in
       writeInPlaceBinaryDocument(at: fileURL, contents: contents) { error in
         if let error {
           continuation.resume(throwing: error)
@@ -1162,17 +1161,23 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
     
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(
-        operation: "documentExists",
-        relativePath: relativePath
-      ))
-      return
-    }
+    let preflight = WriteEntrypointPreflight.live
 
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-    result(FileManager.default.fileExists(atPath: fileURL.path))
+    Task {
+      do {
+        let fileURL = try await preflight.itemURL(
+          containerId: containerId,
+          relativePath: relativePath,
+          createParentDirectory: false
+        )
+        result(FileManager.default.fileExists(atPath: fileURL.path))
+      } catch {
+        result(containerAccessError(
+          operation: "documentExists",
+          relativePath: relativePath
+        ))
+      }
+    }
   }
 
   /// Get file or directory metadata without downloading content.
@@ -1186,44 +1191,48 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
     
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(
-        operation: "getDocumentMetadata",
-        relativePath: relativePath
-      ))
-      return
-    }
+    let preflight = WriteEntrypointPreflight.live
 
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-    guard FileManager.default.fileExists(atPath: fileURL.path) else {
-      result(nil)
-      return
-    }
+    Task {
+      do {
+        let containerURL = try await preflight.containerURL(containerId: containerId)
+        let fileURL = containerURL.appendingPathComponent(relativePath)
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+          result(nil)
+          return
+        }
 
-    do {
-      let values = try fileURL.resourceValues(forKeys: [
-        .isDirectoryKey,
-        .fileSizeKey,
-        .creationDateKey,
-        .contentModificationDateKey,
-        .ubiquitousItemDownloadingStatusKey,
-        .ubiquitousItemIsDownloadingKey,
-        .ubiquitousItemIsUploadedKey,
-        .ubiquitousItemIsUploadingKey,
-        .ubiquitousItemHasUnresolvedConflictsKey,
-      ])
-      result(mapResourceValues(
-        fileURL: fileURL,
-        values: values,
-        containerPath: containerURL.standardizedFileURL.path
-      ))
-    } catch {
-      result(nativeCodeError(
-        error,
-        operation: "getDocumentMetadata",
-        relativePath: relativePath
-      ))
+        let values = try fileURL.resourceValues(forKeys: [
+          .isDirectoryKey,
+          .fileSizeKey,
+          .creationDateKey,
+          .contentModificationDateKey,
+          .ubiquitousItemDownloadingStatusKey,
+          .ubiquitousItemIsDownloadingKey,
+          .ubiquitousItemIsUploadedKey,
+          .ubiquitousItemIsUploadingKey,
+          .ubiquitousItemHasUnresolvedConflictsKey,
+        ])
+        result(mapResourceValues(
+          fileURL: fileURL,
+          values: values,
+          containerPath: containerURL.standardizedFileURL.path
+        ))
+      } catch {
+        if let mapped = mapWriteEntrypointPreflightError(
+          error,
+          operation: "getDocumentMetadata",
+          relativePath: relativePath
+        ) {
+          result(mapped)
+          return
+        }
+        result(nativeCodeError(
+          error,
+          operation: "getDocumentMetadata",
+          relativePath: relativePath
+        ))
+      }
     }
   }
 
@@ -1241,50 +1250,53 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
-    guard let containerURL = FileManager.default.url(
-      forUbiquityContainerIdentifier: containerId
-    ) else {
-      result(containerAccessError(
-        operation: "getItemMetadata",
-        relativePath: relativePath
-      ))
-      return
-    }
+    let preflight = WriteEntrypointPreflight.live
 
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-    guard FileManager.default.fileExists(atPath: fileURL.path) else {
-      result(nil)
-      return
-    }
+    Task {
+      do {
+        let containerURL = try await preflight.containerURL(containerId: containerId)
+        let fileURL = containerURL.appendingPathComponent(relativePath)
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+          result(nil)
+          return
+        }
 
-    do {
-      let values = try fileURL.resourceValues(forKeys: [
-        .isDirectoryKey,
-        .fileSizeKey,
-        .creationDateKey,
-        .contentModificationDateKey,
-        .ubiquitousItemDownloadingStatusKey,
-        .ubiquitousItemIsDownloadingKey,
-        .ubiquitousItemIsUploadedKey,
-        .ubiquitousItemIsUploadingKey,
-        .ubiquitousItemHasUnresolvedConflictsKey,
-      ])
-      let containerPath = containerURL.standardizedFileURL.path
-      var metadata = mapResourceValues(
-        fileURL: fileURL,
-        values: values,
-        containerPath: containerPath
-      )
-      metadata["downloadStatus"] = normalizeDownloadStatus(
-        values.ubiquitousItemDownloadingStatus
-      ) ?? values.ubiquitousItemDownloadingStatus?.rawValue
-      result(metadata)
-    } catch {
-      result(nativeCodeError(
-        error,
-        operation: "getItemMetadata",
-        relativePath: relativePath
-      ))
+        let values = try fileURL.resourceValues(forKeys: [
+          .isDirectoryKey,
+          .fileSizeKey,
+          .creationDateKey,
+          .contentModificationDateKey,
+          .ubiquitousItemDownloadingStatusKey,
+          .ubiquitousItemIsDownloadingKey,
+          .ubiquitousItemIsUploadedKey,
+          .ubiquitousItemIsUploadingKey,
+          .ubiquitousItemHasUnresolvedConflictsKey,
+        ])
+        let containerPath = containerURL.standardizedFileURL.path
+        var metadata = mapResourceValues(
+          fileURL: fileURL,
+          values: values,
+          containerPath: containerPath
+        )
+        metadata["downloadStatus"] = normalizeDownloadStatus(
+          values.ubiquitousItemDownloadingStatus
+        ) ?? values.ubiquitousItemDownloadingStatus?.rawValue
+        result(metadata)
+      } catch {
+        if let mapped = mapWriteEntrypointPreflightError(
+          error,
+          operation: "getItemMetadata",
+          relativePath: relativePath
+        ) {
+          result(mapped)
+          return
+        }
+        result(nativeCodeError(
+          error,
+          operation: "getItemMetadata",
+          relativePath: relativePath
+        ))
+      }
     }
   }
   
@@ -1307,17 +1319,6 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
 
     let subdir = args["relativePath"] as? String
 
-    guard let containerURL = FileManager.default
-      .url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(operation: "listContents", relativePath: subdir))
-      return
-    }
-
-    let listURL = subdir != nil
-      ? containerURL.appendingPathComponent(subdir!)
-      : containerURL
-
     let keys: [URLResourceKey] = [
       .isDirectoryKey,
       .ubiquitousItemDownloadingStatusKey,
@@ -1327,8 +1328,15 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       .ubiquitousItemHasUnresolvedConflictsKey,
     ]
 
-    DispatchQueue.global(qos: .userInitiated).async {
+    let preflight = WriteEntrypointPreflight.live
+
+    Task {
       do {
+        let containerURL = try await preflight.containerURL(containerId: containerId)
+        let listURL = subdir != nil
+          ? containerURL.appendingPathComponent(subdir!)
+          : containerURL
+
         let contents = try FileManager.default.contentsOfDirectory(
           at: listURL,
           includingPropertiesForKeys: keys,
@@ -1380,8 +1388,16 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           ])
         }
 
-        DispatchQueue.main.async { result(items) }
+        result(items)
       } catch {
+        if let mapped = mapWriteEntrypointPreflightError(
+          error,
+          operation: "listContents",
+          relativePath: subdir
+        ) {
+          result(mapped)
+          return
+        }
         DispatchQueue.main.async {
           result(self.nativeCodeError(
             error,
@@ -1757,7 +1773,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     for token in tokens {
       NotificationCenter.default.removeObserver(token)
     }
-    queryObserversQueue.sync {
+    _ = queryObserversQueue.sync {
       queryObservers.removeValue(forKey: key)
     }
   }
@@ -1925,6 +1941,21 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     )
   }
 
+  private func mapWriteEntrypointPreflightError(
+    _ error: Error,
+    operation: String,
+    relativePath: String?
+  ) -> FlutterError? {
+    guard WriteEntrypointPreflight.isContainerUnavailableError(error) else {
+      return nil
+    }
+
+    return containerAccessError(
+      operation: operation,
+      relativePath: relativePath
+    )
+  }
+
   /// Maps file-not-found errors to specific Flutter error codes.
   private func mapFileNotFoundError(
     _ error: Error,
@@ -2073,7 +2104,7 @@ private struct WriteEntrypointWriter {
   }
 }
 
-private final class CompletionGate {
+private final class CompletionGate: @unchecked Sendable {
   private let queue = DispatchQueue(
     label: "icloud_storage_plus.completion_gate"
   )

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/ConflictResolver.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/ConflictResolver.swift
@@ -1,11 +1,16 @@
 import Foundation
 
+// Keep this mirrored with the iOS foundation package until the reset work
+// intentionally consolidates Darwin sources in a later task.
+
 func resolvePresentedItemConflictsSync(at url: URL) throws {
     guard let conflicts = NSFileVersion.unresolvedConflictVersionsOfItem(at: url),
           !conflicts.isEmpty else {
         return
     }
 
+    // Observer recovery restores the newest known file version so the
+    // presented item converges on the latest iCloud winner.
     let sorted = conflicts.sorted {
         ($0.modificationDate ?? .distantPast) >
             ($1.modificationDate ?? .distantPast)

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/ConflictResolver.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/ConflictResolver.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+func resolvePresentedItemConflictsSync(at url: URL) throws {
+    guard let conflicts = NSFileVersion.unresolvedConflictVersionsOfItem(at: url),
+          !conflicts.isEmpty else {
+        return
+    }
+
+    let sorted = conflicts.sorted {
+        ($0.modificationDate ?? .distantPast) >
+            ($1.modificationDate ?? .distantPast)
+    }
+
+    if let latest = sorted.first {
+        try latest.replaceItem(at: url, options: [])
+    }
+
+    for version in conflicts {
+        version.isResolved = true
+    }
+
+    try NSFileVersion.removeOtherVersionsOfItem(at: url)
+}
+
+func resolvePresentedItemConflicts(at url: URL) async throws {
+    try resolvePresentedItemConflictsSync(at: url)
+}
+
+func cleanupConflictsAfterOverwrite(at url: URL) throws {
+    guard let conflicts = NSFileVersion.unresolvedConflictVersionsOfItem(at: url),
+          !conflicts.isEmpty else {
+        return
+    }
+
+    for version in conflicts {
+        version.isResolved = true
+    }
+
+    try NSFileVersion.removeOtherVersionsOfItem(at: url)
+}

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
@@ -2,14 +2,16 @@ import Foundation
 
 struct CoordinatedReplaceWriter {
     typealias FileExists = (String) -> Bool
+    typealias EnsureDownloaded = (URL) async throws -> Void
     typealias VerifyDestination = (URL) throws -> Void
     typealias CreateReplacementDirectory = (URL) throws -> URL
-    typealias CoordinateReplace = (URL, (URL) throws -> Void) throws -> Void
+    typealias CoordinateReplace = (URL, (URL) throws -> Void) async throws -> Void
     typealias CleanupConflicts = (URL) throws -> Void
     typealias ReplaceItem = (URL, URL) throws -> Void
     typealias RemoveItem = (URL) throws -> Void
 
     let fileExists: FileExists
+    let ensureDownloaded: EnsureDownloaded
     let verifyDestination: VerifyDestination
     let createReplacementDirectory: CreateReplacementDirectory
     let coordinateReplace: CoordinateReplace
@@ -20,11 +22,12 @@ struct CoordinatedReplaceWriter {
     func overwriteExistingItem(
         at destinationURL: URL,
         prepareReplacementFile: (URL) throws -> Void
-    ) throws -> Bool {
+    ) async throws -> Bool {
         guard fileExists(destinationURL.path) else {
             return false
         }
 
+        try await ensureDownloaded(destinationURL)
         try verifyDestination(destinationURL)
 
         let replacementDirectory = try createReplacementDirectory(destinationURL)
@@ -35,7 +38,7 @@ struct CoordinatedReplaceWriter {
             try prepareReplacementFile(replacementURL)
             let cleanupConflicts = self.cleanupConflicts
             let replaceItem = self.replaceItem
-            try coordinateReplace(destinationURL) { coordinatedURL in
+            try await coordinateReplace(destinationURL) { coordinatedURL in
                 try replaceItem(coordinatedURL, replacementURL)
                 do {
                     try cleanupConflicts(coordinatedURL)
@@ -150,6 +153,7 @@ extension CoordinatedReplaceWriter {
 
     static let live = CoordinatedReplaceWriter(
         fileExists: { FileManager.default.fileExists(atPath: $0) },
+        ensureDownloaded: { _ in },
         verifyDestination: { destinationURL in
             let values = try destinationURL.resourceValues(forKeys: [.isDirectoryKey])
 

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
@@ -51,6 +51,7 @@ struct CoordinatedReplaceWriter {
 
 extension CoordinatedReplaceWriter {
     static let replaceStateErrorDomain = "ICloudStoragePlusErrorDomain"
+    static let conflictReplaceStateCode = 1
     static let itemNotDownloadedReplaceStateCode = 2
     static let directoryReplaceStateCode = 4
 
@@ -99,6 +100,24 @@ extension CoordinatedReplaceWriter {
     static func verifyExistingDestinationCanBeReplaced(
         at destinationURL: URL
     ) throws {
+        let hasConflicts = if let conflictVersions =
+            NSFileVersion.unresolvedConflictVersionsOfItem(at: destinationURL) {
+            !conflictVersions.isEmpty
+        } else {
+            false
+        }
+
+        if hasConflicts {
+            throw NSError(
+                domain: replaceStateErrorDomain,
+                code: conflictReplaceStateCode,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Cannot replace an iCloud item with unresolved conflict versions.",
+                ]
+            )
+        }
+
         let values = try destinationURL.resourceValues(forKeys: [
             .isUbiquitousItemKey,
             .ubiquitousItemDownloadingStatusKey,

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
@@ -62,6 +62,10 @@ extension CoordinatedReplaceWriter {
     static let itemNotDownloadedReplaceStateCode = 2
     static let directoryReplaceStateCode = 4
 
+    // Task 4 keeps foundation self-contained for tests. Task 5 replaces this
+    // placeholder at the plugin boundary with the real download/wait behavior.
+    static let foundationDefaultEnsureDownloaded: EnsureDownloaded = { _ in }
+
     static func cleanupConflictError(underlying: Error) -> NSError {
         NSError(
             domain: replaceStateErrorDomain,
@@ -153,7 +157,7 @@ extension CoordinatedReplaceWriter {
 
     static let live = CoordinatedReplaceWriter(
         fileExists: { FileManager.default.fileExists(atPath: $0) },
-        ensureDownloaded: { _ in },
+        ensureDownloaded: foundationDefaultEnsureDownloaded,
         verifyDestination: { destinationURL in
             let values = try destinationURL.resourceValues(forKeys: [.isDirectoryKey])
 

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
@@ -5,6 +5,7 @@ struct CoordinatedReplaceWriter {
     typealias VerifyDestination = (URL) throws -> Void
     typealias CreateReplacementDirectory = (URL) throws -> URL
     typealias CoordinateReplace = (URL, (URL) throws -> Void) throws -> Void
+    typealias CleanupConflicts = (URL) throws -> Void
     typealias ReplaceItem = (URL, URL) throws -> Void
     typealias RemoveItem = (URL) throws -> Void
 
@@ -12,6 +13,7 @@ struct CoordinatedReplaceWriter {
     let verifyDestination: VerifyDestination
     let createReplacementDirectory: CreateReplacementDirectory
     let coordinateReplace: CoordinateReplace
+    let cleanupConflicts: CleanupConflicts
     let replaceItem: ReplaceItem
     let removeItem: RemoveItem
 
@@ -31,8 +33,11 @@ struct CoordinatedReplaceWriter {
 
         do {
             try prepareReplacementFile(replacementURL)
+            let cleanupConflicts = self.cleanupConflicts
+            let replaceItem = self.replaceItem
             try coordinateReplace(destinationURL) { coordinatedURL in
                 try replaceItem(coordinatedURL, replacementURL)
+                try cleanupConflicts(coordinatedURL)
             }
         } catch {
             try? removeItem(replacementDirectory)
@@ -46,9 +51,7 @@ struct CoordinatedReplaceWriter {
 
 extension CoordinatedReplaceWriter {
     static let replaceStateErrorDomain = "ICloudStoragePlusErrorDomain"
-    static let conflictReplaceStateCode = 1
     static let itemNotDownloadedReplaceStateCode = 2
-    static let downloadInProgressReplaceStateCode = 3
     static let directoryReplaceStateCode = 4
 
     static func fileDestinationError(isDirectory: Bool) -> NSError? {
@@ -72,16 +75,8 @@ extension CoordinatedReplaceWriter {
         downloadStatus: URLUbiquitousItemDownloadingStatus?,
         isDownloading: Bool
     ) -> NSError? {
-        if hasConflicts {
-            return NSError(
-                domain: replaceStateErrorDomain,
-                code: conflictReplaceStateCode,
-                userInfo: [
-                    NSLocalizedDescriptionKey:
-                        "Cannot replace an iCloud item with unresolved conflict versions.",
-                ]
-            )
-        }
+        _ = hasConflicts
+        _ = isDownloading
 
         guard isUbiquitousItem else {
             return nil
@@ -89,17 +84,6 @@ extension CoordinatedReplaceWriter {
 
         if downloadStatus == .current {
             return nil
-        }
-
-        if isDownloading {
-            return NSError(
-                domain: replaceStateErrorDomain,
-                code: downloadInProgressReplaceStateCode,
-                userInfo: [
-                    NSLocalizedDescriptionKey:
-                        "Cannot replace an iCloud item while it is downloading.",
-                ]
-            )
         }
 
         return NSError(
@@ -115,13 +99,6 @@ extension CoordinatedReplaceWriter {
     static func verifyExistingDestinationCanBeReplaced(
         at destinationURL: URL
     ) throws {
-        let hasConflicts = if let conflictVersions =
-            NSFileVersion.unresolvedConflictVersionsOfItem(at: destinationURL) {
-            !conflictVersions.isEmpty
-        } else {
-            false
-        }
-
         let values = try destinationURL.resourceValues(forKeys: [
             .isUbiquitousItemKey,
             .ubiquitousItemDownloadingStatusKey,
@@ -134,7 +111,7 @@ extension CoordinatedReplaceWriter {
         }
 
         if let replaceStateError = replaceReadyStateError(
-            hasConflicts: hasConflicts,
+            hasConflicts: false,
             isUbiquitousItem: values.isUbiquitousItem == true,
             downloadStatus: values.ubiquitousItemDownloadingStatus,
             isDownloading: values.ubiquitousItemIsDownloading == true
@@ -143,24 +120,16 @@ extension CoordinatedReplaceWriter {
         }
     }
 
-    private static func verifyFileDestinationCanBeOverwritten(
-        at destinationURL: URL
-    ) throws {
-        let values = try destinationURL.resourceValues(forKeys: [.isDirectoryKey])
-
-        if let destinationError = fileDestinationError(
-            isDirectory: values.isDirectory == true
-        ) {
-            throw destinationError
-        }
-
-        try verifyExistingDestinationCanBeReplaced(at: destinationURL)
-    }
-
     static let live = CoordinatedReplaceWriter(
         fileExists: { FileManager.default.fileExists(atPath: $0) },
         verifyDestination: { destinationURL in
-            try verifyFileDestinationCanBeOverwritten(at: destinationURL)
+            let values = try destinationURL.resourceValues(forKeys: [.isDirectoryKey])
+
+            if let destinationError = fileDestinationError(
+                isDirectory: values.isDirectory == true
+            ) {
+                throw destinationError
+            }
         },
         createReplacementDirectory: { destinationURL in
             try FileManager.default.url(
@@ -195,6 +164,7 @@ extension CoordinatedReplaceWriter {
                 throw accessError
             }
         },
+        cleanupConflicts: cleanupConflictsAfterOverwrite,
         replaceItem: { destinationURL, replacementURL in
             _ = try FileManager.default.replaceItemAt(
                 destinationURL,

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
@@ -37,7 +37,11 @@ struct CoordinatedReplaceWriter {
             let replaceItem = self.replaceItem
             try coordinateReplace(destinationURL) { coordinatedURL in
                 try replaceItem(coordinatedURL, replacementURL)
-                try cleanupConflicts(coordinatedURL)
+                do {
+                    try cleanupConflicts(coordinatedURL)
+                } catch {
+                    throw Self.cleanupConflictError(underlying: error)
+                }
             }
         } catch {
             try? removeItem(replacementDirectory)
@@ -55,6 +59,18 @@ extension CoordinatedReplaceWriter {
     static let itemNotDownloadedReplaceStateCode = 2
     static let directoryReplaceStateCode = 4
 
+    static func cleanupConflictError(underlying: Error) -> NSError {
+        NSError(
+            domain: replaceStateErrorDomain,
+            code: conflictReplaceStateCode,
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "Cannot replace an iCloud item: auto-resolution failed.",
+                NSUnderlyingErrorKey: underlying as NSError,
+            ]
+        )
+    }
+
     static func fileDestinationError(isDirectory: Bool) -> NSError? {
         guard isDirectory else {
             return nil
@@ -70,15 +86,10 @@ extension CoordinatedReplaceWriter {
         )
     }
 
-    static func replaceReadyStateError(
-        hasConflicts: Bool,
+    static func copyDestinationReadyStateError(
         isUbiquitousItem: Bool,
-        downloadStatus: URLUbiquitousItemDownloadingStatus?,
-        isDownloading: Bool
+        downloadStatus: URLUbiquitousItemDownloadingStatus?
     ) -> NSError? {
-        _ = hasConflicts
-        _ = isDownloading
-
         guard isUbiquitousItem else {
             return nil
         }
@@ -129,11 +140,9 @@ extension CoordinatedReplaceWriter {
             throw downloadError
         }
 
-        if let replaceStateError = replaceReadyStateError(
-            hasConflicts: false,
+        if let replaceStateError = copyDestinationReadyStateError(
             isUbiquitousItem: values.isUbiquitousItem == true,
-            downloadStatus: values.ubiquitousItemDownloadingStatus,
-            isDownloading: values.ubiquitousItemIsDownloading == true
+            downloadStatus: values.ubiquitousItemDownloadingStatus
         ) {
             throw replaceStateError
         }

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -14,33 +14,35 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         XCTAssertNil(error)
     }
 
-    func testReplaceReadyStateErrorAllowsConflictedCurrentItemsToProceed() {
-        let error = CoordinatedReplaceWriter.replaceReadyStateError(
-            hasConflicts: true,
-            isUbiquitousItem: true,
-            downloadStatus: .current,
-            isDownloading: false
+    func testHelperSourceCleansUpConflictsAfterReplacementWrite() throws {
+        let helperSource = try String(
+            contentsOfFile: #filePath
+                .replacingOccurrences(
+                    of: "/Tests/icloud_storage_plus_foundationTests/"
+                        + "CoordinatedReplaceWriterTests.swift",
+                    with: "/CoordinatedReplaceWriter.swift"
+                ),
+            encoding: .utf8
         )
 
-        XCTAssertNil(error)
-    }
+        let replaceSnippet = "try replaceItem(coordinatedURL, replacementURL)"
+        let cleanupSnippet = "try cleanupConflicts(coordinatedURL)"
 
-    func testReplaceReadyStateErrorTreatsDownloadingItemsAsNotDownloaded() {
-        let error = CoordinatedReplaceWriter.replaceReadyStateError(
-            hasConflicts: false,
-            isUbiquitousItem: true,
-            downloadStatus: .downloaded,
-            isDownloading: true
-        ) as NSError?
+        let replaceRange = helperSource.range(of: replaceSnippet)
+        let cleanupRange = helperSource.range(of: cleanupSnippet)
 
-        XCTAssertEqual(
-            error?.code,
-            CoordinatedReplaceWriter.itemNotDownloadedReplaceStateCode
+        XCTAssertNotNil(replaceRange)
+        XCTAssertNotNil(
+            cleanupRange,
+            "overwrite path should clean up conflicts after replacement write"
         )
-        XCTAssertEqual(
-            error?.localizedDescription,
-            "Cannot replace a nonlocal iCloud item until it is fully downloaded."
-        )
+
+        if let replaceRange, let cleanupRange {
+            XCTAssertLessThan(
+                replaceRange.lowerBound.utf16Offset(in: helperSource),
+                cleanupRange.lowerBound.utf16Offset(in: helperSource)
+            )
+        }
     }
 
     func testMacOSCopyPropagatesSourceReadCoordinationErrors() throws {
@@ -182,6 +184,49 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         }
     }
 
+    func testOverwriteExistingItemThrowsWhenDestinationHasUnresolvedConflicts() {
+        let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
+        var preparedReplacement = false
+
+        let writer = CoordinatedReplaceWriter(
+            fileExists: { _ in true },
+            verifyDestination: { _ in
+                throw NSError(
+                    domain: "ICloudStoragePlusErrorDomain",
+                    code: 1,
+                    userInfo: [
+                        NSLocalizedDescriptionKey:
+                            "Cannot replace an iCloud item with unresolved conflict versions.",
+                    ]
+                )
+            },
+            createReplacementDirectory: { _ in
+                XCTFail("should not create replacement directory")
+                return URL(fileURLWithPath: "/tmp/replacement")
+            },
+            coordinateReplace: { _, _ in
+                XCTFail("should not coordinate replace")
+            },
+            replaceItem: { _, _ in
+                XCTFail("should not replace item")
+            },
+            removeItem: { _ in }
+        )
+
+        XCTAssertThrowsError(
+            try writer.overwriteExistingItem(at: destinationURL) { _ in
+                preparedReplacement = true
+            }
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Cannot replace an iCloud item with unresolved conflict versions."
+            )
+        }
+
+        XCTAssertFalse(preparedReplacement)
+    }
+
     func testOverwriteExistingItemThrowsWhenDestinationIsNotFullyLocal() {
         let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
         var preparedReplacement = false
@@ -223,6 +268,22 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         }
 
         XCTAssertFalse(preparedReplacement)
+    }
+
+    func testReplaceReadyStateErrorReturnsDistinctDownloadInProgressCode() {
+        let error = CoordinatedReplaceWriter.replaceReadyStateError(
+            hasConflicts: false,
+            isUbiquitousItem: true,
+            downloadStatus: URLUbiquitousItemDownloadingStatus.downloaded,
+            isDownloading: true
+        ) as NSError?
+
+        XCTAssertEqual(error?.domain, "ICloudStoragePlusErrorDomain")
+        XCTAssertEqual(error?.code, 3)
+        XCTAssertEqual(
+            error?.localizedDescription,
+            "Cannot replace an iCloud item while it is downloading."
+        )
     }
 
     func testReplaceReadyStateErrorRejectsDownloadedButNotCurrentItems() {

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -28,14 +28,14 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         )
     }
 
-    func testLiveWriterReplacesExistingLocalFile() throws {
+    func testLiveWriterReplacesExistingLocalFile() async throws {
         let temporaryDirectory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
 
         let destinationURL = temporaryDirectory.appendingPathComponent("file.json")
         try Data("old".utf8).write(to: destinationURL)
 
-        let handled = try CoordinatedReplaceWriter.live.overwriteExistingItem(
+        let handled = try await CoordinatedReplaceWriter.live.overwriteExistingItem(
             at: destinationURL
         ) { replacementURL in
             try Data("new".utf8).write(to: replacementURL)
@@ -45,7 +45,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         XCTAssertEqual(try String(contentsOf: destinationURL), "new")
     }
 
-    func testLiveWriterRejectsExistingDirectoryDestination() throws {
+    func testLiveWriterRejectsExistingDirectoryDestination() async throws {
         let temporaryDirectory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
 
@@ -58,13 +58,14 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             withIntermediateDirectories: true
         )
 
-        XCTAssertThrowsError(
-            try CoordinatedReplaceWriter.live.overwriteExistingItem(
+        do {
+            _ = try await CoordinatedReplaceWriter.live.overwriteExistingItem(
                 at: destinationURL
             ) { replacementURL in
                 try Data("new".utf8).write(to: replacementURL)
             }
-        ) { error in
+            XCTFail("expected overwrite to throw")
+        } catch {
             XCTAssertEqual(
                 error.localizedDescription,
                 "Cannot replace an existing directory with file content."
@@ -72,12 +73,13 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         }
     }
 
-    func testOverwriteExistingItemThrowsWhenDestinationHasUnresolvedConflicts() {
+    func testOverwriteExistingItemThrowsWhenDestinationHasUnresolvedConflicts() async {
         let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
         var preparedReplacement = false
 
         let writer = CoordinatedReplaceWriter(
             fileExists: { _ in true },
+            ensureDownloaded: { _ in },
             verifyDestination: { _ in
                 throw NSError(
                     domain: "ICloudStoragePlusErrorDomain",
@@ -102,11 +104,12 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             removeItem: { _ in }
         )
 
-        XCTAssertThrowsError(
-            try writer.overwriteExistingItem(at: destinationURL) { _ in
+        do {
+            _ = try await writer.overwriteExistingItem(at: destinationURL) { _ in
                 preparedReplacement = true
             }
-        ) { error in
+            XCTFail("expected overwrite to throw")
+        } catch {
             XCTAssertEqual(
                 error.localizedDescription,
                 "Cannot replace an iCloud item with unresolved conflict versions."
@@ -116,12 +119,13 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         XCTAssertFalse(preparedReplacement)
     }
 
-    func testOverwriteExistingItemThrowsWhenDestinationIsNotFullyLocal() {
+    func testOverwriteExistingItemThrowsWhenDestinationIsNotFullyLocal() async {
         let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
         var preparedReplacement = false
 
         let writer = CoordinatedReplaceWriter(
             fileExists: { _ in true },
+            ensureDownloaded: { _ in },
             verifyDestination: { _ in
                 throw NSError(
                     domain: "ICloudStoragePlusErrorDomain",
@@ -146,11 +150,12 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             removeItem: { _ in }
         )
 
-        XCTAssertThrowsError(
-            try writer.overwriteExistingItem(at: destinationURL) { _ in
+        do {
+            _ = try await writer.overwriteExistingItem(at: destinationURL) { _ in
                 preparedReplacement = true
             }
-        ) { error in
+            XCTFail("expected overwrite to throw")
+        } catch {
             XCTAssertEqual(
                 error.localizedDescription,
                 "Cannot replace a nonlocal iCloud item until it is fully downloaded."
@@ -174,12 +179,15 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         )
     }
 
-    func testOverwriteExistingItemReturnsFalseWhenDestinationDoesNotExist() throws {
+    func testOverwriteExistingItemReturnsFalseWhenDestinationDoesNotExist() async throws {
         var preparedReplacement = false
         var verifiedDestinationState = false
 
         let writer = CoordinatedReplaceWriter(
             fileExists: { _ in false },
+            ensureDownloaded: { _ in
+                XCTFail("should not ensure download")
+            },
             verifyDestination: { _ in
                 verifiedDestinationState = true
             },
@@ -197,7 +205,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             removeItem: { _ in }
         )
 
-        let handled = try writer.overwriteExistingItem(
+        let handled = try await writer.overwriteExistingItem(
             at: URL(fileURLWithPath: "/tmp/file.json")
         ) { _ in
             preparedReplacement = true
@@ -208,7 +216,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         XCTAssertFalse(verifiedDestinationState)
     }
 
-    func testOverwriteExistingItemCleansUpReplacementArtifactWhenReplaceFails() {
+    func testOverwriteExistingItemCleansUpReplacementArtifactWhenReplaceFails() async {
         let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
         let replacementDirectory = URL(fileURLWithPath: "/tmp/replacement")
         let expectedError = NSError(domain: NSCocoaErrorDomain, code: 512)
@@ -216,6 +224,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
 
         let writer = CoordinatedReplaceWriter(
             fileExists: { _ in true },
+            ensureDownloaded: { _ in },
             verifyDestination: { _ in },
             createReplacementDirectory: { _ in replacementDirectory },
             coordinateReplace: { url, accessor in try accessor(url) },
@@ -224,25 +233,27 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             removeItem: { cleanedURL = $0 }
         )
 
-        XCTAssertThrowsError(
-            try writer.overwriteExistingItem(at: destinationURL) { url in
+        do {
+            _ = try await writer.overwriteExistingItem(at: destinationURL) { url in
                 XCTAssertEqual(
                     url.deletingLastPathComponent().path,
                     replacementDirectory.path
                 )
             }
-        ) { error in
+            XCTFail("expected overwrite to throw")
+        } catch {
             XCTAssertEqual((error as NSError).code, expectedError.code)
         }
 
         XCTAssertNotNil(cleanedURL)
     }
 
-    func testOverwriteExistingItemReplacesBeforeConflictCleanup() throws {
+    func testOverwriteExistingItemReplacesBeforeConflictCleanup() async throws {
         var events: [String] = []
 
         let writer = CoordinatedReplaceWriter(
             fileExists: { _ in true },
+            ensureDownloaded: { _ in },
             verifyDestination: { _ in },
             createReplacementDirectory: { _ in
                 URL(fileURLWithPath: "/tmp/replacement")
@@ -255,14 +266,14 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             removeItem: { _ in }
         )
 
-        _ = try writer.overwriteExistingItem(
+        _ = try await writer.overwriteExistingItem(
             at: URL(fileURLWithPath: "/tmp/file.json")
         ) { _ in }
 
         XCTAssertEqual(events, ["replaceItem", "cleanupConflicts"])
     }
 
-    func testOverwriteExistingItemMapsCleanupFailureToConflictError() {
+    func testOverwriteExistingItemMapsCleanupFailureToConflictError() async {
         let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
         let replacementDirectory = URL(fileURLWithPath: "/tmp/replacement")
         let underlyingError = NSError(domain: NSCocoaErrorDomain, code: 512)
@@ -270,6 +281,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
 
         let writer = CoordinatedReplaceWriter(
             fileExists: { _ in true },
+            ensureDownloaded: { _ in },
             verifyDestination: { _ in },
             createReplacementDirectory: { _ in replacementDirectory },
             coordinateReplace: { url, accessor in try accessor(url) },
@@ -278,9 +290,10 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             removeItem: { cleanedURL = $0 }
         )
 
-        XCTAssertThrowsError(
-            try writer.overwriteExistingItem(at: destinationURL) { _ in }
-        ) { error in
+        do {
+            _ = try await writer.overwriteExistingItem(at: destinationURL) { _ in }
+            XCTFail("expected overwrite to throw")
+        } catch {
             let nsError = error as NSError
             XCTAssertEqual(
                 nsError.domain,
@@ -301,6 +314,31 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         }
 
         XCTAssertEqual(cleanedURL, replacementDirectory)
+    }
+
+    func testOverwriteExistingItemEnsuresDownloadBeforeValidation() async throws {
+        var events: [String] = []
+
+        let writer = CoordinatedReplaceWriter(
+            fileExists: { _ in true },
+            ensureDownloaded: { _ in events.append("ensureDownloaded") },
+            verifyDestination: { _ in events.append("verifyDestination") },
+            createReplacementDirectory: { _ in
+                URL(fileURLWithPath: "/tmp/replacement")
+            },
+            coordinateReplace: { _, accessor in
+                try accessor(URL(fileURLWithPath: "/tmp/file.json"))
+            },
+            cleanupConflicts: { _ in },
+            replaceItem: { _, _ in },
+            removeItem: { _ in }
+        )
+
+        _ = try await writer.overwriteExistingItem(
+            at: URL(fileURLWithPath: "/tmp/file.json")
+        ) { _ in }
+
+        XCTAssertEqual(events, ["ensureDownloaded", "verifyDestination"])
     }
 
     private func makeTemporaryDirectory() throws -> URL {

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -248,6 +248,36 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         XCTAssertNotNil(cleanedURL)
     }
 
+    func testOverwriteExistingItemCleanupSeesReplacementContent() async throws {
+        let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
+        let replacementDirectory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: replacementDirectory) }
+        var destinationContents = "old"
+        var cleanupSawContents: String?
+
+        let writer = CoordinatedReplaceWriter(
+            fileExists: { _ in true },
+            ensureDownloaded: { _ in },
+            verifyDestination: { _ in },
+            createReplacementDirectory: { _ in replacementDirectory },
+            coordinateReplace: { url, accessor in try accessor(url) },
+            cleanupConflicts: { _ in
+                cleanupSawContents = destinationContents
+            },
+            replaceItem: { _, replacementURL in
+                destinationContents = try String(contentsOf: replacementURL)
+            },
+            removeItem: { _ in }
+        )
+
+        _ = try await writer.overwriteExistingItem(at: destinationURL) { url in
+            try "new".write(to: url, atomically: true, encoding: .utf8)
+        }
+
+        XCTAssertEqual(destinationContents, "new")
+        XCTAssertEqual(cleanupSawContents, "new")
+    }
+
     func testOverwriteExistingItemMapsCleanupFailureToConflictError() async {
         let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
         let replacementDirectory = URL(fileURLWithPath: "/tmp/replacement")

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -219,6 +219,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
     func testOverwriteExistingItemVerifiesDestinationAfterEnsuringDownload() async throws {
         var downloadPrepared = false
         var verifySawPreparedDownload = false
+        let fileManager = FileManager.default
 
         let writer = CoordinatedReplaceWriter(
             fileExists: { _ in true },
@@ -233,7 +234,11 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             coordinateReplace: { url, accessor in try accessor(url) },
             cleanupConflicts: { _ in },
             replaceItem: { _, _ in },
-            removeItem: { _ in }
+            removeItem: { url in
+                if fileManager.fileExists(atPath: url.path) {
+                    try fileManager.removeItem(at: url)
+                }
+            }
         )
 
         _ = try await writer.overwriteExistingItem(
@@ -280,6 +285,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         var destinationContents = "old"
         var cleanupSawContents: String?
         let replacementContents = "new"
+        let fileManager = FileManager.default
 
         let writer = CoordinatedReplaceWriter(
             fileExists: { _ in true },
@@ -293,7 +299,11 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             replaceItem: { _, _ in
                 destinationContents = replacementContents
             },
-            removeItem: { _ in }
+            removeItem: { url in
+                if fileManager.fileExists(atPath: url.path) {
+                    try fileManager.removeItem(at: url)
+                }
+            }
         )
 
         _ = try await writer.overwriteExistingItem(at: destinationURL) { _ in

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -3,60 +3,43 @@ import XCTest
 @testable import icloud_storage_plus_foundation
 
 final class CoordinatedReplaceWriterTests: XCTestCase {
-    func testHelperSourceMatchesProductionSource() throws {
-        let helperSource = try String(
-            contentsOfFile: #filePath
-                .replacingOccurrences(
-                    of: "/Tests/icloud_storage_plus_foundationTests/"
-                        + "CoordinatedReplaceWriterTests.swift",
-                    with: "/CoordinatedReplaceWriter.swift"
-                ),
-            encoding: .utf8
-        )
-        let productionSource = try String(
-            contentsOfFile: #filePath
-                .replacingOccurrences(
-                    of: "/Sources/icloud_storage_plus_foundation/Tests/"
-                        + "icloud_storage_plus_foundationTests/"
-                        + "CoordinatedReplaceWriterTests.swift",
-                    with: "/Sources/icloud_storage_plus/"
-                        + "CoordinatedReplaceWriter.swift"
-                ),
-            encoding: .utf8
+    func testReplaceReadyStateErrorAllowsCurrentItemsWithoutConflicts() {
+        let error = CoordinatedReplaceWriter.replaceReadyStateError(
+            hasConflicts: false,
+            isUbiquitousItem: true,
+            downloadStatus: .current,
+            isDownloading: false
         )
 
-        XCTAssertEqual(helperSource, productionSource)
+        XCTAssertNil(error)
     }
 
-    func testHelperSourceDoesNotExposeCopyOverwriteEntryPoint() throws {
-        let helperSource = try String(
-            contentsOfFile: #filePath
-                .replacingOccurrences(
-                    of: "/Tests/icloud_storage_plus_foundationTests/"
-                        + "CoordinatedReplaceWriterTests.swift",
-                    with: "/CoordinatedReplaceWriter.swift"
-                ),
-            encoding: .utf8
+    func testReplaceReadyStateErrorAllowsConflictedCurrentItemsToProceed() {
+        let error = CoordinatedReplaceWriter.replaceReadyStateError(
+            hasConflicts: true,
+            isUbiquitousItem: true,
+            downloadStatus: .current,
+            isDownloading: false
         )
 
-        XCTAssertFalse(helperSource.contains("copyItemOverwritingExistingItem"))
+        XCTAssertNil(error)
     }
 
-    func testHelperSourceDoesNotKeepRedundantNonCurrentGuard() throws {
-        let helperSource = try String(
-            contentsOfFile: #filePath
-                .replacingOccurrences(
-                    of: "/Tests/icloud_storage_plus_foundationTests/"
-                        + "CoordinatedReplaceWriterTests.swift",
-                    with: "/CoordinatedReplaceWriter.swift"
-                ),
-            encoding: .utf8
-        )
+    func testReplaceReadyStateErrorTreatsDownloadingItemsAsNotDownloaded() {
+        let error = CoordinatedReplaceWriter.replaceReadyStateError(
+            hasConflicts: false,
+            isUbiquitousItem: true,
+            downloadStatus: .downloaded,
+            isDownloading: true
+        ) as NSError?
 
-        XCTAssertFalse(
-            helperSource.contains("if downloadStatus != .current"),
-            "replaceReadyStateError should not keep a non-current guard after "
-                + "the earlier .current return."
+        XCTAssertEqual(
+            error?.code,
+            CoordinatedReplaceWriter.itemNotDownloadedReplaceStateCode
+        )
+        XCTAssertEqual(
+            error?.localizedDescription,
+            "Cannot replace a nonlocal iCloud item until it is fully downloaded."
         )
     }
 
@@ -199,49 +182,6 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         }
     }
 
-    func testOverwriteExistingItemThrowsWhenDestinationHasUnresolvedConflicts() {
-        let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
-        var preparedReplacement = false
-
-        let writer = CoordinatedReplaceWriter(
-            fileExists: { _ in true },
-            verifyDestination: { _ in
-                throw NSError(
-                    domain: "ICloudStoragePlusErrorDomain",
-                    code: 1,
-                    userInfo: [
-                        NSLocalizedDescriptionKey:
-                            "Cannot replace an iCloud item with unresolved conflict versions.",
-                    ]
-                )
-            },
-            createReplacementDirectory: { _ in
-                XCTFail("should not create replacement directory")
-                return URL(fileURLWithPath: "/tmp/replacement")
-            },
-            coordinateReplace: { _, _ in
-                XCTFail("should not coordinate replace")
-            },
-            replaceItem: { _, _ in
-                XCTFail("should not replace item")
-            },
-            removeItem: { _ in }
-        )
-
-        XCTAssertThrowsError(
-            try writer.overwriteExistingItem(at: destinationURL) { _ in
-                preparedReplacement = true
-            }
-        ) { error in
-            XCTAssertEqual(
-                error.localizedDescription,
-                "Cannot replace an iCloud item with unresolved conflict versions."
-            )
-        }
-
-        XCTAssertFalse(preparedReplacement)
-    }
-
     func testOverwriteExistingItemThrowsWhenDestinationIsNotFullyLocal() {
         let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
         var preparedReplacement = false
@@ -283,22 +223,6 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         }
 
         XCTAssertFalse(preparedReplacement)
-    }
-
-    func testReplaceReadyStateErrorReturnsDistinctDownloadInProgressCode() {
-        let error = CoordinatedReplaceWriter.replaceReadyStateError(
-            hasConflicts: false,
-            isUbiquitousItem: true,
-            downloadStatus: URLUbiquitousItemDownloadingStatus.downloaded,
-            isDownloading: true
-        ) as NSError?
-
-        XCTAssertEqual(error?.domain, "ICloudStoragePlusErrorDomain")
-        XCTAssertEqual(error?.code, 3)
-        XCTAssertEqual(
-            error?.localizedDescription,
-            "Cannot replace an iCloud item while it is downloading."
-        )
     }
 
     func testReplaceReadyStateErrorRejectsDownloadedButNotCurrentItems() {

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -248,31 +248,6 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         XCTAssertNotNil(cleanedURL)
     }
 
-    func testOverwriteExistingItemReplacesBeforeConflictCleanup() async throws {
-        var events: [String] = []
-
-        let writer = CoordinatedReplaceWriter(
-            fileExists: { _ in true },
-            ensureDownloaded: { _ in },
-            verifyDestination: { _ in },
-            createReplacementDirectory: { _ in
-                URL(fileURLWithPath: "/tmp/replacement")
-            },
-            coordinateReplace: { _, accessor in
-                try accessor(URL(fileURLWithPath: "/tmp/file.json"))
-            },
-            cleanupConflicts: { _ in events.append("cleanupConflicts") },
-            replaceItem: { _, _ in events.append("replaceItem") },
-            removeItem: { _ in }
-        )
-
-        _ = try await writer.overwriteExistingItem(
-            at: URL(fileURLWithPath: "/tmp/file.json")
-        ) { _ in }
-
-        XCTAssertEqual(events, ["replaceItem", "cleanupConflicts"])
-    }
-
     func testOverwriteExistingItemMapsCleanupFailureToConflictError() async {
         let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
         let replacementDirectory = URL(fileURLWithPath: "/tmp/replacement")
@@ -314,31 +289,6 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         }
 
         XCTAssertEqual(cleanedURL, replacementDirectory)
-    }
-
-    func testOverwriteExistingItemEnsuresDownloadBeforeValidation() async throws {
-        var events: [String] = []
-
-        let writer = CoordinatedReplaceWriter(
-            fileExists: { _ in true },
-            ensureDownloaded: { _ in events.append("ensureDownloaded") },
-            verifyDestination: { _ in events.append("verifyDestination") },
-            createReplacementDirectory: { _ in
-                URL(fileURLWithPath: "/tmp/replacement")
-            },
-            coordinateReplace: { _, accessor in
-                try accessor(URL(fileURLWithPath: "/tmp/file.json"))
-            },
-            cleanupConflicts: { _ in },
-            replaceItem: { _, _ in },
-            removeItem: { _ in }
-        )
-
-        _ = try await writer.overwriteExistingItem(
-            at: URL(fileURLWithPath: "/tmp/file.json")
-        ) { _ in }
-
-        XCTAssertEqual(events, ["ensureDownloaded", "verifyDestination"])
     }
 
     private func makeTemporaryDirectory() throws -> URL {

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -3,34 +3,19 @@ import XCTest
 @testable import icloud_storage_plus_foundation
 
 final class CoordinatedReplaceWriterTests: XCTestCase {
-    func testReplaceReadyStateErrorAllowsCurrentItemsWithoutConflicts() {
-        let error = CoordinatedReplaceWriter.replaceReadyStateError(
-            hasConflicts: false,
+    func testCopyDestinationReadyStateErrorAllowsCurrentItems() {
+        let error = CoordinatedReplaceWriter.copyDestinationReadyStateError(
             isUbiquitousItem: true,
-            downloadStatus: .current,
-            isDownloading: false
+            downloadStatus: .current
         )
 
         XCTAssertNil(error)
     }
 
-    func testReplaceReadyStateErrorAllowsConflictedCurrentItemsToProceed() {
-        let error = CoordinatedReplaceWriter.replaceReadyStateError(
-            hasConflicts: true,
+    func testCopyDestinationReadyStateErrorRejectsNotDownloadedItems() {
+        let error = CoordinatedReplaceWriter.copyDestinationReadyStateError(
             isUbiquitousItem: true,
-            downloadStatus: .current,
-            isDownloading: false
-        )
-
-        XCTAssertNil(error)
-    }
-
-    func testReplaceReadyStateErrorTreatsDownloadingItemsAsNotDownloaded() {
-        let error = CoordinatedReplaceWriter.replaceReadyStateError(
-            hasConflicts: false,
-            isUbiquitousItem: true,
-            downloadStatus: .downloaded,
-            isDownloading: true
+            downloadStatus: .notDownloaded
         ) as NSError?
 
         XCTAssertEqual(
@@ -175,12 +160,10 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         XCTAssertFalse(preparedReplacement)
     }
 
-    func testReplaceReadyStateErrorRejectsDownloadedButNotCurrentItems() {
-        let error = CoordinatedReplaceWriter.replaceReadyStateError(
-            hasConflicts: false,
+    func testCopyDestinationReadyStateErrorRejectsDownloadedButNotCurrentItems() {
+        let error = CoordinatedReplaceWriter.copyDestinationReadyStateError(
             isUbiquitousItem: true,
-            downloadStatus: URLUbiquitousItemDownloadingStatus.downloaded,
-            isDownloading: false
+            downloadStatus: .downloaded
         ) as NSError?
 
         XCTAssertEqual(error?.domain, "ICloudStoragePlusErrorDomain")
@@ -277,6 +260,47 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         ) { _ in }
 
         XCTAssertEqual(events, ["replaceItem", "cleanupConflicts"])
+    }
+
+    func testOverwriteExistingItemMapsCleanupFailureToConflictError() {
+        let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
+        let replacementDirectory = URL(fileURLWithPath: "/tmp/replacement")
+        let underlyingError = NSError(domain: NSCocoaErrorDomain, code: 512)
+        var cleanedURL: URL?
+
+        let writer = CoordinatedReplaceWriter(
+            fileExists: { _ in true },
+            verifyDestination: { _ in },
+            createReplacementDirectory: { _ in replacementDirectory },
+            coordinateReplace: { url, accessor in try accessor(url) },
+            cleanupConflicts: { _ in throw underlyingError },
+            replaceItem: { _, _ in },
+            removeItem: { cleanedURL = $0 }
+        )
+
+        XCTAssertThrowsError(
+            try writer.overwriteExistingItem(at: destinationURL) { _ in }
+        ) { error in
+            let nsError = error as NSError
+            XCTAssertEqual(
+                nsError.domain,
+                CoordinatedReplaceWriter.replaceStateErrorDomain
+            )
+            XCTAssertEqual(
+                nsError.code,
+                CoordinatedReplaceWriter.conflictReplaceStateCode
+            )
+            XCTAssertEqual(
+                nsError.localizedDescription,
+                "Cannot replace an iCloud item: auto-resolution failed."
+            )
+            XCTAssertEqual(
+                (nsError.userInfo[NSUnderlyingErrorKey] as? NSError)?.code,
+                underlyingError.code
+            )
+        }
+
+        XCTAssertEqual(cleanedURL, replacementDirectory)
     }
 
     private func makeTemporaryDirectory() throws -> URL {

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -110,6 +110,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             coordinateReplace: { _, _ in
                 XCTFail("should not coordinate replace")
             },
+            cleanupConflicts: { _ in },
             replaceItem: { _, _ in
                 XCTFail("should not replace item")
             },
@@ -153,6 +154,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             coordinateReplace: { _, _ in
                 XCTFail("should not coordinate replace")
             },
+            cleanupConflicts: { _ in },
             replaceItem: { _, _ in
                 XCTFail("should not replace item")
             },
@@ -205,6 +207,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             coordinateReplace: { _, _ in
                 XCTFail("should not coordinate replace")
             },
+            cleanupConflicts: { _ in },
             replaceItem: { _, _ in
                 XCTFail("should not replace item")
             },
@@ -233,6 +236,7 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
             verifyDestination: { _ in },
             createReplacementDirectory: { _ in replacementDirectory },
             coordinateReplace: { url, accessor in try accessor(url) },
+            cleanupConflicts: { _ in },
             replaceItem: { _, _ in throw expectedError },
             removeItem: { cleanedURL = $0 }
         )
@@ -249,6 +253,30 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         }
 
         XCTAssertNotNil(cleanedURL)
+    }
+
+    func testOverwriteExistingItemReplacesBeforeConflictCleanup() throws {
+        var events: [String] = []
+
+        let writer = CoordinatedReplaceWriter(
+            fileExists: { _ in true },
+            verifyDestination: { _ in },
+            createReplacementDirectory: { _ in
+                URL(fileURLWithPath: "/tmp/replacement")
+            },
+            coordinateReplace: { _, accessor in
+                try accessor(URL(fileURLWithPath: "/tmp/file.json"))
+            },
+            cleanupConflicts: { _ in events.append("cleanupConflicts") },
+            replaceItem: { _, _ in events.append("replaceItem") },
+            removeItem: { _ in }
+        )
+
+        _ = try writer.overwriteExistingItem(
+            at: URL(fileURLWithPath: "/tmp/file.json")
+        ) { _ in }
+
+        XCTAssertEqual(events, ["replaceItem", "cleanupConflicts"])
     }
 
     private func makeTemporaryDirectory() throws -> URL {

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -14,35 +14,33 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         XCTAssertNil(error)
     }
 
-    func testHelperSourceCleansUpConflictsAfterReplacementWrite() throws {
-        let helperSource = try String(
-            contentsOfFile: #filePath
-                .replacingOccurrences(
-                    of: "/Tests/icloud_storage_plus_foundationTests/"
-                        + "CoordinatedReplaceWriterTests.swift",
-                    with: "/CoordinatedReplaceWriter.swift"
-                ),
-            encoding: .utf8
+    func testReplaceReadyStateErrorAllowsConflictedCurrentItemsToProceed() {
+        let error = CoordinatedReplaceWriter.replaceReadyStateError(
+            hasConflicts: true,
+            isUbiquitousItem: true,
+            downloadStatus: .current,
+            isDownloading: false
         )
 
-        let replaceSnippet = "try replaceItem(coordinatedURL, replacementURL)"
-        let cleanupSnippet = "try cleanupConflicts(coordinatedURL)"
+        XCTAssertNil(error)
+    }
 
-        let replaceRange = helperSource.range(of: replaceSnippet)
-        let cleanupRange = helperSource.range(of: cleanupSnippet)
+    func testReplaceReadyStateErrorTreatsDownloadingItemsAsNotDownloaded() {
+        let error = CoordinatedReplaceWriter.replaceReadyStateError(
+            hasConflicts: false,
+            isUbiquitousItem: true,
+            downloadStatus: .downloaded,
+            isDownloading: true
+        ) as NSError?
 
-        XCTAssertNotNil(replaceRange)
-        XCTAssertNotNil(
-            cleanupRange,
-            "overwrite path should clean up conflicts after replacement write"
+        XCTAssertEqual(
+            error?.code,
+            CoordinatedReplaceWriter.itemNotDownloadedReplaceStateCode
         )
-
-        if let replaceRange, let cleanupRange {
-            XCTAssertLessThan(
-                replaceRange.lowerBound.utf16Offset(in: helperSource),
-                cleanupRange.lowerBound.utf16Offset(in: helperSource)
-            )
-        }
+        XCTAssertEqual(
+            error?.localizedDescription,
+            "Cannot replace a nonlocal iCloud item until it is fully downloaded."
+        )
     }
 
     func testMacOSCopyPropagatesSourceReadCoordinationErrors() throws {

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -216,6 +216,33 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         XCTAssertFalse(verifiedDestinationState)
     }
 
+    func testOverwriteExistingItemVerifiesDestinationAfterEnsuringDownload() async throws {
+        var downloadPrepared = false
+        var verifySawPreparedDownload = false
+
+        let writer = CoordinatedReplaceWriter(
+            fileExists: { _ in true },
+            ensureDownloaded: { _ in
+                downloadPrepared = true
+            },
+            verifyDestination: { _ in
+                verifySawPreparedDownload = downloadPrepared
+                XCTAssertTrue(downloadPrepared)
+            },
+            createReplacementDirectory: { _ in try self.makeTemporaryDirectory() },
+            coordinateReplace: { url, accessor in try accessor(url) },
+            cleanupConflicts: { _ in },
+            replaceItem: { _, _ in },
+            removeItem: { _ in }
+        )
+
+        _ = try await writer.overwriteExistingItem(
+            at: URL(fileURLWithPath: "/tmp/file.json")
+        ) { _ in }
+
+        XCTAssertTrue(verifySawPreparedDownload)
+    }
+
     func testOverwriteExistingItemCleansUpReplacementArtifactWhenReplaceFails() async {
         let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
         let replacementDirectory = URL(fileURLWithPath: "/tmp/replacement")
@@ -248,34 +275,32 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         XCTAssertNotNil(cleanedURL)
     }
 
-    func testOverwriteExistingItemCleanupSeesReplacementContent() async throws {
+    func testOverwriteExistingItemCleanupSeesUpdatedDestinationState() async throws {
         let destinationURL = URL(fileURLWithPath: "/tmp/file.json")
-        let replacementDirectory = try makeTemporaryDirectory()
-        defer { try? FileManager.default.removeItem(at: replacementDirectory) }
         var destinationContents = "old"
         var cleanupSawContents: String?
+        let replacementContents = "new"
 
         let writer = CoordinatedReplaceWriter(
             fileExists: { _ in true },
             ensureDownloaded: { _ in },
             verifyDestination: { _ in },
-            createReplacementDirectory: { _ in replacementDirectory },
+            createReplacementDirectory: { _ in try self.makeTemporaryDirectory() },
             coordinateReplace: { url, accessor in try accessor(url) },
             cleanupConflicts: { _ in
                 cleanupSawContents = destinationContents
             },
-            replaceItem: { _, replacementURL in
-                destinationContents = try String(contentsOf: replacementURL)
+            replaceItem: { _, _ in
+                destinationContents = replacementContents
             },
             removeItem: { _ in }
         )
 
-        _ = try await writer.overwriteExistingItem(at: destinationURL) { url in
-            try "new".write(to: url, atomically: true, encoding: .utf8)
+        _ = try await writer.overwriteExistingItem(at: destinationURL) { _ in
         }
 
-        XCTAssertEqual(destinationContents, "new")
-        XCTAssertEqual(cleanupSawContents, "new")
+        XCTAssertEqual(destinationContents, replacementContents)
+        XCTAssertEqual(cleanupSawContents, replacementContents)
     }
 
     func testOverwriteExistingItemMapsCleanupFailureToConflictError() async {

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -43,101 +43,6 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         )
     }
 
-    func testMacOSCopyPropagatesSourceReadCoordinationErrors() throws {
-        let pluginSource = try String(
-            contentsOfFile: #filePath
-                .replacingOccurrences(
-                    of: "/Sources/icloud_storage_plus_foundation/Tests/"
-                        + "icloud_storage_plus_foundationTests/"
-                        + "CoordinatedReplaceWriterTests.swift",
-                    with: "/Sources/icloud_storage_plus/"
-                        + "macOSICloudStoragePlugin.swift"
-                ),
-            encoding: .utf8
-        )
-
-        XCTAssertTrue(
-            pluginSource.contains("var sourceCoordinationError: NSError?"),
-            "copy() should capture read coordination failures before "
-                + "falling through to destination handling."
-        )
-        XCTAssertTrue(
-            pluginSource.contains("error: &sourceCoordinationError"),
-            "copy() should pass a read coordination error pointer instead "
-                + "of discarding coordination failures."
-        )
-        XCTAssertTrue(
-            pluginSource.contains("if let sourceCoordinationError"),
-            "copy() should surface a failed source read coordination "
-                + "instead of continuing silently."
-        )
-        XCTAssertTrue(
-            pluginSource.contains("var copyCoordinationError: NSError?"),
-            "copy() should also capture read/write coordination failures in "
-                + "the non-overwrite path."
-        )
-        XCTAssertTrue(
-            pluginSource.contains("error: &copyCoordinationError"),
-            "copy() should not discard the combined read/write "
-                + "coordination error."
-        )
-        XCTAssertTrue(
-            pluginSource.contains("if let copyCoordinationError"),
-            "copy() should surface a failed combined coordination instead "
-                + "of leaving the Flutter call without a result."
-        )
-    }
-
-    func testMacOSCopyFailuresReportDestinationRelativePath() throws {
-        let pluginSource = try String(
-            contentsOfFile: #filePath
-                .replacingOccurrences(
-                    of: "/Sources/icloud_storage_plus_foundation/Tests/"
-                        + "icloud_storage_plus_foundationTests/"
-                        + "CoordinatedReplaceWriterTests.swift",
-                    with: "/Sources/icloud_storage_plus/"
-                        + "macOSICloudStoragePlugin.swift"
-                ),
-            encoding: .utf8
-        )
-
-        XCTAssertEqual(
-            pluginSource.components(
-                separatedBy: "relativePath: toRelativePath"
-            ).count - 1,
-            3,
-            "copy() should surface the blocked destination path for both "
-                + "destination-side failure branches, including coordination "
-                + "errors in the combined read/write path."
-        )
-    }
-
-    func testMacOSUploadProgressFailuresReportCloudRelativePath() throws {
-        let pluginSource = try String(
-            contentsOfFile: #filePath
-                .replacingOccurrences(
-                    of: "/Sources/icloud_storage_plus_foundation/Tests/"
-                        + "icloud_storage_plus_foundationTests/"
-                        + "CoordinatedReplaceWriterTests.swift",
-                    with: "/Sources/icloud_storage_plus/"
-                        + "macOSICloudStoragePlugin.swift"
-                ),
-            encoding: .utf8
-        )
-
-        XCTAssertTrue(
-            pluginSource.contains(
-                "streamHandler.setEvent(nativeCodeError(\n"
-                    + "        error,\n"
-                    + "        operation: \"uploadFile\",\n"
-                    + "        relativePath: cloudRelativePath\n"
-                    + "      ))"
-            ),
-            "upload progress failures should surface cloudRelativePath in "
-                + "the structured error payload."
-        )
-    }
-
     func testLiveWriterReplacesExistingLocalFile() throws {
         let temporaryDirectory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
@@ -266,22 +171,6 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         }
 
         XCTAssertFalse(preparedReplacement)
-    }
-
-    func testReplaceReadyStateErrorReturnsDistinctDownloadInProgressCode() {
-        let error = CoordinatedReplaceWriter.replaceReadyStateError(
-            hasConflicts: false,
-            isUbiquitousItem: true,
-            downloadStatus: URLUbiquitousItemDownloadingStatus.downloaded,
-            isDownloading: true
-        ) as NSError?
-
-        XCTAssertEqual(error?.domain, "ICloudStoragePlusErrorDomain")
-        XCTAssertEqual(error?.code, 3)
-        XCTAssertEqual(
-            error?.localizedDescription,
-            "Cannot replace an iCloud item while it is downloading."
-        )
     }
 
     func testReplaceReadyStateErrorRejectsDownloadedButNotCurrentItems() {

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/WriteEntrypointPreflightTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/WriteEntrypointPreflightTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import XCTest
+@testable import icloud_storage_plus_foundation
+
+final class WriteEntrypointPreflightTests: XCTestCase {
+    func testLivePrepareRunsBlockingWorkOffMainThread() async throws {
+        let temporaryDirectory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let expectedDirectory = temporaryDirectory
+            .appendingPathComponent("nested", isDirectory: true)
+        let expectedFileURL = expectedDirectory.appendingPathComponent("file.txt")
+        let expectation = expectation(description: "preflight work ran")
+        expectation.expectedFulfillmentCount = 2
+        let lock = NSLock()
+        var observedMainThreadStates: [Bool] = []
+
+        let preflight = WriteEntrypointPreflight(
+            execute: WriteEntrypointPreflight.live.execute,
+            resolveContainerURL: { _ in
+                lock.lock()
+                observedMainThreadStates.append(Thread.isMainThread)
+                lock.unlock()
+                expectation.fulfill()
+                return temporaryDirectory
+            },
+            createDirectory: { directoryURL in
+                lock.lock()
+                observedMainThreadStates.append(Thread.isMainThread)
+                lock.unlock()
+                expectation.fulfill()
+                XCTAssertEqual(directoryURL.path, expectedDirectory.path)
+                try FileManager.default.createDirectory(
+                    at: directoryURL,
+                    withIntermediateDirectories: true
+                )
+            }
+        )
+
+        let fileURL = try await preflight.prepare(
+            containerId: "container",
+            relativePath: "nested/file.txt"
+        )
+
+        await fulfillment(of: [expectation], timeout: 1.0)
+        XCTAssertEqual(fileURL.path, expectedFileURL.path)
+        XCTAssertEqual(observedMainThreadStates, [false, false])
+    }
+
+    func testPrepareThrowsTypedContainerUnavailableError() async {
+        let preflight = WriteEntrypointPreflight(
+            execute: { work in try work() },
+            resolveContainerURL: { _ in nil },
+            createDirectory: { _ in XCTFail("should not create directory") }
+        )
+
+        do {
+            _ = try await preflight.prepare(
+                containerId: "missing",
+                relativePath: "nested/file.txt"
+            )
+            XCTFail("expected prepare to throw")
+        } catch {
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.domain, WriteEntrypointPreflight.errorDomain)
+            XCTAssertEqual(
+                nsError.code,
+                WriteEntrypointPreflight.containerUnavailableErrorCode
+            )
+        }
+    }
+
+    func testItemURLWithoutParentDirectoryCreationSkipsCreateDirectory() async throws {
+        let temporaryDirectory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        var createDirectoryCalled = false
+        let preflight = WriteEntrypointPreflight(
+            execute: { work in try work() },
+            resolveContainerURL: { _ in temporaryDirectory },
+            createDirectory: { _ in createDirectoryCalled = true }
+        )
+
+        let fileURL = try await preflight.itemURL(
+            containerId: "container",
+            relativePath: "nested/file.txt",
+            createParentDirectory: false
+        )
+
+        XCTAssertEqual(
+            fileURL.path,
+            temporaryDirectory
+                .appendingPathComponent("nested/file.txt")
+                .path
+        )
+        XCTAssertFalse(createDirectoryCalled)
+    }
+
+    func testContainerURLRunsOffMainThread() async throws {
+        let temporaryDirectory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let expectation = expectation(description: "container lookup ran")
+        var observedMainThreadState: Bool?
+        let preflight = WriteEntrypointPreflight(
+            execute: WriteEntrypointPreflight.live.execute,
+            resolveContainerURL: { _ in
+                observedMainThreadState = Thread.isMainThread
+                expectation.fulfill()
+                return temporaryDirectory
+            },
+            createDirectory: { _ in XCTFail("should not create directory") }
+        )
+
+        let containerURL = try await preflight.containerURL(containerId: "container")
+
+        await fulfillment(of: [expectation], timeout: 1.0)
+        XCTAssertEqual(containerURL.path, temporaryDirectory.path)
+        XCTAssertEqual(observedMainThreadState, false)
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: temporaryDirectory,
+            withIntermediateDirectories: true
+        )
+        return temporaryDirectory
+    }
+}

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/WriteEntrypointPreflight.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/WriteEntrypointPreflight.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+@available(macOS 10.15, iOS 13.0, *)
+struct WriteEntrypointPreflight {
+    typealias Execute = (@escaping @Sendable () throws -> URL) async throws -> URL
+    typealias ResolveContainerURL = (String) -> URL?
+    typealias CreateDirectory = (URL) throws -> Void
+
+    let execute: Execute
+    let resolveContainerURL: ResolveContainerURL
+    let createDirectory: CreateDirectory
+
+    func containerURL(containerId: String) async throws -> URL {
+        try await execute {
+            guard let containerURL = resolveContainerURL(containerId) else {
+                throw Self.containerUnavailableError()
+            }
+
+            return containerURL
+        }
+    }
+
+    func itemURL(
+        containerId: String,
+        relativePath: String,
+        createParentDirectory: Bool
+    ) async throws -> URL {
+        let containerURL = try await containerURL(containerId: containerId)
+        let fileURL = containerURL.appendingPathComponent(relativePath)
+
+        if createParentDirectory {
+            try createDirectory(fileURL.deletingLastPathComponent())
+        }
+
+        return fileURL
+    }
+
+    func prepare(
+        containerId: String,
+        relativePath: String
+    ) async throws -> URL {
+        try await execute {
+            guard let containerURL = resolveContainerURL(containerId) else {
+                throw Self.containerUnavailableError()
+            }
+
+            let fileURL = containerURL.appendingPathComponent(relativePath)
+            try createDirectory(fileURL.deletingLastPathComponent())
+            return fileURL
+        }
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, *)
+extension WriteEntrypointPreflight {
+    static let errorDomain = "ICloudStoragePlusWriteEntrypointPreflight"
+    static let containerUnavailableErrorCode = 1
+
+    static func containerUnavailableError() -> NSError {
+        NSError(
+            domain: errorDomain,
+            code: containerUnavailableErrorCode,
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "Unable to access the requested iCloud container.",
+            ]
+        )
+    }
+
+    static func isContainerUnavailableError(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        return nsError.domain == errorDomain
+            && nsError.code == containerUnavailableErrorCode
+    }
+
+    static let live = WriteEntrypointPreflight(
+        execute: { work in
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<URL, Error>) in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    do {
+                        continuation.resume(returning: try work())
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
+        },
+        resolveContainerURL: {
+            FileManager.default.url(forUbiquityContainerIdentifier: $0)
+        },
+        createDirectory: { directoryURL in
+            try FileManager.default.createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+        }
+    )
+}

--- a/test/icloud_storage_method_channel_test.dart
+++ b/test/icloud_storage_method_channel_test.dart
@@ -693,7 +693,10 @@ void main() {
   });
 
   group('writeInPlace error mapping', () {
-    test('maps directory destination to InvalidArgumentException', () async {
+    test(
+      'TODO: maps directory destination to InvalidArgumentException '
+      'instead of the current unknown-native fallback',
+      () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (methodCall) async {
         if (methodCall.method == 'writeInPlace') {
@@ -719,7 +722,8 @@ void main() {
         ),
         throwsA(isA<InvalidArgumentException>()),
       );
-    });
+      },
+    );
 
     test('maps conflict recovery failure to ICloudConflictException', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger

--- a/test/icloud_storage_method_channel_test.dart
+++ b/test/icloud_storage_method_channel_test.dart
@@ -692,6 +692,64 @@ void main() {
     );
   });
 
+  group('writeInPlace error mapping', () {
+    test('maps directory destination to InvalidArgumentException', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (methodCall) async {
+        if (methodCall.method == 'writeInPlace') {
+          throw PlatformException(
+            code: PlatformExceptionCode.argumentError,
+            message: 'Cannot replace an existing directory with file content.',
+            details: {
+              'category': 'invalidArgument',
+              'operation': 'writeInPlace',
+              'retryable': false,
+              'relativePath': 'Documents/folder',
+            },
+          );
+        }
+        return null;
+      });
+
+      await expectLater(
+        () => platform.writeInPlace(
+          containerId: containerId,
+          relativePath: 'Documents/folder',
+          contents: '{}',
+        ),
+        throwsA(isA<InvalidArgumentException>()),
+      );
+    });
+
+    test('maps conflict recovery failure to ICloudConflictException', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (methodCall) async {
+        if (methodCall.method == 'writeInPlaceBytes') {
+          throw PlatformException(
+            code: PlatformExceptionCode.conflict,
+            message: 'Cannot replace an iCloud item: auto-resolution failed',
+            details: {
+              'category': 'conflict',
+              'operation': 'writeInPlaceBytes',
+              'retryable': false,
+              'relativePath': 'Documents/file.bin',
+            },
+          );
+        }
+        return null;
+      });
+
+      await expectLater(
+        () => platform.writeInPlaceBytes(
+          containerId: containerId,
+          relativePath: 'Documents/file.bin',
+          contents: Uint8List.fromList([1, 2, 3]),
+        ),
+        throwsA(isA<ICloudConflictException>()),
+      );
+    });
+  });
+
   test('icloudAvailable keeps raw PlatformException behavior', () async {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (methodCall) async {

--- a/test/icloud_storage_method_channel_test.dart
+++ b/test/icloud_storage_method_channel_test.dart
@@ -694,34 +694,34 @@ void main() {
 
   group('writeInPlace error mapping', () {
     test(
-      'TODO: maps directory destination to InvalidArgumentException '
-      'instead of the current unknown-native fallback',
+      'maps directory destination to ICloudInvalidArgumentException',
       () async {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(channel, (methodCall) async {
-        if (methodCall.method == 'writeInPlace') {
-          throw PlatformException(
-            code: PlatformExceptionCode.argumentError,
-            message: 'Cannot replace an existing directory with file content.',
-            details: {
-              'category': 'invalidArgument',
-              'operation': 'writeInPlace',
-              'retryable': false,
-              'relativePath': 'Documents/folder',
-            },
-          );
-        }
-        return null;
-      });
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (methodCall) async {
+          if (methodCall.method == 'writeInPlace') {
+            throw PlatformException(
+              code: PlatformExceptionCode.argumentError,
+              message:
+                  'Cannot replace an existing directory with file content.',
+              details: {
+                'category': 'invalidArgument',
+                'operation': 'writeInPlace',
+                'retryable': false,
+                'relativePath': 'Documents/folder',
+              },
+            );
+          }
+          return null;
+        });
 
-      await expectLater(
-        () => platform.writeInPlace(
-          containerId: containerId,
-          relativePath: 'Documents/folder',
-          contents: '{}',
-        ),
-        throwsA(isA<InvalidArgumentException>()),
-      );
+        await expectLater(
+          () => platform.writeInPlace(
+            containerId: containerId,
+            relativePath: 'Documents/folder',
+            contents: '{}',
+          ),
+          throwsA(isA<ICloudInvalidArgumentException>()),
+        );
       },
     );
 


### PR DESCRIPTION
## Summary
- reset the Darwin `writeInPlace` path around the locked contract, separating observer conflict handling from overwrite cleanup and preserving the stable Dart-visible error categories
- move iCloud container and item preflight work off the entry thread for write, read, metadata, and container lookup paths while restoring the iOS Flutter task-queue registration used by the plugin
- add contract-focused Dart and Swift coverage for overwrite behavior, error mapping, and off-main-thread preflight helpers on both iOS and macOS

## Verification
- `flutter test`
- `flutter analyze`
- `swift test --package-path Sources/icloud_storage_plus_foundation` in `ios/icloud_storage_plus`
- `swift test --package-path Sources/icloud_storage_plus_foundation` in `macos/icloud_storage_plus`
- `flutter build ios --simulator --debug --target lib/main.dart` in `example`
- `pod lib lint \"macos/icloud_storage_plus.podspec\" --allow-warnings`

## Notes
- `pod lib lint \"ios/icloud_storage_plus.podspec\" --allow-warnings` still fails on the Flutter `makeBackgroundTaskQueue` / `taskQueue:` API, but the same failure reproduces on `origin/main`, so this branch does not introduce that CocoaPods lint behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kingdomseed/icloud_storage_plus/pull/26" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
