### PR TITLE
Prepare iCloud storage 2.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `UbiquityContainerResolver`, including `gather`, so transient
   `FileManager.url(forUbiquityContainerIdentifier:)` nil responses retry
   before surfacing a container-access failure.
+- Container resolution retry delays now preserve `Task.sleep` cancellation
+  instead of swallowing it, so cancelled calls stop before issuing an
+  unnecessary second container lookup.
 - Native iOS and macOS metadata query sessions are retained for their full
   query lifetimes, preventing observers from being released before
   `NSMetadataQuery` completes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.3] - 2026-05-03
+
+### Fixed
+- iOS and macOS container operations now route through a shared
+  `UbiquityContainerResolver`, including `gather`, so transient
+  `FileManager.url(forUbiquityContainerIdentifier:)` nil responses retry
+  before surfacing a container-access failure.
+- Native iOS and macOS metadata query sessions are retained for their full
+  query lifetimes, preventing observers from being released before
+  `NSMetadataQuery` completes.
+- Native write failures now preserve structured path and native error context
+  for Dart typed exceptions without exposing full local filesystem paths.
+
 ## [2.1.2] - 2026-04-23
 
 ### Fixed

--- a/ios/icloud_storage_plus.podspec
+++ b/ios/icloud_storage_plus.podspec
@@ -18,6 +18,7 @@ container, with document coordination via UIDocument/NSDocument.
     'icloud_storage_plus/Sources/icloud_storage_plus/**/*.{h,m,swift}',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/DownloadWaiter.swift',
+    'icloud_storage_plus/Sources/icloud_storage_plus_foundation/MetadataQuerySession.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/ConflictResolver.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/WriteEntrypointPreflight.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/UbiquityContainerResolver.swift',

--- a/ios/icloud_storage_plus.podspec
+++ b/ios/icloud_storage_plus.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'icloud_storage_plus'
-  s.version          = '2.1.2'
+  s.version          = '2.1.3'
   s.summary          = 'iCloud document storage for Flutter (iOS/macOS).'
   s.description      = <<-DESC
 Flutter plugin for uploading, downloading, and managing files in an iCloud

--- a/ios/icloud_storage_plus.podspec
+++ b/ios/icloud_storage_plus.podspec
@@ -20,6 +20,7 @@ container, with document coordination via UIDocument/NSDocument.
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/DownloadWaiter.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/ConflictResolver.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/WriteEntrypointPreflight.swift',
+    'icloud_storage_plus/Sources/icloud_storage_plus_foundation/UbiquityContainerResolver.swift',
   ]
   s.dependency 'Flutter'
   s.platform = :ios, '13.0'

--- a/ios/icloud_storage_plus/Package.swift
+++ b/ios/icloud_storage_plus/Package.swift
@@ -30,6 +30,7 @@ let package = Package(
                 "icloud_storage_plus_foundation/DownloadWaiter.swift",
                 "icloud_storage_plus_foundation/ConflictResolver.swift",
                 "icloud_storage_plus_foundation/WriteEntrypointPreflight.swift",
+                "icloud_storage_plus_foundation/UbiquityContainerResolver.swift",
             ],
             resources: [
                 // If this plugin requires a privacy manifest (e.g. uses required

--- a/ios/icloud_storage_plus/Package.swift
+++ b/ios/icloud_storage_plus/Package.swift
@@ -28,6 +28,7 @@ let package = Package(
                 "icloud_storage_plus",
                 "icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift",
                 "icloud_storage_plus_foundation/DownloadWaiter.swift",
+                "icloud_storage_plus_foundation/MetadataQuerySession.swift",
                 "icloud_storage_plus_foundation/ConflictResolver.swift",
                 "icloud_storage_plus_foundation/WriteEntrypointPreflight.swift",
                 "icloud_storage_plus_foundation/UbiquityContainerResolver.swift",

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
@@ -102,6 +102,28 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     result(status)
   }
 
+  private func resolveContainerURL(
+    containerId: String,
+    operation: String,
+    relativePath: String? = nil,
+    result: @escaping FlutterResult,
+    onResolved: @escaping (URL) -> Void
+  ) {
+    Task { @MainActor [self] in
+      guard let containerURL = await ubiquityContainerResolver.resolve(
+        containerId: containerId
+      ) else {
+        result(containerAccessError(
+          operation: operation,
+          relativePath: relativePath
+        ))
+        return
+      }
+
+      onResolved(containerURL)
+    }
+  }
+
   /// Returns the filesystem path for the iCloud container.
   private func getContainerPath(_ call: FlutterMethodCall, _ result: @escaping FlutterResult){
     guard let args = call.arguments as? Dictionary<String, Any>,
@@ -110,14 +132,14 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       result(argumentError)
       return
     }
-    
-    guard let containerURL = FileManager.default.url(
-      forUbiquityContainerIdentifier: containerId
-    ) else {
-      result(containerAccessError(operation: "getContainerPath"))
-      return
+
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "getContainerPath",
+      result: result
+    ) { containerURL in
+      result(containerURL.path)
     }
-    result(containerURL.path)
   }
   
   /// Lists all items in the container using NSMetadataQuery.
@@ -536,85 +558,19 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
     
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(operation: "downloadFile", relativePath: cloudRelativePath))
-      return
-    }
-    DebugHelper.log("containerURL: \(containerURL.path)")
-    
-    let cloudFileURL = containerURL.appendingPathComponent(cloudRelativePath)
-    let localFileURL = URL(fileURLWithPath: localFilePath)
-    do {
-      try FileManager.default.startDownloadingUbiquitousItem(at: cloudFileURL)
-    } catch {
-      let mapped = mapFileNotFoundError(
-        error,
-        operation: "downloadFile",
-        relativePath: cloudRelativePath
-      ) ?? nativeCodeError(
-        error,
-        operation: "downloadFile",
-        relativePath: cloudRelativePath
-      )
-      result(mapped)
-      return
-    }
-    
-    let completionGate = CompletionGate()
-    let completeOnce: (Any?) -> Void = { value in
-      guard completionGate.tryComplete() else {
-        return
-      }
-      result(value)
-    }
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "downloadFile",
+      relativePath: cloudRelativePath,
+      result: result
+    ) { [self] containerURL in
+      DebugHelper.log("containerURL: \(containerURL.path)")
 
-    let query: NSMetadataQuery? = eventChannelName.isEmpty
-      ? nil
-      : {
-          let query = NSMetadataQuery()
-          query.operationQueue = .main
-          query.searchScopes = querySearchScopes
-          query.predicate = NSPredicate(
-            format: "%K == %@",
-            NSMetadataItemPathKey,
-            cloudFileURL.path
-          )
-          return query
-        }()
-
-    let downloadStreamHandler = registeredStreamHandler(for: eventChannelName)
-    downloadStreamHandler?.onCancelHandler = { [self] in
-      if let query {
-        removeObservers(query)
-        query.stop()
-      }
-      removeStreamHandler(eventChannelName)
-      completeOnce(
-        FlutterError(
-          code: "E_CANCEL",
-          message: "Download canceled",
-          details: nil
-        )
-      )
-    }
-
-    if let query {
-      addDownloadObservers(
-        query: query,
-        eventChannelName: eventChannelName
-      )
-      query.start()
-    }
-    if downloadStreamHandler != nil {
-      emitProgress(10.0, eventChannelName: eventChannelName)
-    }
-
-    readDocumentAt(url: cloudFileURL, destinationURL: localFileURL) { [self] error in
-      if completionGate.isCompleted {
-        return
-      }
-      if let error = error {
+      let cloudFileURL = containerURL.appendingPathComponent(cloudRelativePath)
+      let localFileURL = URL(fileURLWithPath: localFilePath)
+      do {
+        try FileManager.default.startDownloadingUbiquitousItem(at: cloudFileURL)
+      } catch {
         let mapped = mapFileNotFoundError(
           error,
           operation: "downloadFile",
@@ -624,25 +580,94 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           operation: "downloadFile",
           relativePath: cloudRelativePath
         )
-        downloadStreamHandler?.setEvent(mapped)
+        result(mapped)
+        return
+      }
+
+      let completionGate = CompletionGate()
+      let completeOnce: (Any?) -> Void = { value in
+        guard completionGate.tryComplete() else {
+          return
+        }
+        result(value)
+      }
+
+      let query: NSMetadataQuery? = eventChannelName.isEmpty
+        ? nil
+        : {
+            let query = NSMetadataQuery()
+            query.operationQueue = .main
+            query.searchScopes = querySearchScopes
+            query.predicate = NSPredicate(
+              format: "%K == %@",
+              NSMetadataItemPathKey,
+              cloudFileURL.path
+            )
+            return query
+          }()
+
+      let downloadStreamHandler = registeredStreamHandler(for: eventChannelName)
+      downloadStreamHandler?.onCancelHandler = { [self] in
+        if let query {
+          removeObservers(query)
+          query.stop()
+        }
+        removeStreamHandler(eventChannelName)
+        completeOnce(
+          FlutterError(
+            code: "E_CANCEL",
+            message: "Download canceled",
+            details: nil
+          )
+        )
+      }
+
+      if let query {
+        addDownloadObservers(
+          query: query,
+          eventChannelName: eventChannelName
+        )
+        query.start()
+      }
+      if downloadStreamHandler != nil {
+        emitProgress(10.0, eventChannelName: eventChannelName)
+      }
+
+      readDocumentAt(url: cloudFileURL, destinationURL: localFileURL) {
+        [self] error in
+        if completionGate.isCompleted {
+          return
+        }
+        if let error = error {
+          let mapped = mapFileNotFoundError(
+            error,
+            operation: "downloadFile",
+            relativePath: cloudRelativePath
+          ) ?? nativeCodeError(
+            error,
+            operation: "downloadFile",
+            relativePath: cloudRelativePath
+          )
+          downloadStreamHandler?.setEvent(mapped)
+          downloadStreamHandler?.setEvent(FlutterEndOfEventStream)
+          if let query {
+            removeObservers(query)
+            query.stop()
+          }
+          removeStreamHandler(eventChannelName)
+          completeOnce(mapped)
+          return
+        }
+
+        emitProgress(100.0, eventChannelName: eventChannelName)
         downloadStreamHandler?.setEvent(FlutterEndOfEventStream)
         if let query {
           removeObservers(query)
           query.stop()
         }
         removeStreamHandler(eventChannelName)
-        completeOnce(mapped)
-        return
+        completeOnce(nil)
       }
-
-      emitProgress(100.0, eventChannelName: eventChannelName)
-      downloadStreamHandler?.setEvent(FlutterEndOfEventStream)
-      if let query {
-        removeObservers(query)
-        query.stop()
-      }
-      removeStreamHandler(eventChannelName)
-      completeOnce(nil)
     }
   }
 
@@ -661,71 +686,71 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     let retryBackoff = (args["retryBackoffSeconds"] as? [NSNumber])?
       .map { $0.doubleValue } ?? []
 
-    guard let containerURL = FileManager.default.url(
-      forUbiquityContainerIdentifier: containerId
-    ) else {
-      result(containerAccessError(operation: "readInPlace", relativePath: relativePath))
-      return
-    }
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "readInPlace",
+      relativePath: relativePath,
+      result: result
+    ) { [self] containerURL in
+      let fileURL = containerURL.appendingPathComponent(relativePath)
 
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-
-    do {
-      try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
-    } catch {
-      let mapped = mapFileNotFoundError(
-        error,
-        operation: "readInPlace",
-        relativePath: relativePath
-      ) ?? nativeCodeError(
-        error,
-        operation: "readInPlace",
-        relativePath: relativePath
-      )
-      result(mapped)
-      return
-    }
-
-    Task { @MainActor [self] in
       do {
-        try await waitForDownloadCompletion(
-          at: fileURL,
-          idleTimeouts: idleTimeouts,
-          retryBackoff: retryBackoff
-        )
+        try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
       } catch {
-        if let timeoutError = mapTimeoutError(
+        let mapped = mapFileNotFoundError(
           error,
           operation: "readInPlace",
           relativePath: relativePath
-        ) {
-          result(timeoutError)
-          return
-        }
-        result(nativeCodeError(
+        ) ?? nativeCodeError(
           error,
           operation: "readInPlace",
           relativePath: relativePath
-        ))
+        )
+        result(mapped)
         return
       }
 
-      readInPlaceDocument(at: fileURL) { [self] contents, error in
-        if let error = error {
-          let mapped = mapFileNotFoundError(
-            error,
-            operation: "readInPlace",
-            relativePath: relativePath
-          ) ?? nativeCodeError(
-            error,
-            operation: "readInPlace",
-            relativePath: relativePath
+      Task { @MainActor [self] in
+        do {
+          try await waitForDownloadCompletion(
+            at: fileURL,
+            idleTimeouts: idleTimeouts,
+            retryBackoff: retryBackoff
           )
-          result(mapped)
+        } catch {
+          if let timeoutError = mapTimeoutError(
+            error,
+            operation: "readInPlace",
+            relativePath: relativePath
+          ) {
+            result(timeoutError)
+            return
+          }
+          result(nativeCodeError(
+            error,
+            operation: "readInPlace",
+            relativePath: relativePath
+          ))
           return
         }
 
-        result(contents)
+        readInPlaceDocument(at: fileURL) { [self] contents, error in
+          if let error = error {
+            let mapped = mapFileNotFoundError(
+              error,
+              operation: "readInPlace",
+              relativePath: relativePath
+            ) ?? nativeCodeError(
+              error,
+              operation: "readInPlace",
+              relativePath: relativePath
+            )
+            result(mapped)
+            return
+          }
+
+          result(contents)
+        }
       }
     }
   }
@@ -795,73 +820,74 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     let retryBackoff = (args["retryBackoffSeconds"] as? [NSNumber])?
       .map { $0.doubleValue } ?? []
 
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(operation: "readInPlaceBytes", relativePath: relativePath))
-      return
-    }
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "readInPlaceBytes",
+      relativePath: relativePath,
+      result: result
+    ) { [self] containerURL in
+      let fileURL = containerURL.appendingPathComponent(relativePath)
 
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-
-    do {
-      try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
-    } catch {
-      let mapped = mapFileNotFoundError(
-        error,
-        operation: "readInPlaceBytes",
-        relativePath: relativePath
-      ) ?? nativeCodeError(
-        error,
-        operation: "readInPlaceBytes",
-        relativePath: relativePath
-      )
-      result(mapped)
-      return
-    }
-
-    Task { @MainActor [self] in
       do {
-        try await waitForDownloadCompletion(
-          at: fileURL,
-          idleTimeouts: idleTimeouts,
-          retryBackoff: retryBackoff
-        )
+        try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
       } catch {
-        if let timeoutError = mapTimeoutError(
+        let mapped = mapFileNotFoundError(
           error,
           operation: "readInPlaceBytes",
           relativePath: relativePath
-        ) {
-          result(timeoutError)
-          return
-        }
-        result(nativeCodeError(
+        ) ?? nativeCodeError(
           error,
           operation: "readInPlaceBytes",
           relativePath: relativePath
-        ))
+        )
+        result(mapped)
         return
       }
 
-      readInPlaceBinaryDocument(at: fileURL) { [self] contents, error in
-        if let error = error {
-          let mapped = mapFileNotFoundError(
-            error,
-            operation: "readInPlaceBytes",
-            relativePath: relativePath
-          ) ?? nativeCodeError(
-            error,
-            operation: "readInPlaceBytes",
-            relativePath: relativePath
+      Task { @MainActor [self] in
+        do {
+          try await waitForDownloadCompletion(
+            at: fileURL,
+            idleTimeouts: idleTimeouts,
+            retryBackoff: retryBackoff
           )
-          result(mapped)
+        } catch {
+          if let timeoutError = mapTimeoutError(
+            error,
+            operation: "readInPlaceBytes",
+            relativePath: relativePath
+          ) {
+            result(timeoutError)
+            return
+          }
+          result(nativeCodeError(
+            error,
+            operation: "readInPlaceBytes",
+            relativePath: relativePath
+          ))
           return
         }
 
-        if let contents {
-          result(FlutterStandardTypedData(bytes: contents))
-        } else {
-          result(nil)
+        readInPlaceBinaryDocument(at: fileURL) { [self] contents, error in
+          if let error = error {
+            let mapped = mapFileNotFoundError(
+              error,
+              operation: "readInPlaceBytes",
+              relativePath: relativePath
+            ) ?? nativeCodeError(
+              error,
+              operation: "readInPlaceBytes",
+              relativePath: relativePath
+            )
+            result(mapped)
+            return
+          }
+
+          if let contents {
+            result(FlutterStandardTypedData(bytes: contents))
+          } else {
+            result(nil)
+          }
         }
       }
     }
@@ -968,14 +994,15 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
     
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(operation: "documentExists", relativePath: relativePath))
-      return
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "documentExists",
+      relativePath: relativePath,
+      result: result
+    ) { containerURL in
+      let fileURL = containerURL.appendingPathComponent(relativePath)
+      result(FileManager.default.fileExists(atPath: fileURL.path))
     }
-
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-    result(FileManager.default.fileExists(atPath: fileURL.path))
   }
   
   /// Get file or directory metadata without downloading content.
@@ -989,38 +1016,43 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
     
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(operation: "getDocumentMetadata", relativePath: relativePath))
-      return
-    }
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "getDocumentMetadata",
+      relativePath: relativePath,
+      result: result
+    ) { [self] containerURL in
+      let fileURL = containerURL.appendingPathComponent(relativePath)
+      guard FileManager.default.fileExists(atPath: fileURL.path) else {
+        result(nil)
+        return
+      }
 
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-    guard FileManager.default.fileExists(atPath: fileURL.path) else {
-      result(nil)
-      return
-    }
-
-    do {
-      let values = try fileURL.resourceValues(forKeys: [
-        .isDirectoryKey,
-        .fileSizeKey,
-        .creationDateKey,
-        .contentModificationDateKey,
-        .ubiquitousItemDownloadingStatusKey,
-        .ubiquitousItemIsDownloadingKey,
-        .ubiquitousItemIsUploadedKey,
-        .ubiquitousItemIsUploadingKey,
-        .ubiquitousItemHasUnresolvedConflictsKey,
-      ])
-      let containerPath = containerURL.standardizedFileURL.path
-      result(mapResourceValues(
-        fileURL: fileURL,
-        values: values,
-        containerPath: containerPath
-      ))
-    } catch {
-      result(nativeCodeError(error, operation: "getDocumentMetadata", relativePath: relativePath))
+      do {
+        let values = try fileURL.resourceValues(forKeys: [
+          .isDirectoryKey,
+          .fileSizeKey,
+          .creationDateKey,
+          .contentModificationDateKey,
+          .ubiquitousItemDownloadingStatusKey,
+          .ubiquitousItemIsDownloadingKey,
+          .ubiquitousItemIsUploadedKey,
+          .ubiquitousItemIsUploadingKey,
+          .ubiquitousItemHasUnresolvedConflictsKey,
+        ])
+        let containerPath = containerURL.standardizedFileURL.path
+        result(mapResourceValues(
+          fileURL: fileURL,
+          values: values,
+          containerPath: containerPath
+        ))
+      } catch {
+        result(nativeCodeError(
+          error,
+          operation: "getDocumentMetadata",
+          relativePath: relativePath
+        ))
+      }
     }
   }
 
@@ -1038,50 +1070,47 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
-    guard let containerURL = FileManager.default.url(
-      forUbiquityContainerIdentifier: containerId
-    ) else {
-      result(containerAccessError(
-        operation: "getItemMetadata",
-        relativePath: relativePath
-      ))
-      return
-    }
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "getItemMetadata",
+      relativePath: relativePath,
+      result: result
+    ) { [self] containerURL in
+      let fileURL = containerURL.appendingPathComponent(relativePath)
+      guard FileManager.default.fileExists(atPath: fileURL.path) else {
+        result(nil)
+        return
+      }
 
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-    guard FileManager.default.fileExists(atPath: fileURL.path) else {
-      result(nil)
-      return
-    }
-
-    do {
-      let values = try fileURL.resourceValues(forKeys: [
-        .isDirectoryKey,
-        .fileSizeKey,
-        .creationDateKey,
-        .contentModificationDateKey,
-        .ubiquitousItemDownloadingStatusKey,
-        .ubiquitousItemIsDownloadingKey,
-        .ubiquitousItemIsUploadedKey,
-        .ubiquitousItemIsUploadingKey,
-        .ubiquitousItemHasUnresolvedConflictsKey,
-      ])
-      let containerPath = containerURL.standardizedFileURL.path
-      var metadata = mapResourceValues(
-        fileURL: fileURL,
-        values: values,
-        containerPath: containerPath
-      )
-      metadata["downloadStatus"] = normalizeDownloadStatus(
-        values.ubiquitousItemDownloadingStatus
-      ) ?? values.ubiquitousItemDownloadingStatus?.rawValue
-      result(metadata)
-    } catch {
-      result(nativeCodeError(
-        error,
-        operation: "getItemMetadata",
-        relativePath: relativePath
-      ))
+      do {
+        let values = try fileURL.resourceValues(forKeys: [
+          .isDirectoryKey,
+          .fileSizeKey,
+          .creationDateKey,
+          .contentModificationDateKey,
+          .ubiquitousItemDownloadingStatusKey,
+          .ubiquitousItemIsDownloadingKey,
+          .ubiquitousItemIsUploadedKey,
+          .ubiquitousItemIsUploadingKey,
+          .ubiquitousItemHasUnresolvedConflictsKey,
+        ])
+        let containerPath = containerURL.standardizedFileURL.path
+        var metadata = mapResourceValues(
+          fileURL: fileURL,
+          values: values,
+          containerPath: containerPath
+        )
+        metadata["downloadStatus"] = normalizeDownloadStatus(
+          values.ubiquitousItemDownloadingStatus
+        ) ?? values.ubiquitousItemDownloadingStatus?.rawValue
+        result(metadata)
+      } catch {
+        result(nativeCodeError(
+          error,
+          operation: "getItemMetadata",
+          relativePath: relativePath
+        ))
+      }
     }
   }
 
@@ -1104,87 +1133,87 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
 
     let subdir = args["relativePath"] as? String
 
-    guard let containerURL = FileManager.default
-      .url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(operation: "listContents", relativePath: subdir))
-      return
-    }
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "listContents",
+      relativePath: subdir,
+      result: result
+    ) { [self] containerURL in
+      let listURL = subdir != nil
+        ? containerURL.appendingPathComponent(subdir!)
+        : containerURL
 
-    let listURL = subdir != nil
-      ? containerURL.appendingPathComponent(subdir!)
-      : containerURL
+      let keys: [URLResourceKey] = [
+        .isDirectoryKey,
+        .ubiquitousItemDownloadingStatusKey,
+        .ubiquitousItemIsDownloadingKey,
+        .ubiquitousItemIsUploadedKey,
+        .ubiquitousItemIsUploadingKey,
+        .ubiquitousItemHasUnresolvedConflictsKey,
+      ]
 
-    let keys: [URLResourceKey] = [
-      .isDirectoryKey,
-      .ubiquitousItemDownloadingStatusKey,
-      .ubiquitousItemIsDownloadingKey,
-      .ubiquitousItemIsUploadedKey,
-      .ubiquitousItemIsUploadingKey,
-      .ubiquitousItemHasUnresolvedConflictsKey,
-    ]
-
-    DispatchQueue.global(qos: .userInitiated).async {
-      do {
-        let contents = try FileManager.default.contentsOfDirectory(
-          at: listURL,
-          includingPropertiesForKeys: keys,
-          // Do NOT use .skipsHiddenFiles — iCloud placeholders
-          // have a leading dot and would be filtered out.
-          options: []
-        )
-
-        let containerPath = containerURL.standardizedFileURL.path
-        let keysSet = Set(keys)
-        let parentRelative = self.relativePath(
-          for: listURL, containerPath: containerPath
-        )
-        var items: [[String: Any?]] = []
-
-        for fileURL in contents {
-          let diskName = fileURL.lastPathComponent
-          let resolvedName = self.resolveICloudPlaceholderName(diskName)
-
-          // Skip system hidden files (.DS_Store, .Trash, etc.).
-          // Placeholder files (.foo.icloud) have already been resolved
-          // to their real name, so they pass through this filter.
-          if resolvedName.hasPrefix(".") { continue }
-
-          let values = try fileURL.resourceValues(
-            forKeys: keysSet
+      DispatchQueue.global(qos: .userInitiated).async {
+        do {
+          let contents = try FileManager.default.contentsOfDirectory(
+            at: listURL,
+            includingPropertiesForKeys: keys,
+            // Do NOT use .skipsHiddenFiles — iCloud placeholders
+            // have a leading dot and would be filtered out.
+            options: []
           )
 
-          // Build relative path from the container root so the
-          // result is usable with other plugin methods.
-          let itemRelativePath = parentRelative.isEmpty
-            ? resolvedName
-            : parentRelative + "/" + resolvedName
+          let containerPath = containerURL.standardizedFileURL.path
+          let keysSet = Set(keys)
+          let parentRelative = self.relativePath(
+            for: listURL, containerPath: containerPath
+          )
+          var items: [[String: Any?]] = []
 
-          items.append([
-            "relativePath": itemRelativePath,
-            "isDirectory": values.isDirectory ?? false,
-            "downloadStatus": self.normalizeDownloadStatus(
-              values.ubiquitousItemDownloadingStatus
-            ),
-            "isDownloading":
-              values.ubiquitousItemIsDownloading ?? false,
-            "isUploaded":
-              values.ubiquitousItemIsUploaded ?? false,
-            "isUploading":
-              values.ubiquitousItemIsUploading ?? false,
-            "hasUnresolvedConflicts":
-              values.ubiquitousItemHasUnresolvedConflicts ?? false,
-          ])
-        }
+          for fileURL in contents {
+            let diskName = fileURL.lastPathComponent
+            let resolvedName = self.resolveICloudPlaceholderName(diskName)
 
-        DispatchQueue.main.async { result(items) }
-      } catch {
-        DispatchQueue.main.async {
-          result(self.nativeCodeError(
-            error,
-            operation: "listContents",
-            relativePath: subdir
-          ))
+            // Skip system hidden files (.DS_Store, .Trash, etc.).
+            // Placeholder files (.foo.icloud) have already been resolved
+            // to their real name, so they pass through this filter.
+            if resolvedName.hasPrefix(".") { continue }
+
+            let values = try fileURL.resourceValues(
+              forKeys: keysSet
+            )
+
+            // Build relative path from the container root so the
+            // result is usable with other plugin methods.
+            let itemRelativePath = parentRelative.isEmpty
+              ? resolvedName
+              : parentRelative + "/" + resolvedName
+
+            items.append([
+              "relativePath": itemRelativePath,
+              "isDirectory": values.isDirectory ?? false,
+              "downloadStatus": self.normalizeDownloadStatus(
+                values.ubiquitousItemDownloadingStatus
+              ),
+              "isDownloading":
+                values.ubiquitousItemIsDownloading ?? false,
+              "isUploaded":
+                values.ubiquitousItemIsUploaded ?? false,
+              "isUploading":
+                values.ubiquitousItemIsUploading ?? false,
+              "hasUnresolvedConflicts":
+                values.ubiquitousItemHasUnresolvedConflicts ?? false,
+            ])
+          }
+
+          DispatchQueue.main.async { result(items) }
+        } catch {
+          DispatchQueue.main.async {
+            result(self.nativeCodeError(
+              error,
+              operation: "listContents",
+              relativePath: subdir
+            ))
+          }
         }
       }
     }
@@ -1243,40 +1272,42 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
     
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(operation: "delete", relativePath: relativePath))
-      return
-    }
-    DebugHelper.log("containerURL: \(containerURL.path)")
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "delete",
+      relativePath: relativePath,
+      result: result
+    ) { [self] containerURL in
+      DebugHelper.log("containerURL: \(containerURL.path)")
 
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-    guard FileManager.default.fileExists(atPath: fileURL.path) else {
-      result(itemNotFoundError(operation: "delete", relativePath: relativePath))
-      return
-    }
+      let fileURL = containerURL.appendingPathComponent(relativePath)
+      guard FileManager.default.fileExists(atPath: fileURL.path) else {
+        result(itemNotFoundError(operation: "delete", relativePath: relativePath))
+        return
+      }
 
-    let fileCoordinator = NSFileCoordinator(filePresenter: nil)
-    fileCoordinator.coordinate(
-      writingItemAt: fileURL,
-      options: NSFileCoordinator.WritingOptions.forDeleting,
-      error: nil
-    ) { writingURL in
-      do {
-        try FileManager.default.removeItem(at: writingURL)
-        result(nil)
-      } catch {
-        DebugHelper.log("error: \(error.localizedDescription)")
-        let mapped = mapFileNotFoundError(
-          error,
-          operation: "delete",
-          relativePath: relativePath
-        ) ?? nativeCodeError(
-          error,
-          operation: "delete",
-          relativePath: relativePath
-        )
-        result(mapped)
+      let fileCoordinator = NSFileCoordinator(filePresenter: nil)
+      fileCoordinator.coordinate(
+        writingItemAt: fileURL,
+        options: NSFileCoordinator.WritingOptions.forDeleting,
+        error: nil
+      ) { writingURL in
+        do {
+          try FileManager.default.removeItem(at: writingURL)
+          result(nil)
+        } catch {
+          DebugHelper.log("error: \(error.localizedDescription)")
+          let mapped = mapFileNotFoundError(
+            error,
+            operation: "delete",
+            relativePath: relativePath
+          ) ?? nativeCodeError(
+            error,
+            operation: "delete",
+            relativePath: relativePath
+          )
+          result(mapped)
+        }
       }
     }
   }
@@ -1292,46 +1323,48 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
     
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(operation: "move", relativePath: atRelativePath))
-      return
-    }
-    DebugHelper.log("containerURL: \(containerURL.path)")
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "move",
+      relativePath: atRelativePath,
+      result: result
+    ) { [self] containerURL in
+      DebugHelper.log("containerURL: \(containerURL.path)")
 
-    let atURL = containerURL.appendingPathComponent(atRelativePath)
-    guard FileManager.default.fileExists(atPath: atURL.path) else {
-      result(itemNotFoundError(operation: "move", relativePath: atRelativePath))
-      return
-    }
+      let atURL = containerURL.appendingPathComponent(atRelativePath)
+      guard FileManager.default.fileExists(atPath: atURL.path) else {
+        result(itemNotFoundError(operation: "move", relativePath: atRelativePath))
+        return
+      }
 
-    let toURL = containerURL.appendingPathComponent(toRelativePath)
-    let fileCoordinator = NSFileCoordinator(filePresenter: nil)
-    fileCoordinator.coordinate(
-      writingItemAt: atURL,
-      options: NSFileCoordinator.WritingOptions.forMoving,
-      writingItemAt: toURL,
-      options: NSFileCoordinator.WritingOptions.forReplacing,
-      error: nil
-    ) { atWritingURL, toWritingURL in
-      do {
-        let toDirURL = toWritingURL.deletingLastPathComponent()
-        if !FileManager.default.fileExists(atPath: toDirURL.path) {
-          try FileManager.default.createDirectory(
-            at: toDirURL,
-            withIntermediateDirectories: true,
-            attributes: nil
-          )
+      let toURL = containerURL.appendingPathComponent(toRelativePath)
+      let fileCoordinator = NSFileCoordinator(filePresenter: nil)
+      fileCoordinator.coordinate(
+        writingItemAt: atURL,
+        options: NSFileCoordinator.WritingOptions.forMoving,
+        writingItemAt: toURL,
+        options: NSFileCoordinator.WritingOptions.forReplacing,
+        error: nil
+      ) { atWritingURL, toWritingURL in
+        do {
+          let toDirURL = toWritingURL.deletingLastPathComponent()
+          if !FileManager.default.fileExists(atPath: toDirURL.path) {
+            try FileManager.default.createDirectory(
+              at: toDirURL,
+              withIntermediateDirectories: true,
+              attributes: nil
+            )
+          }
+          try FileManager.default.moveItem(at: atWritingURL, to: toWritingURL)
+          result(nil)
+        } catch {
+          DebugHelper.log("error: \(error.localizedDescription)")
+          result(nativeCodeError(
+            error,
+            operation: "move",
+            relativePath: atRelativePath
+          ))
         }
-        try FileManager.default.moveItem(at: atWritingURL, to: toWritingURL)
-        result(nil)
-      } catch {
-        DebugHelper.log("error: \(error.localizedDescription)")
-        result(nativeCodeError(
-          error,
-          operation: "move",
-          relativePath: atRelativePath
-        ))
       }
     }
   }
@@ -1347,110 +1380,112 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
     
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(operation: "copy", relativePath: fromRelativePath))
-      return
-    }
-    DebugHelper.log("containerURL: \(containerURL.path)")
-    
-    let fromURL = containerURL.appendingPathComponent(fromRelativePath)
-    guard FileManager.default.fileExists(atPath: fromURL.path) else {
-      result(itemNotFoundError(operation: "copy", relativePath: fromRelativePath))
-      return
-    }
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "copy",
+      relativePath: fromRelativePath,
+      result: result
+    ) { [self] containerURL in
+      DebugHelper.log("containerURL: \(containerURL.path)")
 
-    let toURL = containerURL.appendingPathComponent(toRelativePath)
-    let fileCoordinator = NSFileCoordinator(filePresenter: nil)
-    var handledExistingDestination = false
-    var overwriteError: Error?
-    var sourceCoordinationError: NSError?
-
-    fileCoordinator.coordinate(
-      readingItemAt: fromURL,
-      options: .withoutChanges,
-      error: &sourceCoordinationError
-    ) { fromReadingURL in
-      do {
-        handledExistingDestination = try copyOverwritingExistingItem(
-          from: fromReadingURL,
-          to: toURL
-        )
-      } catch {
-        overwriteError = error
+      let fromURL = containerURL.appendingPathComponent(fromRelativePath)
+      guard FileManager.default.fileExists(atPath: fromURL.path) else {
+        result(itemNotFoundError(operation: "copy", relativePath: fromRelativePath))
+        return
       }
-    }
 
-    if let sourceCoordinationError {
-      DebugHelper.log("copy source coordination error: \(sourceCoordinationError.localizedDescription)")
-      result(nativeCodeError(
-        sourceCoordinationError,
-        operation: "copy",
-        relativePath: fromRelativePath
-      ))
-      return
-    }
+      let toURL = containerURL.appendingPathComponent(toRelativePath)
+      let fileCoordinator = NSFileCoordinator(filePresenter: nil)
+      var handledExistingDestination = false
+      var overwriteError: Error?
+      var sourceCoordinationError: NSError?
 
-    if let overwriteError {
-      DebugHelper.log("copy error: \(overwriteError.localizedDescription)")
-      result(nativeCodeError(
-        overwriteError,
-        operation: "copy",
-        relativePath: toRelativePath
-      ))
-      return
-    }
-
-    if handledExistingDestination {
-      result(nil)
-      return
-    }
-
-    // Use reading coordination for source and writing coordination for destination
-    var copyCoordinationError: NSError?
-    fileCoordinator.coordinate(
-      readingItemAt: fromURL,
-      options: .withoutChanges,
-      writingItemAt: toURL,
-      options: .forReplacing,
-      error: &copyCoordinationError
-    ) { fromReadingURL, toWritingURL in
-      do {
-        // Create destination directory if needed
-        let toDirURL = toWritingURL.deletingLastPathComponent()
-        if !FileManager.default.fileExists(atPath: toDirURL.path) {
-          try FileManager.default.createDirectory(
-            at: toDirURL,
-            withIntermediateDirectories: true,
-            attributes: nil
+      fileCoordinator.coordinate(
+        readingItemAt: fromURL,
+        options: .withoutChanges,
+        error: &sourceCoordinationError
+      ) { fromReadingURL in
+        do {
+          handledExistingDestination = try copyOverwritingExistingItem(
+            from: fromReadingURL,
+            to: toURL
           )
+        } catch {
+          overwriteError = error
         }
+      }
 
-        // Remove destination file if it exists
-        if FileManager.default.fileExists(atPath: toWritingURL.path) {
-          try FileManager.default.removeItem(at: toWritingURL)
-        }
-
-        // Copy the file
-        try FileManager.default.copyItem(at: fromReadingURL, to: toWritingURL)
-        result(nil)
-      } catch {
-        DebugHelper.log("copy error: \(error.localizedDescription)")
+      if let sourceCoordinationError {
+        DebugHelper.log("copy source coordination error: \(sourceCoordinationError.localizedDescription)")
         result(nativeCodeError(
-          error,
+          sourceCoordinationError,
+          operation: "copy",
+          relativePath: fromRelativePath
+        ))
+        return
+      }
+
+      if let overwriteError {
+        DebugHelper.log("copy error: \(overwriteError.localizedDescription)")
+        result(nativeCodeError(
+          overwriteError,
+          operation: "copy",
+          relativePath: toRelativePath
+        ))
+        return
+      }
+
+      if handledExistingDestination {
+        result(nil)
+        return
+      }
+
+      // Use reading coordination for source and writing coordination for destination
+      var copyCoordinationError: NSError?
+      fileCoordinator.coordinate(
+        readingItemAt: fromURL,
+        options: .withoutChanges,
+        writingItemAt: toURL,
+        options: .forReplacing,
+        error: &copyCoordinationError
+      ) { fromReadingURL, toWritingURL in
+        do {
+          // Create destination directory if needed
+          let toDirURL = toWritingURL.deletingLastPathComponent()
+          if !FileManager.default.fileExists(atPath: toDirURL.path) {
+            try FileManager.default.createDirectory(
+              at: toDirURL,
+              withIntermediateDirectories: true,
+              attributes: nil
+            )
+          }
+
+          // Remove destination file if it exists
+          if FileManager.default.fileExists(atPath: toWritingURL.path) {
+            try FileManager.default.removeItem(at: toWritingURL)
+          }
+
+          // Copy the file
+          try FileManager.default.copyItem(at: fromReadingURL, to: toWritingURL)
+          result(nil)
+        } catch {
+          DebugHelper.log("copy error: \(error.localizedDescription)")
+          result(nativeCodeError(
+            error,
+            operation: "copy",
+            relativePath: toRelativePath
+          ))
+        }
+      }
+
+      if let copyCoordinationError {
+        DebugHelper.log("copy coordination error: \(copyCoordinationError.localizedDescription)")
+        result(nativeCodeError(
+          copyCoordinationError,
           operation: "copy",
           relativePath: toRelativePath
         ))
       }
-    }
-
-    if let copyCoordinationError {
-      DebugHelper.log("copy coordination error: \(copyCoordinationError.localizedDescription)")
-      result(nativeCodeError(
-        copyCoordinationError,
-        operation: "copy",
-        relativePath: toRelativePath
-      ))
     }
   }
 

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
@@ -10,9 +10,11 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     label: "icloud_storage_plus.stream_state"
   )
   let querySearchScopes = iCloudMetadataQuerySearchScopes
-  private var queryObservers: [ObjectIdentifier: [NSObjectProtocol]] = [:]
-  private let queryObserversQueue = DispatchQueue(
-    label: "icloud_storage_plus.query_observers"
+  private var metadataQuerySessions: [
+    MetadataQuerySession.ID: MetadataQuerySession
+  ] = [:]
+  private let metadataQuerySessionsQueue = DispatchQueue(
+    label: "icloud_storage_plus.metadata_query_sessions"
   )
   private let metadataQueryOperationQueue: OperationQueue = {
     let queue = OperationQueue()
@@ -28,6 +30,15 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   ) {
     self.ubiquityContainerResolver = ubiquityContainerResolver
     super.init()
+  }
+
+  deinit {
+    let sessions = metadataQuerySessionsQueue.sync {
+      Array(metadataQuerySessions.values)
+    }
+    for session in sessions {
+      session.cancel()
+    }
   }
 
   /// Registers the plugin with the Flutter registrar.
@@ -189,30 +200,38 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     query.operationQueue = metadataQueryOperationQueue
     query.searchScopes = querySearchScopes
     query.predicate = NSPredicate(format: "%K beginswith %@", NSMetadataItemPathKey, containerURL.path)
-    addGatherFilesObservers(query: query, containerURL: containerURL, eventChannelName: eventChannelName, result: result)
+    let session = makeMetadataQuerySession(query: query)
+    addGatherFilesObservers(
+      session: session,
+      containerURL: containerURL,
+      eventChannelName: eventChannelName,
+      result: result
+    )
 
     if let streamHandler {
-      streamHandler.onCancelHandler = { [self] in
-        removeObservers(query)
-        query.stop()
-        removeStreamHandler(eventChannelName)
+      streamHandler.onCancelHandler = { [weak self, weak session] in
+        session?.cancel()
+        self?.removeStreamHandler(eventChannelName)
       }
     }
-    query.start()
+    session.start()
   }
   
   /// Adds observers for metadata gather and update notifications.
-  private func addGatherFilesObservers(query: NSMetadataQuery, containerURL: URL, eventChannelName: String, result: @escaping FlutterResult) {
-    addObserver(
-      for: query,
+  private func addGatherFilesObservers(session: MetadataQuerySession, containerURL: URL, eventChannelName: String, result: @escaping FlutterResult) {
+    session.addObserver(
       name: NSNotification.Name.NSMetadataQueryDidFinishGathering
-    ) { [self] _ in
+    ) { [weak self] session, query, _ in
+      guard let self else { return }
       query.disableUpdates()
-      defer { query.enableUpdates() }
+      defer {
+        if !session.isCancelled {
+          query.enableUpdates()
+        }
+      }
       let files = mapFileAttributesFromQuery(query: query, containerURL: containerURL)
       if eventChannelName.isEmpty {
-        removeObservers(query)
-        query.stop()
+        session.cancel()
       }
       DispatchQueue.main.async {
         result(files)
@@ -220,17 +239,21 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     }
     
     if !eventChannelName.isEmpty {
-      addObserver(
-        for: query,
+      session.addObserver(
         name: NSNotification.Name.NSMetadataQueryDidUpdate
-      ) { [self] _ in
+      ) { [weak self] session, query, _ in
+        guard let self else { return }
         let hasStreamHandler = hasStreamHandler(named: eventChannelName)
         guard hasStreamHandler else {
           return
         }
 
         query.disableUpdates()
-        defer { query.enableUpdates() }
+        defer {
+          if !session.isCancelled {
+            query.enableUpdates()
+          }
+        }
         let files = mapFileAttributesFromQuery(query: query, containerURL: containerURL)
         DispatchQueue.main.async {
           guard let streamHandler = self.registeredStreamHandler(
@@ -441,49 +464,52 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     query.operationQueue = .main
     query.searchScopes = querySearchScopes
     query.predicate = NSPredicate(format: "%K == %@", NSMetadataItemPathKey, cloudFileURL.path)
+    let session = makeMetadataQuerySession(query: query)
 
     guard let uploadStreamHandler = registeredStreamHandler(
       for: eventChannelName
     ) else {
+      session.cancel()
       return
     }
     emitProgress(10.0, eventChannelName: eventChannelName)
-    uploadStreamHandler.onCancelHandler = { [self] in
-      removeObservers(query)
-      query.stop()
-      removeStreamHandler(eventChannelName)
+    uploadStreamHandler.onCancelHandler = { [weak self, weak session] in
+      session?.cancel()
+      self?.removeStreamHandler(eventChannelName)
     }
     addUploadObservers(
-      query: query,
+      session: session,
       cloudRelativePath: cloudRelativePath,
       eventChannelName: eventChannelName
     )
 
-    query.start()
+    session.start()
   }
   
   /// Adds observers for upload progress updates.
   private func addUploadObservers(
-    query: NSMetadataQuery,
+    session: MetadataQuerySession,
     cloudRelativePath: String,
     eventChannelName: String
   ) {
-    addObserver(
-      for: query,
+    session.addObserver(
       name: NSNotification.Name.NSMetadataQueryDidFinishGathering
-    ) { [self] _ in
+    ) { [weak self] session, query, _ in
+      guard let self else { return }
       onUploadQueryNotification(
+        session: session,
         query: query,
         cloudRelativePath: cloudRelativePath,
         eventChannelName: eventChannelName
       )
     }
     
-    addObserver(
-      for: query,
+    session.addObserver(
       name: NSNotification.Name.NSMetadataQueryDidUpdate
-    ) { [self] _ in
+    ) { [weak self] session, query, _ in
+      guard let self else { return }
       onUploadQueryNotification(
+        session: session,
         query: query,
         cloudRelativePath: cloudRelativePath,
         eventChannelName: eventChannelName
@@ -493,11 +519,12 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   
   /// Emits upload progress updates to the event channel.
   private func onUploadQueryNotification(
+    session: MetadataQuerySession,
     query: NSMetadataQuery,
     cloudRelativePath: String,
     eventChannelName: String
   ) {
-    if !query.isStarted {
+    if session.isCancelled || !query.isStarted {
       return
     }
 
@@ -524,8 +551,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
         relativePath: cloudRelativePath
       ))
       streamHandler.setEvent(FlutterEndOfEventStream)
-      removeObservers(query)
-      query.stop()
+      session.cancel()
       removeStreamHandler(eventChannelName)
       return
     }
@@ -539,8 +565,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           return
         }
         streamHandler.setEvent(FlutterEndOfEventStream)
-        removeObservers(query)
-        query.stop()
+        session.cancel()
         removeStreamHandler(eventChannelName)
       }
     }
@@ -592,7 +617,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
         result(value)
       }
 
-      let query: NSMetadataQuery? = eventChannelName.isEmpty
+      let downloadSession: MetadataQuerySession? = eventChannelName.isEmpty
         ? nil
         : {
             let query = NSMetadataQuery()
@@ -603,31 +628,31 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
               NSMetadataItemPathKey,
               cloudFileURL.path
             )
-            return query
+            return makeMetadataQuerySession(query: query)
           }()
 
       let downloadStreamHandler = registeredStreamHandler(for: eventChannelName)
-      downloadStreamHandler?.onCancelHandler = { [self] in
-        if let query {
-          removeObservers(query)
-          query.stop()
-        }
-        removeStreamHandler(eventChannelName)
-        completeOnce(
-          FlutterError(
-            code: "E_CANCEL",
-            message: "Download canceled",
-            details: nil
+      if let downloadSession {
+        downloadStreamHandler?.onCancelHandler = {
+          [weak self, weak downloadSession] in
+          downloadSession?.cancel()
+          self?.removeStreamHandler(eventChannelName)
+          completeOnce(
+            FlutterError(
+              code: "E_CANCEL",
+              message: "Download canceled",
+              details: nil
+            )
           )
-        )
+        }
       }
 
-      if let query {
+      if let downloadSession {
         addDownloadObservers(
-          query: query,
+          session: downloadSession,
           eventChannelName: eventChannelName
         )
-        query.start()
+        downloadSession.start()
       }
       if downloadStreamHandler != nil {
         emitProgress(10.0, eventChannelName: eventChannelName)
@@ -650,10 +675,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           )
           downloadStreamHandler?.setEvent(mapped)
           downloadStreamHandler?.setEvent(FlutterEndOfEventStream)
-          if let query {
-            removeObservers(query)
-            query.stop()
-          }
+          downloadSession?.cancel()
           removeStreamHandler(eventChannelName)
           completeOnce(mapped)
           return
@@ -661,10 +683,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
 
         emitProgress(100.0, eventChannelName: eventChannelName)
         downloadStreamHandler?.setEvent(FlutterEndOfEventStream)
-        if let query {
-          removeObservers(query)
-          query.stop()
-        }
+        downloadSession?.cancel()
         removeStreamHandler(eventChannelName)
         completeOnce(nil)
       }
@@ -946,24 +965,26 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   
   /// Adds observers for download progress updates.
   private func addDownloadObservers(
-    query: NSMetadataQuery,
+    session: MetadataQuerySession,
     eventChannelName: String
   ) {
-    addObserver(
-      for: query,
+    session.addObserver(
       name: NSNotification.Name.NSMetadataQueryDidFinishGathering
-    ) { [self] _ in
+    ) { [weak self] session, query, _ in
+      guard let self else { return }
       emitDownloadProgress(
+        session: session,
         query: query,
         eventChannelName: eventChannelName
       )
     }
     
-    addObserver(
-      for: query,
+    session.addObserver(
       name: NSNotification.Name.NSMetadataQueryDidUpdate
-    ) { [self] _ in
+    ) { [weak self] session, query, _ in
+      guard let self else { return }
       emitDownloadProgress(
+        session: session,
         query: query,
         eventChannelName: eventChannelName
       )
@@ -972,10 +993,11 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   
   /// Emits download progress updates.
   private func emitDownloadProgress(
+    session: MetadataQuerySession,
     query: NSMetadataQuery,
     eventChannelName: String
   ) {
-    if !query.isStarted {
+    if session.isCancelled || !query.isStarted {
       return
     }
     guard let fileItem = query.results.first as? NSMetadataItem else { return }
@@ -1550,38 +1572,26 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     return true
   }
   
-  /// Adds an observers for a metadata query.
-  private func addObserver(
-    for query: NSMetadataQuery,
-    name: Notification.Name,
-    using block: @escaping (Notification) -> Void
-  ) {
-    let token = NotificationCenter.default.addObserver(
-      forName: name,
-      object: query,
-      queue: query.operationQueue,
-      using: block
-    )
-    let key = ObjectIdentifier(query)
-    queryObserversQueue.sync {
-      var tokens = queryObservers[key] ?? []
-      tokens.append(token)
-      queryObservers[key] = tokens
+  /// Creates and retains a metadata query session until cleanup completes.
+  private func makeMetadataQuerySession(
+    query: NSMetadataQuery
+  ) -> MetadataQuerySession {
+    let session = MetadataQuerySession(query: query) { [weak self] session in
+      self?.releaseMetadataQuerySession(session)
     }
+    metadataQuerySessionsQueue.sync {
+      metadataQuerySessions[session.id] = session
+    }
+    return session
   }
 
-  /// Removes all observers for a metadata query.
-  private func removeObservers(_ query: NSMetadataQuery) {
-    let key = ObjectIdentifier(query)
-    let tokens: [NSObjectProtocol]? = queryObserversQueue.sync {
-      queryObservers[key]
-    }
-    guard let tokens else { return }
-    for token in tokens {
-      NotificationCenter.default.removeObserver(token)
-    }
-    queryObserversQueue.sync {
-      queryObservers.removeValue(forKey: key)
+  /// Releases a metadata query session after observers have been removed and
+  /// the query has been stopped.
+  private func releaseMetadataQuerySession(
+    _ session: MetadataQuerySession
+  ) {
+    metadataQuerySessionsQueue.sync {
+      metadataQuerySessions.removeValue(forKey: session.id)
     }
   }
   

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
@@ -21,6 +21,14 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     queue.qualityOfService = .userInitiated
     return queue
   }()
+  private let ubiquityContainerResolver: UbiquityContainerResolver
+
+  init(
+    ubiquityContainerResolver: UbiquityContainerResolver = .live
+  ) {
+    self.ubiquityContainerResolver = ubiquityContainerResolver
+    super.init()
+  }
 
   /// Registers the plugin with the Flutter registrar.
   public static func register(with registrar: FlutterPluginRegistrar) {
@@ -122,11 +130,27 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(operation: "gather"))
-      return
+    Task { @MainActor [self] in
+      guard let containerURL = await ubiquityContainerResolver.resolve(
+        containerId: containerId
+      ) else {
+        result(containerAccessError(operation: "gather"))
+        return
+      }
+
+      startGather(
+        containerURL: containerURL,
+        eventChannelName: eventChannelName,
+        result: result
+      )
     }
+  }
+
+  private func startGather(
+    containerURL: URL,
+    eventChannelName: String,
+    result: @escaping FlutterResult
+  ) {
     DebugHelper.log("containerURL: \(containerURL.path)")
 
     // Verify event channel handler exists before registering observers

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
@@ -163,14 +163,11 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
-    Task { @MainActor [self] in
-      guard let containerURL = await ubiquityContainerResolver.resolve(
-        containerId: containerId
-      ) else {
-        result(containerAccessError(operation: "gather"))
-        return
-      }
-
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "gather",
+      result: result
+    ) { [self] containerURL in
       startGather(
         containerURL: containerURL,
         eventChannelName: eventChannelName,

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
@@ -392,8 +392,78 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     return nativeCodeError(
       error,
       operation: operation,
-      relativePath: relativePath
+      relativePath: relativePath,
+      pathKind: "containerParentDirectory"
     )
+  }
+
+  private func mapNativeWriteError(
+    _ error: Error,
+    operation: String,
+    relativePath: String,
+    destinationURL: URL
+  ) -> FlutterError {
+    let nsError = error as NSError
+    return mapFileNotFoundError(
+      error,
+      operation: operation,
+      relativePath: relativePath,
+      pathKind: nativeWritePathKind(
+        for: nsError,
+        destinationURL: destinationURL
+      )
+    ) ?? mapTimeoutError(
+      error,
+      operation: operation,
+      relativePath: relativePath,
+      pathKind: "containerRelative"
+    ) ?? nativeCodeError(
+      error,
+      operation: operation,
+      relativePath: relativePath,
+      pathKind: nativeWritePathKind(
+        for: nsError,
+        destinationURL: destinationURL
+      )
+    )
+  }
+
+  private func nativeWritePathKind(
+    for nativeError: NSError,
+    destinationURL: URL
+  ) -> String {
+    guard let nativePath = nativeError.userInfo[NSFilePathErrorKey] as? String
+    else {
+      return "containerRelative"
+    }
+
+    let standardizedNativePath = URL(fileURLWithPath: nativePath)
+      .standardizedFileURL
+      .path
+    let standardizedDestinationPath = destinationURL
+      .standardizedFileURL
+      .path
+    if standardizedNativePath == standardizedDestinationPath {
+      return "destination"
+    }
+
+    let temporaryPath = FileManager.default.temporaryDirectory
+      .standardizedFileURL
+      .path
+    let normalizedTemporaryPath = temporaryPath.hasSuffix("/")
+      ? temporaryPath
+      : temporaryPath + "/"
+    if standardizedNativePath.hasPrefix(normalizedTemporaryPath) {
+      return "temporaryReplacement"
+    }
+
+    return "nativeFilePath"
+  }
+
+  private func isFileContentWriteOperation(_ operation: String) -> Bool {
+    operation == "uploadFile"
+      || operation == "writeInPlace"
+      || operation == "writeInPlaceBytes"
   }
 
   /// Copies a local file into the iCloud container (copy-in).
@@ -803,18 +873,11 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
 
       writeInPlaceDocument(at: fileURL, contents: contents) { [self] error in
         if let error = error {
-          let mapped = mapFileNotFoundError(
+          let mapped = mapNativeWriteError(
             error,
             operation: "writeInPlace",
-            relativePath: relativePath
-          ) ?? mapTimeoutError(
-            error,
-            operation: "writeInPlace",
-            relativePath: relativePath
-          ) ?? nativeCodeError(
-            error,
-            operation: "writeInPlace",
-            relativePath: relativePath
+            relativePath: relativePath,
+            destinationURL: fileURL
           )
           result(mapped)
           return
@@ -942,18 +1005,11 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       writeInPlaceBinaryDocument(at: fileURL, contents: contents.data) {
         [self] error in
         if let error = error {
-          let mapped = mapFileNotFoundError(
+          let mapped = mapNativeWriteError(
             error,
             operation: "writeInPlaceBytes",
-            relativePath: relativePath
-          ) ?? mapTimeoutError(
-            error,
-            operation: "writeInPlaceBytes",
-            relativePath: relativePath
-          ) ?? nativeCodeError(
-            error,
-            operation: "writeInPlaceBytes",
-            relativePath: relativePath
+            relativePath: relativePath,
+            destinationURL: fileURL
           )
           result(mapped)
           return
@@ -1688,6 +1744,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     operation: String,
     retryable: Bool,
     relativePath: String? = nil,
+    pathKind: String? = nil,
     nativeError: NSError? = nil,
     underlying: Any? = nil
   ) -> FlutterError {
@@ -1698,6 +1755,9 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     ]
     if let relativePath {
       details["relativePath"] = relativePath
+    }
+    if let pathKind {
+      details["pathKind"] = pathKind
     }
     if let nativeError {
       details["nativeDomain"] = nativeError.domain
@@ -1732,7 +1792,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     relativePath: String? = nil,
     code: String = "E_FNF",
     message: String = "The file does not exist",
-    nativeError: NSError? = nil
+    nativeError: NSError? = nil,
+    pathKind: String? = nil
   ) -> FlutterError {
     flutterError(
       code: code,
@@ -1741,6 +1802,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       operation: operation,
       retryable: false,
       relativePath: relativePath,
+      pathKind: pathKind,
       nativeError: nativeError
     )
   }
@@ -1748,7 +1810,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   private func timeoutError(
     operation: String,
     relativePath: String? = nil,
-    nativeError: NSError? = nil
+    nativeError: NSError? = nil,
+    pathKind: String? = nil
   ) -> FlutterError {
     flutterError(
       code: "E_TIMEOUT",
@@ -1757,6 +1820,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       operation: operation,
       retryable: true,
       relativePath: relativePath,
+      pathKind: pathKind,
       nativeError: nativeError
     )
   }
@@ -1765,7 +1829,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   private func mapFileNotFoundError(
     _ error: Error,
     operation: String = "unknown",
-    relativePath: String? = nil
+    relativePath: String? = nil,
+    pathKind: String? = nil
   ) -> FlutterError? {
     let nsError = error as NSError
     guard nsError.domain == NSCocoaErrorDomain else { return nil }
@@ -1778,13 +1843,15 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           relativePath: relativePath,
           code: "E_FNF_WRITE",
           message: "The file could not be written because it does not exist",
-          nativeError: nsError
+          nativeError: nsError,
+          pathKind: pathKind
         )
       }
       return itemNotFoundError(
         operation: operation,
         relativePath: relativePath,
-        nativeError: nsError
+        nativeError: nsError,
+        pathKind: pathKind
       )
     case NSFileReadNoSuchFileError:
       return itemNotFoundError(
@@ -1792,7 +1859,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
         relativePath: relativePath,
         code: "E_FNF_READ",
         message: "The file could not be read because it does not exist",
-        nativeError: nsError
+        nativeError: nsError,
+        pathKind: pathKind
       )
     default:
       return nil
@@ -1803,7 +1871,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   private func nativeCodeError(
     _ error: Error,
     operation: String = "unknown",
-    relativePath: String? = nil
+    relativePath: String? = nil,
+    pathKind: String? = nil
   ) -> FlutterError {
     let nsError = error as NSError
 
@@ -1817,6 +1886,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           operation: operation,
           retryable: false,
           relativePath: relativePath,
+          pathKind: pathKind,
           nativeError: nsError
         )
       case CoordinatedReplaceWriter.itemNotDownloadedReplaceStateCode:
@@ -1827,6 +1897,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           operation: operation,
           retryable: true,
           relativePath: relativePath,
+          pathKind: pathKind,
           nativeError: nsError
         )
       case CoordinatedReplaceWriter.downloadInProgressReplaceStateCode:
@@ -1837,6 +1908,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           operation: operation,
           retryable: true,
           relativePath: relativePath,
+          pathKind: pathKind,
           nativeError: nsError
         )
       case CoordinatedReplaceWriter.directoryReplaceStateCode:
@@ -1847,6 +1919,38 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           operation: operation,
           retryable: false,
           relativePath: relativePath,
+          pathKind: pathKind,
+          nativeError: nsError
+        )
+      case CoordinatedReplaceWriter.coordinationReplaceStateCode:
+        return flutterError(
+          code: "E_COORDINATION",
+          message: nsError.localizedDescription,
+          category: "coordination",
+          operation: operation,
+          retryable: false,
+          relativePath: relativePath,
+          pathKind: pathKind,
+          nativeError: nsError
+        )
+      default:
+        break
+      }
+    }
+
+    if isFileContentWriteOperation(operation)
+      && nsError.domain == NSCocoaErrorDomain {
+      switch nsError.code {
+      case NSFileWriteInvalidFileNameError,
+           NSFileWriteUnsupportedSchemeError:
+        return flutterError(
+          code: "E_ARG",
+          message: nsError.localizedDescription,
+          category: "invalidArgument",
+          operation: operation,
+          retryable: false,
+          relativePath: relativePath,
+          pathKind: pathKind,
           nativeError: nsError
         )
       default:
@@ -1861,6 +1965,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       operation: operation,
       retryable: false,
       relativePath: relativePath,
+      pathKind: pathKind,
       nativeError: nsError,
       underlying: String(describing: error)
     )
@@ -1869,14 +1974,16 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   private func mapTimeoutError(
     _ error: Error,
     operation: String = "unknown",
-    relativePath: String? = nil
+    relativePath: String? = nil,
+    pathKind: String? = nil
   ) -> FlutterError? {
     let nsError = error as NSError
     guard nsError.domain == "ICloudStorageTimeout" else { return nil }
     return timeoutError(
       operation: operation,
       relativePath: relativePath,
-      nativeError: nsError
+      nativeError: nsError,
+      pathKind: pathKind
     )
   }
 }

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
@@ -80,6 +80,7 @@ extension CoordinatedReplaceWriter {
     static let itemNotDownloadedReplaceStateCode = 2
     static let downloadInProgressReplaceStateCode = 3
     static let directoryReplaceStateCode = 4
+    static let coordinationReplaceStateCode = 5
     static let autoResolveFailedDescriptionMarker = "auto-resolution failed"
 
     static func fileDestinationError(isDirectory: Bool) -> NSError? {
@@ -160,6 +161,18 @@ extension CoordinatedReplaceWriter {
                     + "\(autoResolveFailedDescriptionMarker) — "
                     + underlyingNSError.localizedDescription,
                 NSUnderlyingErrorKey: underlyingNSError,
+            ]
+        )
+    }
+
+    static func coordinationError(underlying: NSError) -> NSError {
+        NSError(
+            domain: replaceStateErrorDomain,
+            code: coordinationReplaceStateCode,
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "File coordination failed while replacing an iCloud item.",
+                NSUnderlyingErrorKey: underlying,
             ]
         )
     }
@@ -274,7 +287,9 @@ extension CoordinatedReplaceWriter {
                 }
 
                 if let coordinationError {
-                    continuation.resume(throwing: coordinationError)
+                    continuation.resume(throwing: Self.coordinationError(
+                        underlying: coordinationError
+                    ))
                     return
                 }
                 if let accessError {

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/MetadataQuerySession.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/MetadataQuerySession.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// Owns an NSMetadataQuery and its NotificationCenter observer tokens for
+/// the full query lifecycle.
+final class MetadataQuerySession {
+    typealias ID = UUID
+    typealias Cleanup = (MetadataQuerySession) -> Void
+    typealias Observer = (
+        MetadataQuerySession,
+        NSMetadataQuery,
+        Notification
+    ) -> Void
+
+    let id = ID()
+    let query: NSMetadataQuery
+
+    private let stateQueue = DispatchQueue(
+        label: "icloud_storage_plus.metadata_query_session"
+    )
+    private var observerTokens: [NSObjectProtocol] = []
+    private var cancelled = false
+    private var cleanupFinished = false
+    private let onCleanup: Cleanup
+
+    var isCancelled: Bool {
+        stateQueue.sync { cancelled }
+    }
+
+    init(
+        query: NSMetadataQuery,
+        onCleanup: @escaping Cleanup
+    ) {
+        self.query = query
+        self.onCleanup = onCleanup
+    }
+
+    @discardableResult
+    func addObserver(
+        name: Notification.Name,
+        using observer: @escaping Observer
+    ) -> Bool {
+        let token = NotificationCenter.default.addObserver(
+            forName: name,
+            object: query,
+            queue: query.operationQueue
+        ) { [weak self] notification in
+            guard let self else { return }
+            observer(self, self.query, notification)
+        }
+
+        let shouldKeepToken = stateQueue.sync {
+            guard !cancelled else { return false }
+            observerTokens.append(token)
+            return true
+        }
+
+        if !shouldKeepToken {
+            NotificationCenter.default.removeObserver(token)
+        }
+        return shouldKeepToken
+    }
+
+    func start() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, !self.isCancelled else { return }
+            self.query.start()
+        }
+    }
+
+    func cancel() {
+        let tokens = stateQueue.sync { () -> [NSObjectProtocol]? in
+            guard !cancelled else { return nil }
+            cancelled = true
+            let tokens = observerTokens
+            observerTokens.removeAll()
+            return tokens
+        }
+
+        guard let tokens else { return }
+        for token in tokens {
+            NotificationCenter.default.removeObserver(token)
+        }
+
+        let stopAndFinish = { [self] in
+            if query.isStarted {
+                query.stop()
+            }
+            finishCleanup()
+        }
+
+        if Thread.isMainThread {
+            stopAndFinish()
+        } else {
+            DispatchQueue.main.async(execute: stopAndFinish)
+        }
+    }
+
+    private func finishCleanup() {
+        let shouldCleanup = stateQueue.sync { () -> Bool in
+            guard !cleanupFinished else { return false }
+            cleanupFinished = true
+            return true
+        }
+
+        if shouldCleanup {
+            onCleanup(self)
+        }
+    }
+}

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -710,6 +710,31 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         )
     }
 
+    func testCoordinationErrorPreservesUnderlyingNativeSignature() {
+        let underlying = NSError(
+            domain: NSCocoaErrorDomain,
+            code: NSFileWriteUnknownError,
+            userInfo: [NSLocalizedDescriptionKey: "coordination failed"]
+        )
+
+        let wrapped = CoordinatedReplaceWriter.coordinationError(
+            underlying: underlying
+        )
+
+        XCTAssertEqual(
+            wrapped.domain,
+            CoordinatedReplaceWriter.replaceStateErrorDomain
+        )
+        XCTAssertEqual(
+            wrapped.code,
+            CoordinatedReplaceWriter.coordinationReplaceStateCode
+        )
+        XCTAssertEqual(
+            wrapped.userInfo[NSUnderlyingErrorKey] as? NSError,
+            underlying
+        )
+    }
+
     // MARK: - Slice C: deadlock-free coord bridge contract
 
     func testLiveCoordinateReplaceDoesNotStarveCooperativePool() async throws {

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/MetadataQuerySessionTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/MetadataQuerySessionTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import XCTest
+@testable import icloud_storage_plus_foundation
+
+final class MetadataQuerySessionTests: XCTestCase {
+    func testCancelRemovesObserversAndRunsCleanupOnce() {
+        let query = NSMetadataQuery()
+        let notificationName = Notification.Name(
+            "MetadataQuerySessionTests.cancel"
+        )
+        let cleanup = expectation(description: "cleanup")
+        var cleanupCount = 0
+        var notificationCount = 0
+
+        let session = MetadataQuerySession(query: query) { _ in
+            cleanupCount += 1
+            cleanup.fulfill()
+        }
+        session.addObserver(name: notificationName) { _, _, _ in
+            notificationCount += 1
+        }
+
+        NotificationCenter.default.post(name: notificationName, object: query)
+        XCTAssertEqual(notificationCount, 1)
+
+        session.cancel()
+        session.cancel()
+
+        wait(for: [cleanup], timeout: 1.0)
+        NotificationCenter.default.post(name: notificationName, object: query)
+
+        XCTAssertTrue(session.isCancelled)
+        XCTAssertEqual(cleanupCount, 1)
+        XCTAssertEqual(notificationCount, 1)
+    }
+
+    func testAddObserverAfterCancelIsImmediatelyRemoved() {
+        let query = NSMetadataQuery()
+        let notificationName = Notification.Name(
+            "MetadataQuerySessionTests.addAfterCancel"
+        )
+        let cleanup = expectation(description: "cleanup")
+        var notificationCount = 0
+
+        let session = MetadataQuerySession(query: query) { _ in
+            cleanup.fulfill()
+        }
+        session.cancel()
+        wait(for: [cleanup], timeout: 1.0)
+
+        let wasAdded = session.addObserver(name: notificationName) { _, _, _ in
+            notificationCount += 1
+        }
+        NotificationCenter.default.post(name: notificationName, object: query)
+
+        XCTAssertFalse(wasAdded)
+        XCTAssertEqual(notificationCount, 0)
+    }
+}

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/UbiquityContainerResolverTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/UbiquityContainerResolverTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import XCTest
+@testable import icloud_storage_plus_foundation
+
+final class UbiquityContainerResolverTests: XCTestCase {
+    func testLiveResolveRunsBlockingLookupOffMainThread() async throws {
+        let temporaryDirectory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let expectation = expectation(description: "container lookup ran")
+        let lock = NSLock()
+        var observedMainThreadState: Bool?
+        let resolver = UbiquityContainerResolver(
+            execute: UbiquityContainerResolver.live.execute,
+            resolveContainerURL: { _ in
+                lock.lock()
+                observedMainThreadState = Thread.isMainThread
+                lock.unlock()
+                expectation.fulfill()
+                return temporaryDirectory
+            },
+            delay: { _ in XCTFail("should not retry") },
+            retryDelay: UbiquityContainerResolver.maximumRetryDelay
+        )
+
+        let containerURL = await resolver.resolve(containerId: "container")
+
+        await fulfillment(of: [expectation], timeout: 1.0)
+        XCTAssertEqual(containerURL?.path, temporaryDirectory.path)
+        XCTAssertEqual(observedMainThreadState, false)
+    }
+
+    func testResolveRetriesOnceAfterNilResult() async throws {
+        let temporaryDirectory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        var attempts = 0
+        var delays: [TimeInterval] = []
+        let resolver = UbiquityContainerResolver(
+            execute: { work in work() },
+            resolveContainerURL: { _ in
+                attempts += 1
+                if attempts == 2 {
+                    return temporaryDirectory
+                }
+                return nil
+            },
+            delay: { delays.append($0) },
+            retryDelay: UbiquityContainerResolver.maximumRetryDelay
+        )
+
+        let containerURL = await resolver.resolve(containerId: "container")
+
+        XCTAssertEqual(containerURL?.path, temporaryDirectory.path)
+        XCTAssertEqual(attempts, UbiquityContainerResolver.maxAttempts)
+        XCTAssertEqual(
+            delays,
+            [UbiquityContainerResolver.maximumRetryDelay]
+        )
+    }
+
+    func testResolveReturnsNilAfterPersistentNilResults() async {
+        var attempts = 0
+        var delays: [TimeInterval] = []
+        let resolver = UbiquityContainerResolver(
+            execute: { work in work() },
+            resolveContainerURL: { _ in
+                attempts += 1
+                return nil
+            },
+            delay: { delays.append($0) },
+            retryDelay: UbiquityContainerResolver.maximumRetryDelay
+        )
+
+        let containerURL = await resolver.resolve(containerId: "missing")
+
+        XCTAssertNil(containerURL)
+        XCTAssertEqual(attempts, UbiquityContainerResolver.maxAttempts)
+        XCTAssertEqual(
+            delays,
+            [UbiquityContainerResolver.maximumRetryDelay]
+        )
+    }
+
+    func testRetryDelayIsClampedTo150Milliseconds() async {
+        var delays: [TimeInterval] = []
+        let resolver = UbiquityContainerResolver(
+            execute: { work in work() },
+            resolveContainerURL: { _ in nil },
+            delay: { delays.append($0) },
+            retryDelay: 1
+        )
+
+        _ = await resolver.resolve(containerId: "missing")
+
+        XCTAssertEqual(
+            delays,
+            [UbiquityContainerResolver.maximumRetryDelay]
+        )
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: temporaryDirectory,
+            withIntermediateDirectories: true
+        )
+        return temporaryDirectory
+    }
+}

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/UbiquityContainerResolverTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/UbiquityContainerResolverTests.swift
@@ -99,6 +99,24 @@ final class UbiquityContainerResolverTests: XCTestCase {
         )
     }
 
+    func testResolveStopsAfterCancelledRetryDelay() async {
+        var attempts = 0
+        let resolver = UbiquityContainerResolver(
+            execute: { work in work() },
+            resolveContainerURL: { _ in
+                attempts += 1
+                return nil
+            },
+            delay: { _ in throw CancellationError() },
+            retryDelay: UbiquityContainerResolver.maximumRetryDelay
+        )
+
+        let containerURL = await resolver.resolve(containerId: "cancelled")
+
+        XCTAssertNil(containerURL)
+        XCTAssertEqual(attempts, 1)
+    }
+
     private func makeTemporaryDirectory() throws -> URL {
         let temporaryDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/WriteEntrypointPreflightTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/WriteEntrypointPreflightTests.swift
@@ -17,13 +17,18 @@ final class WriteEntrypointPreflightTests: XCTestCase {
 
         let preflight = WriteEntrypointPreflight(
             execute: WriteEntrypointPreflight.live.execute,
-            resolveContainerURL: { _ in
-                lock.lock()
-                observedMainThreadStates.append(Thread.isMainThread)
-                lock.unlock()
-                expectation.fulfill()
-                return temporaryDirectory
-            },
+            ubiquityContainerResolver: UbiquityContainerResolver(
+                execute: UbiquityContainerResolver.live.execute,
+                resolveContainerURL: { _ in
+                    lock.lock()
+                    observedMainThreadStates.append(Thread.isMainThread)
+                    lock.unlock()
+                    expectation.fulfill()
+                    return temporaryDirectory
+                },
+                delay: { _ in XCTFail("should not retry") },
+                retryDelay: UbiquityContainerResolver.maximumRetryDelay
+            ),
             createDirectory: { directoryURL in
                 lock.lock()
                 observedMainThreadStates.append(Thread.isMainThread)
@@ -50,7 +55,12 @@ final class WriteEntrypointPreflightTests: XCTestCase {
     func testPrepareThrowsTypedContainerUnavailableError() async {
         let preflight = WriteEntrypointPreflight(
             execute: { work in try work() },
-            resolveContainerURL: { _ in nil },
+            ubiquityContainerResolver: UbiquityContainerResolver(
+                execute: { work in work() },
+                resolveContainerURL: { _ in nil },
+                delay: { _ in },
+                retryDelay: UbiquityContainerResolver.maximumRetryDelay
+            ),
             createDirectory: { _ in XCTFail("should not create directory") }
         )
 
@@ -79,7 +89,12 @@ final class WriteEntrypointPreflightTests: XCTestCase {
         var createDirectoryCalled = false
         let preflight = WriteEntrypointPreflight(
             execute: { work in try work() },
-            resolveContainerURL: { _ in temporaryDirectory },
+            ubiquityContainerResolver: UbiquityContainerResolver(
+                execute: { work in work() },
+                resolveContainerURL: { _ in temporaryDirectory },
+                delay: { _ in XCTFail("should not retry") },
+                retryDelay: UbiquityContainerResolver.maximumRetryDelay
+            ),
             createDirectory: { _ in createDirectoryCalled = true }
         )
 
@@ -106,11 +121,16 @@ final class WriteEntrypointPreflightTests: XCTestCase {
         var observedMainThreadState: Bool?
         let preflight = WriteEntrypointPreflight(
             execute: WriteEntrypointPreflight.live.execute,
-            resolveContainerURL: { _ in
-                observedMainThreadState = Thread.isMainThread
-                expectation.fulfill()
-                return temporaryDirectory
-            },
+            ubiquityContainerResolver: UbiquityContainerResolver(
+                execute: UbiquityContainerResolver.live.execute,
+                resolveContainerURL: { _ in
+                    observedMainThreadState = Thread.isMainThread
+                    expectation.fulfill()
+                    return temporaryDirectory
+                },
+                delay: { _ in XCTFail("should not retry") },
+                retryDelay: UbiquityContainerResolver.maximumRetryDelay
+            ),
             createDirectory: { _ in XCTFail("should not create directory") }
         )
 
@@ -121,6 +141,51 @@ final class WriteEntrypointPreflightTests: XCTestCase {
         await fulfillment(of: [expectation], timeout: 1.0)
         XCTAssertEqual(containerURL.path, temporaryDirectory.path)
         XCTAssertEqual(observedMainThreadState, false)
+    }
+
+    func testPrepareSucceedsWhenInitialContainerLookupIsNil() async throws {
+        let temporaryDirectory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        var attempts = 0
+        var delays: [TimeInterval] = []
+        var createdDirectory: URL?
+        let preflight = WriteEntrypointPreflight(
+            execute: { work in try work() },
+            ubiquityContainerResolver: UbiquityContainerResolver(
+                execute: { work in work() },
+                resolveContainerURL: { _ in
+                    attempts += 1
+                    return attempts == 2 ? temporaryDirectory : nil
+                },
+                delay: { delays.append($0) },
+                retryDelay: UbiquityContainerResolver.maximumRetryDelay
+            ),
+            createDirectory: { createdDirectory = $0 }
+        )
+
+        let fileURL = try await preflight.prepare(
+            containerId: "container",
+            relativePath: "nested/file.txt"
+        )
+
+        XCTAssertEqual(attempts, UbiquityContainerResolver.maxAttempts)
+        XCTAssertEqual(
+            delays,
+            [UbiquityContainerResolver.maximumRetryDelay]
+        )
+        XCTAssertEqual(
+            fileURL.path,
+            temporaryDirectory
+                .appendingPathComponent("nested/file.txt")
+                .path
+        )
+        XCTAssertEqual(
+            createdDirectory?.path,
+            temporaryDirectory
+                .appendingPathComponent("nested", isDirectory: true)
+                .path
+        )
     }
 
     private func makeTemporaryDirectory() throws -> URL {

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/UbiquityContainerResolver.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/UbiquityContainerResolver.swift
@@ -6,7 +6,7 @@ struct UbiquityContainerResolver {
         @escaping @Sendable () -> URL?
     ) async -> URL?
     typealias ResolveContainerURL = (String) -> URL?
-    typealias Delay = (TimeInterval) async -> Void
+    typealias Delay = (TimeInterval) async throws -> Void
 
     static let maxAttempts = 2
     static let maximumRetryDelay: TimeInterval = 0.15
@@ -25,7 +25,13 @@ struct UbiquityContainerResolver {
             }
 
             if attempt < Self.maxAttempts - 1 {
-                await delay(clampedRetryDelay)
+                do {
+                    try await delay(clampedRetryDelay)
+                } catch is CancellationError {
+                    return nil
+                } catch {
+                    return nil
+                }
             }
         }
 
@@ -53,7 +59,7 @@ extension UbiquityContainerResolver {
         },
         delay: { delay in
             let nanoseconds = UInt64(delay * 1_000_000_000)
-            try? await Task.sleep(nanoseconds: nanoseconds)
+            try await Task.sleep(nanoseconds: nanoseconds)
         },
         retryDelay: maximumRetryDelay
     )

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/UbiquityContainerResolver.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/UbiquityContainerResolver.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+@available(macOS 10.15, iOS 13.0, *)
+struct UbiquityContainerResolver {
+    typealias Execute = (
+        @escaping @Sendable () -> URL?
+    ) async -> URL?
+    typealias ResolveContainerURL = (String) -> URL?
+    typealias Delay = (TimeInterval) async -> Void
+
+    static let maxAttempts = 2
+    static let maximumRetryDelay: TimeInterval = 0.15
+
+    let execute: Execute
+    let resolveContainerURL: ResolveContainerURL
+    let delay: Delay
+    let retryDelay: TimeInterval
+
+    func resolve(containerId: String) async -> URL? {
+        for attempt in 0..<Self.maxAttempts {
+            if let containerURL = await execute({
+                resolveContainerURL(containerId)
+            }) {
+                return containerURL
+            }
+
+            if attempt < Self.maxAttempts - 1 {
+                await delay(clampedRetryDelay)
+            }
+        }
+
+        return nil
+    }
+
+    private var clampedRetryDelay: TimeInterval {
+        max(0, min(retryDelay, Self.maximumRetryDelay))
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, *)
+extension UbiquityContainerResolver {
+    static let live = UbiquityContainerResolver(
+        execute: { work in
+            await withCheckedContinuation {
+                (continuation: CheckedContinuation<URL?, Never>) in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    continuation.resume(returning: work())
+                }
+            }
+        },
+        resolveContainerURL: {
+            FileManager.default.url(forUbiquityContainerIdentifier: $0)
+        },
+        delay: { delay in
+            let nanoseconds = UInt64(delay * 1_000_000_000)
+            try? await Task.sleep(nanoseconds: nanoseconds)
+        },
+        retryDelay: maximumRetryDelay
+    )
+}

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/WriteEntrypointPreflight.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/WriteEntrypointPreflight.swift
@@ -5,21 +5,20 @@ struct WriteEntrypointPreflight {
     typealias Execute = (
         @escaping @Sendable () throws -> URL
     ) async throws -> URL
-    typealias ResolveContainerURL = (String) -> URL?
     typealias CreateDirectory = (URL) throws -> Void
 
     let execute: Execute
-    let resolveContainerURL: ResolveContainerURL
+    let ubiquityContainerResolver: UbiquityContainerResolver
     let createDirectory: CreateDirectory
 
     func containerURL(containerId: String) async throws -> URL {
-        try await execute {
-            guard let containerURL = resolveContainerURL(containerId) else {
-                throw Self.containerUnavailableError()
-            }
-
-            return containerURL
+        guard let containerURL = await ubiquityContainerResolver.resolve(
+            containerId: containerId
+        ) else {
+            throw Self.containerUnavailableError()
         }
+
+        return containerURL
     }
 
     func itemURL(
@@ -41,11 +40,8 @@ struct WriteEntrypointPreflight {
         containerId: String,
         relativePath: String
     ) async throws -> URL {
-        try await execute {
-            guard let containerURL = resolveContainerURL(containerId) else {
-                throw Self.containerUnavailableError()
-            }
-
+        let containerURL = try await containerURL(containerId: containerId)
+        return try await execute {
             let fileURL = containerURL.appendingPathComponent(relativePath)
             try createDirectory(fileURL.deletingLastPathComponent())
             return fileURL
@@ -88,9 +84,7 @@ extension WriteEntrypointPreflight {
                 }
             }
         },
-        resolveContainerURL: {
-            FileManager.default.url(forUbiquityContainerIdentifier: $0)
-        },
+        ubiquityContainerResolver: .live,
         createDirectory: { directoryURL in
             try FileManager.default.createDirectory(
                 at: directoryURL,

--- a/lib/models/exceptions.dart
+++ b/lib/models/exceptions.dart
@@ -78,6 +78,7 @@ class ICloudOperationException implements Exception {
     required this.retryable,
     required this.message,
     this.relativePath,
+    this.pathKind,
     this.nativeDomain,
     this.nativeCode,
     this.nativeDescription,
@@ -98,6 +99,9 @@ class ICloudOperationException implements Exception {
 
   /// Relative path associated with the failure, when present.
   final String? relativePath;
+
+  /// Non-PII classification of the native path involved in the failure.
+  final String? pathKind;
 
   /// Native error domain, when present.
   final String? nativeDomain;
@@ -125,6 +129,7 @@ class ICloudItemNotFoundException extends ICloudOperationException {
           retryable: data.retryable,
           message: data.message,
           relativePath: data.relativePath,
+          pathKind: data.pathKind,
           nativeDomain: data.nativeDomain,
           nativeCode: data.nativeCode,
           nativeDescription: data.nativeDescription,
@@ -142,6 +147,7 @@ class ICloudContainerAccessException extends ICloudOperationException {
           retryable: data.retryable,
           message: data.message,
           relativePath: data.relativePath,
+          pathKind: data.pathKind,
           nativeDomain: data.nativeDomain,
           nativeCode: data.nativeCode,
           nativeDescription: data.nativeDescription,
@@ -159,6 +165,7 @@ class ICloudConflictException extends ICloudOperationException {
           retryable: data.retryable,
           message: data.message,
           relativePath: data.relativePath,
+          pathKind: data.pathKind,
           nativeDomain: data.nativeDomain,
           nativeCode: data.nativeCode,
           nativeDescription: data.nativeDescription,
@@ -177,6 +184,7 @@ class ICloudItemNotDownloadedException extends ICloudOperationException {
           retryable: data.retryable,
           message: data.message,
           relativePath: data.relativePath,
+          pathKind: data.pathKind,
           nativeDomain: data.nativeDomain,
           nativeCode: data.nativeCode,
           nativeDescription: data.nativeDescription,
@@ -195,6 +203,7 @@ class ICloudDownloadInProgressException extends ICloudOperationException {
           retryable: data.retryable,
           message: data.message,
           relativePath: data.relativePath,
+          pathKind: data.pathKind,
           nativeDomain: data.nativeDomain,
           nativeCode: data.nativeCode,
           nativeDescription: data.nativeDescription,
@@ -212,6 +221,7 @@ class ICloudTimeoutException extends ICloudOperationException {
           retryable: data.retryable,
           message: data.message,
           relativePath: data.relativePath,
+          pathKind: data.pathKind,
           nativeDomain: data.nativeDomain,
           nativeCode: data.nativeCode,
           nativeDescription: data.nativeDescription,
@@ -229,6 +239,7 @@ class ICloudCoordinationException extends ICloudOperationException {
           retryable: data.retryable,
           message: data.message,
           relativePath: data.relativePath,
+          pathKind: data.pathKind,
           nativeDomain: data.nativeDomain,
           nativeCode: data.nativeCode,
           nativeDescription: data.nativeDescription,
@@ -246,6 +257,7 @@ class ICloudInvalidArgumentException extends ICloudOperationException {
           retryable: data.retryable,
           message: data.message,
           relativePath: data.relativePath,
+          pathKind: data.pathKind,
           nativeDomain: data.nativeDomain,
           nativeCode: data.nativeCode,
           nativeDescription: data.nativeDescription,
@@ -263,6 +275,7 @@ class ICloudUnknownNativeException extends ICloudOperationException {
           retryable: data.retryable,
           message: data.message,
           relativePath: data.relativePath,
+          pathKind: data.pathKind,
           nativeDomain: data.nativeDomain,
           nativeCode: data.nativeCode,
           nativeDescription: data.nativeDescription,
@@ -280,6 +293,7 @@ ICloudOperationException mapICloudPlatformException(PlatformException error) {
     retryable: payload['retryable'] == true,
     message: error.message ?? 'iCloud operation failed',
     relativePath: _readString(payload, 'relativePath'),
+    pathKind: _readString(payload, 'pathKind'),
     nativeDomain: _readString(payload, 'nativeDomain'),
     nativeCode: _readInt(payload, 'nativeCode'),
     nativeDescription: _readString(payload, 'nativeDescription'),
@@ -306,6 +320,7 @@ class _ICloudOperationExceptionData {
     required this.retryable,
     required this.message,
     this.relativePath,
+    this.pathKind,
     this.nativeDomain,
     this.nativeCode,
     this.nativeDescription,
@@ -317,6 +332,7 @@ class _ICloudOperationExceptionData {
   final bool retryable;
   final String message;
   final String? relativePath;
+  final String? pathKind;
   final String? nativeDomain;
   final int? nativeCode;
   final String? nativeDescription;

--- a/macos/icloud_storage_plus.podspec
+++ b/macos/icloud_storage_plus.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'icloud_storage_plus'
-  s.version          = '2.1.2'
+  s.version          = '2.1.3'
   s.summary          = 'iCloud document storage for Flutter (iOS/macOS).'
   s.description      = <<-DESC
 Flutter plugin for uploading, downloading, and managing files in an iCloud

--- a/macos/icloud_storage_plus.podspec
+++ b/macos/icloud_storage_plus.podspec
@@ -19,6 +19,7 @@ container, with document coordination via UIDocument/NSDocument.
     'icloud_storage_plus/Sources/icloud_storage_plus/**/*.{h,m,swift}',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/DownloadWaiter.swift',
+    'icloud_storage_plus/Sources/icloud_storage_plus_foundation/MetadataQuerySession.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/ConflictResolver.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/WriteEntrypointPreflight.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/UbiquityContainerResolver.swift',

--- a/macos/icloud_storage_plus.podspec
+++ b/macos/icloud_storage_plus.podspec
@@ -21,6 +21,7 @@ container, with document coordination via UIDocument/NSDocument.
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/DownloadWaiter.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/ConflictResolver.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/WriteEntrypointPreflight.swift',
+    'icloud_storage_plus/Sources/icloud_storage_plus_foundation/UbiquityContainerResolver.swift',
   ]
   s.dependency 'FlutterMacOS'
 

--- a/macos/icloud_storage_plus/Package.swift
+++ b/macos/icloud_storage_plus/Package.swift
@@ -30,6 +30,7 @@ let package = Package(
                 "icloud_storage_plus_foundation/DownloadWaiter.swift",
                 "icloud_storage_plus_foundation/ConflictResolver.swift",
                 "icloud_storage_plus_foundation/WriteEntrypointPreflight.swift",
+                "icloud_storage_plus_foundation/UbiquityContainerResolver.swift",
             ],
             resources: [
                 // If this plugin requires a privacy manifest (e.g. uses required

--- a/macos/icloud_storage_plus/Package.swift
+++ b/macos/icloud_storage_plus/Package.swift
@@ -28,6 +28,7 @@ let package = Package(
                 "icloud_storage_plus",
                 "icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift",
                 "icloud_storage_plus_foundation/DownloadWaiter.swift",
+                "icloud_storage_plus_foundation/MetadataQuerySession.swift",
                 "icloud_storage_plus_foundation/ConflictResolver.swift",
                 "icloud_storage_plus_foundation/WriteEntrypointPreflight.swift",
                 "icloud_storage_plus_foundation/UbiquityContainerResolver.swift",

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
@@ -356,8 +356,78 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     return nativeCodeError(
       error,
       operation: operation,
-      relativePath: relativePath
+      relativePath: relativePath,
+      pathKind: "containerParentDirectory"
     )
+  }
+
+  private func mapNativeWriteError(
+    _ error: Error,
+    operation: String,
+    relativePath: String,
+    destinationURL: URL
+  ) -> FlutterError {
+    let nsError = error as NSError
+    return mapFileNotFoundError(
+      error,
+      operation: operation,
+      relativePath: relativePath,
+      pathKind: nativeWritePathKind(
+        for: nsError,
+        destinationURL: destinationURL
+      )
+    ) ?? mapTimeoutError(
+      error,
+      operation: operation,
+      relativePath: relativePath,
+      pathKind: "containerRelative"
+    ) ?? nativeCodeError(
+      error,
+      operation: operation,
+      relativePath: relativePath,
+      pathKind: nativeWritePathKind(
+        for: nsError,
+        destinationURL: destinationURL
+      )
+    )
+  }
+
+  private func nativeWritePathKind(
+    for nativeError: NSError,
+    destinationURL: URL
+  ) -> String {
+    guard let nativePath = nativeError.userInfo[NSFilePathErrorKey] as? String
+    else {
+      return "containerRelative"
+    }
+
+    let standardizedNativePath = URL(fileURLWithPath: nativePath)
+      .standardizedFileURL
+      .path
+    let standardizedDestinationPath = destinationURL
+      .standardizedFileURL
+      .path
+    if standardizedNativePath == standardizedDestinationPath {
+      return "destination"
+    }
+
+    let temporaryPath = FileManager.default.temporaryDirectory
+      .standardizedFileURL
+      .path
+    let normalizedTemporaryPath = temporaryPath.hasSuffix("/")
+      ? temporaryPath
+      : temporaryPath + "/"
+    if standardizedNativePath.hasPrefix(normalizedTemporaryPath) {
+      return "temporaryReplacement"
+    }
+
+    return "nativeFilePath"
+  }
+
+  private func isFileContentWriteOperation(_ operation: String) -> Bool {
+    operation == "uploadFile"
+      || operation == "writeInPlace"
+      || operation == "writeInPlaceBytes"
   }
 
   /// Copies a local file into the iCloud container (copy-in).
@@ -767,18 +837,11 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
 
       writeInPlaceDocument(at: fileURL, contents: contents) { [self] error in
         if let error = error {
-          let mapped = mapFileNotFoundError(
+          let mapped = mapNativeWriteError(
             error,
             operation: "writeInPlace",
-            relativePath: relativePath
-          ) ?? mapTimeoutError(
-            error,
-            operation: "writeInPlace",
-            relativePath: relativePath
-          ) ?? nativeCodeError(
-            error,
-            operation: "writeInPlace",
-            relativePath: relativePath
+            relativePath: relativePath,
+            destinationURL: fileURL
           )
           result(mapped)
           return
@@ -906,18 +969,11 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       writeInPlaceBinaryDocument(at: fileURL, contents: contents.data) {
         [self] error in
         if let error = error {
-          let mapped = mapFileNotFoundError(
+          let mapped = mapNativeWriteError(
             error,
             operation: "writeInPlaceBytes",
-            relativePath: relativePath
-          ) ?? mapTimeoutError(
-            error,
-            operation: "writeInPlaceBytes",
-            relativePath: relativePath
-          ) ?? nativeCodeError(
-            error,
-            operation: "writeInPlaceBytes",
-            relativePath: relativePath
+            relativePath: relativePath,
+            destinationURL: fileURL
           )
           result(mapped)
           return
@@ -1649,6 +1705,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     operation: String,
     retryable: Bool,
     relativePath: String? = nil,
+    pathKind: String? = nil,
     nativeError: NSError? = nil,
     underlying: Any? = nil
   ) -> FlutterError {
@@ -1659,6 +1716,9 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     ]
     if let relativePath {
       details["relativePath"] = relativePath
+    }
+    if let pathKind {
+      details["pathKind"] = pathKind
     }
     if let nativeError {
       details["nativeDomain"] = nativeError.domain
@@ -1693,7 +1753,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     relativePath: String? = nil,
     code: String = "E_FNF",
     message: String = "The file does not exist",
-    nativeError: NSError? = nil
+    nativeError: NSError? = nil,
+    pathKind: String? = nil
   ) -> FlutterError {
     flutterError(
       code: code,
@@ -1702,6 +1763,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       operation: operation,
       retryable: false,
       relativePath: relativePath,
+      pathKind: pathKind,
       nativeError: nativeError
     )
   }
@@ -1709,7 +1771,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   private func timeoutError(
     operation: String,
     relativePath: String? = nil,
-    nativeError: NSError? = nil
+    nativeError: NSError? = nil,
+    pathKind: String? = nil
   ) -> FlutterError {
     flutterError(
       code: "E_TIMEOUT",
@@ -1718,6 +1781,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       operation: operation,
       retryable: true,
       relativePath: relativePath,
+      pathKind: pathKind,
       nativeError: nativeError
     )
   }
@@ -1726,7 +1790,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   private func mapFileNotFoundError(
     _ error: Error,
     operation: String = "unknown",
-    relativePath: String? = nil
+    relativePath: String? = nil,
+    pathKind: String? = nil
   ) -> FlutterError? {
     let nsError = error as NSError
     guard nsError.domain == NSCocoaErrorDomain else { return nil }
@@ -1739,13 +1804,15 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           relativePath: relativePath,
           code: "E_FNF_WRITE",
           message: "The file could not be written because it does not exist",
-          nativeError: nsError
+          nativeError: nsError,
+          pathKind: pathKind
         )
       }
       return itemNotFoundError(
         operation: operation,
         relativePath: relativePath,
-        nativeError: nsError
+        nativeError: nsError,
+        pathKind: pathKind
       )
     case NSFileReadNoSuchFileError:
       return itemNotFoundError(
@@ -1753,7 +1820,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
         relativePath: relativePath,
         code: "E_FNF_READ",
         message: "The file could not be read because it does not exist",
-        nativeError: nsError
+        nativeError: nsError,
+        pathKind: pathKind
       )
     default:
       return nil
@@ -1764,7 +1832,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   private func nativeCodeError(
     _ error: Error,
     operation: String = "unknown",
-    relativePath: String? = nil
+    relativePath: String? = nil,
+    pathKind: String? = nil
   ) -> FlutterError {
     let nsError = error as NSError
 
@@ -1778,6 +1847,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           operation: operation,
           retryable: false,
           relativePath: relativePath,
+          pathKind: pathKind,
           nativeError: nsError
         )
       case CoordinatedReplaceWriter.itemNotDownloadedReplaceStateCode:
@@ -1788,6 +1858,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           operation: operation,
           retryable: true,
           relativePath: relativePath,
+          pathKind: pathKind,
           nativeError: nsError
         )
       case CoordinatedReplaceWriter.downloadInProgressReplaceStateCode:
@@ -1798,6 +1869,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           operation: operation,
           retryable: true,
           relativePath: relativePath,
+          pathKind: pathKind,
           nativeError: nsError
         )
       case CoordinatedReplaceWriter.directoryReplaceStateCode:
@@ -1808,6 +1880,38 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           operation: operation,
           retryable: false,
           relativePath: relativePath,
+          pathKind: pathKind,
+          nativeError: nsError
+        )
+      case CoordinatedReplaceWriter.coordinationReplaceStateCode:
+        return flutterError(
+          code: "E_COORDINATION",
+          message: nsError.localizedDescription,
+          category: "coordination",
+          operation: operation,
+          retryable: false,
+          relativePath: relativePath,
+          pathKind: pathKind,
+          nativeError: nsError
+        )
+      default:
+        break
+      }
+    }
+
+    if isFileContentWriteOperation(operation)
+      && nsError.domain == NSCocoaErrorDomain {
+      switch nsError.code {
+      case NSFileWriteInvalidFileNameError,
+           NSFileWriteUnsupportedSchemeError:
+        return flutterError(
+          code: "E_ARG",
+          message: nsError.localizedDescription,
+          category: "invalidArgument",
+          operation: operation,
+          retryable: false,
+          relativePath: relativePath,
+          pathKind: pathKind,
           nativeError: nsError
         )
       default:
@@ -1822,6 +1926,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       operation: operation,
       retryable: false,
       relativePath: relativePath,
+      pathKind: pathKind,
       nativeError: nsError,
       underlying: String(describing: error)
     )
@@ -1830,14 +1935,16 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   private func mapTimeoutError(
     _ error: Error,
     operation: String = "unknown",
-    relativePath: String? = nil
+    relativePath: String? = nil,
+    pathKind: String? = nil
   ) -> FlutterError? {
     let nsError = error as NSError
     guard nsError.domain == "ICloudStorageTimeout" else { return nil }
     return timeoutError(
       operation: operation,
       relativePath: relativePath,
-      nativeError: nsError
+      nativeError: nsError,
+      pathKind: pathKind
     )
   }
 }

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
@@ -89,6 +89,28 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     result(status)
   }
 
+  private func resolveContainerURL(
+    containerId: String,
+    operation: String,
+    relativePath: String? = nil,
+    result: @escaping FlutterResult,
+    onResolved: @escaping (URL) -> Void
+  ) {
+    Task { @MainActor [self] in
+      guard let containerURL = await ubiquityContainerResolver.resolve(
+        containerId: containerId
+      ) else {
+        result(containerAccessError(
+          operation: operation,
+          relativePath: relativePath
+        ))
+        return
+      }
+
+      onResolved(containerURL)
+    }
+  }
+
   /// Returns the filesystem path for the iCloud container.
   private func getContainerPath(_ call: FlutterMethodCall, _ result: @escaping FlutterResult){
     guard let args = call.arguments as? Dictionary<String, Any>,
@@ -97,13 +119,14 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       result(argumentError)
       return
     }
-    
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(operation: "getContainerPath"))
-      return
+
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "getContainerPath",
+      result: result
+    ) { containerURL in
+      result(containerURL.path)
     }
-    result(containerURL.path)
   }
   
   /// Lists all items in the container using NSMetadataQuery.
@@ -499,88 +522,19 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
     
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(
-        operation: "downloadFile",
-        relativePath: cloudRelativePath
-      ))
-      return
-    }
-    DebugHelper.log("containerURL: \(containerURL.path)")
-    
-    let cloudFileURL = containerURL.appendingPathComponent(cloudRelativePath)
-    let localFileURL = URL(fileURLWithPath: localFilePath)
-    do {
-      try FileManager.default.startDownloadingUbiquitousItem(at: cloudFileURL)
-    } catch {
-      let mapped = mapFileNotFoundError(
-        error,
-        operation: "downloadFile",
-        relativePath: cloudRelativePath
-      ) ?? nativeCodeError(
-        error,
-        operation: "downloadFile",
-        relativePath: cloudRelativePath
-      )
-      result(mapped)
-      return
-    }
-    
-    let completionGate = CompletionGate()
-    let completeOnce: (Any?) -> Void = { value in
-      guard completionGate.tryComplete() else {
-        return
-      }
-      result(value)
-    }
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "downloadFile",
+      relativePath: cloudRelativePath,
+      result: result
+    ) { [self] containerURL in
+      DebugHelper.log("containerURL: \(containerURL.path)")
 
-    let query: NSMetadataQuery? = eventChannelName.isEmpty
-      ? nil
-      : {
-          let query = NSMetadataQuery()
-          query.operationQueue = .main
-          query.searchScopes = querySearchScopes
-          query.predicate = NSPredicate(
-            format: "%K == %@",
-            NSMetadataItemPathKey,
-            cloudFileURL.path
-          )
-          return query
-        }()
-
-    let downloadStreamHandler = registeredStreamHandler(for: eventChannelName)
-    downloadStreamHandler?.onCancelHandler = { [self] in
-      if let query {
-        removeObservers(query)
-        query.stop()
-      }
-      removeStreamHandler(eventChannelName)
-      completeOnce(
-        FlutterError(
-          code: "E_CANCEL",
-          message: "Download canceled",
-          details: nil
-        )
-      )
-    }
-
-    if let query {
-      addDownloadObservers(
-        query: query,
-        eventChannelName: eventChannelName
-      )
-      query.start()
-    }
-    if downloadStreamHandler != nil {
-      emitProgress(10.0, eventChannelName: eventChannelName)
-    }
-
-    readDocumentAt(url: cloudFileURL, destinationURL: localFileURL) { [self] error in
-      if completionGate.isCompleted {
-        return
-      }
-      if let error = error {
+      let cloudFileURL = containerURL.appendingPathComponent(cloudRelativePath)
+      let localFileURL = URL(fileURLWithPath: localFilePath)
+      do {
+        try FileManager.default.startDownloadingUbiquitousItem(at: cloudFileURL)
+      } catch {
         let mapped = mapFileNotFoundError(
           error,
           operation: "downloadFile",
@@ -590,25 +544,94 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           operation: "downloadFile",
           relativePath: cloudRelativePath
         )
-        downloadStreamHandler?.setEvent(mapped)
+        result(mapped)
+        return
+      }
+
+      let completionGate = CompletionGate()
+      let completeOnce: (Any?) -> Void = { value in
+        guard completionGate.tryComplete() else {
+          return
+        }
+        result(value)
+      }
+
+      let query: NSMetadataQuery? = eventChannelName.isEmpty
+        ? nil
+        : {
+            let query = NSMetadataQuery()
+            query.operationQueue = .main
+            query.searchScopes = querySearchScopes
+            query.predicate = NSPredicate(
+              format: "%K == %@",
+              NSMetadataItemPathKey,
+              cloudFileURL.path
+            )
+            return query
+          }()
+
+      let downloadStreamHandler = registeredStreamHandler(for: eventChannelName)
+      downloadStreamHandler?.onCancelHandler = { [self] in
+        if let query {
+          removeObservers(query)
+          query.stop()
+        }
+        removeStreamHandler(eventChannelName)
+        completeOnce(
+          FlutterError(
+            code: "E_CANCEL",
+            message: "Download canceled",
+            details: nil
+          )
+        )
+      }
+
+      if let query {
+        addDownloadObservers(
+          query: query,
+          eventChannelName: eventChannelName
+        )
+        query.start()
+      }
+      if downloadStreamHandler != nil {
+        emitProgress(10.0, eventChannelName: eventChannelName)
+      }
+
+      readDocumentAt(url: cloudFileURL, destinationURL: localFileURL) {
+        [self] error in
+        if completionGate.isCompleted {
+          return
+        }
+        if let error = error {
+          let mapped = mapFileNotFoundError(
+            error,
+            operation: "downloadFile",
+            relativePath: cloudRelativePath
+          ) ?? nativeCodeError(
+            error,
+            operation: "downloadFile",
+            relativePath: cloudRelativePath
+          )
+          downloadStreamHandler?.setEvent(mapped)
+          downloadStreamHandler?.setEvent(FlutterEndOfEventStream)
+          if let query {
+            removeObservers(query)
+            query.stop()
+          }
+          removeStreamHandler(eventChannelName)
+          completeOnce(mapped)
+          return
+        }
+
+        emitProgress(100.0, eventChannelName: eventChannelName)
         downloadStreamHandler?.setEvent(FlutterEndOfEventStream)
         if let query {
           removeObservers(query)
           query.stop()
         }
         removeStreamHandler(eventChannelName)
-        completeOnce(mapped)
-        return
+        completeOnce(nil)
       }
-
-      emitProgress(100.0, eventChannelName: eventChannelName)
-      downloadStreamHandler?.setEvent(FlutterEndOfEventStream)
-      if let query {
-        removeObservers(query)
-        query.stop()
-      }
-      removeStreamHandler(eventChannelName)
-      completeOnce(nil)
     }
   }
 
@@ -627,73 +650,71 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     let retryBackoff = (args["retryBackoffSeconds"] as? [NSNumber])?
       .map { $0.doubleValue } ?? []
 
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(
-        operation: "readInPlace",
-        relativePath: relativePath
-      ))
-      return
-    }
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "readInPlace",
+      relativePath: relativePath,
+      result: result
+    ) { [self] containerURL in
+      let fileURL = containerURL.appendingPathComponent(relativePath)
 
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-
-    do {
-      try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
-    } catch {
-      let mapped = mapFileNotFoundError(
-        error,
-        operation: "readInPlace",
-        relativePath: relativePath
-      ) ?? nativeCodeError(
-        error,
-        operation: "readInPlace",
-        relativePath: relativePath
-      )
-      result(mapped)
-      return
-    }
-
-    Task { @MainActor [self] in
       do {
-        try await waitForDownloadCompletion(
-          at: fileURL,
-          idleTimeouts: idleTimeouts,
-          retryBackoff: retryBackoff
-        )
+        try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
       } catch {
-        if let timeoutError = mapTimeoutError(
+        let mapped = mapFileNotFoundError(
           error,
           operation: "readInPlace",
           relativePath: relativePath
-        ) {
-          result(timeoutError)
-          return
-        }
-        result(nativeCodeError(
+        ) ?? nativeCodeError(
           error,
           operation: "readInPlace",
           relativePath: relativePath
-        ))
+        )
+        result(mapped)
         return
       }
 
-      readInPlaceDocument(at: fileURL) { [self] contents, error in
-        if let error = error {
-          let mapped = mapFileNotFoundError(
-            error,
-            operation: "readInPlace",
-            relativePath: relativePath
-          ) ?? nativeCodeError(
-            error,
-            operation: "readInPlace",
-            relativePath: relativePath
+      Task { @MainActor [self] in
+        do {
+          try await waitForDownloadCompletion(
+            at: fileURL,
+            idleTimeouts: idleTimeouts,
+            retryBackoff: retryBackoff
           )
-          result(mapped)
+        } catch {
+          if let timeoutError = mapTimeoutError(
+            error,
+            operation: "readInPlace",
+            relativePath: relativePath
+          ) {
+            result(timeoutError)
+            return
+          }
+          result(nativeCodeError(
+            error,
+            operation: "readInPlace",
+            relativePath: relativePath
+          ))
           return
         }
 
-        result(contents)
+        readInPlaceDocument(at: fileURL) { [self] contents, error in
+          if let error = error {
+            let mapped = mapFileNotFoundError(
+              error,
+              operation: "readInPlace",
+              relativePath: relativePath
+            ) ?? nativeCodeError(
+              error,
+              operation: "readInPlace",
+              relativePath: relativePath
+            )
+            result(mapped)
+            return
+          }
+
+          result(contents)
+        }
       }
     }
   }
@@ -763,76 +784,74 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     let retryBackoff = (args["retryBackoffSeconds"] as? [NSNumber])?
       .map { $0.doubleValue } ?? []
 
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(
-        operation: "readInPlaceBytes",
-        relativePath: relativePath
-      ))
-      return
-    }
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "readInPlaceBytes",
+      relativePath: relativePath,
+      result: result
+    ) { [self] containerURL in
+      let fileURL = containerURL.appendingPathComponent(relativePath)
 
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-
-    do {
-      try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
-    } catch {
-      let mapped = mapFileNotFoundError(
-        error,
-        operation: "readInPlaceBytes",
-        relativePath: relativePath
-      ) ?? nativeCodeError(
-        error,
-        operation: "readInPlaceBytes",
-        relativePath: relativePath
-      )
-      result(mapped)
-      return
-    }
-
-    Task { @MainActor [self] in
       do {
-        try await waitForDownloadCompletion(
-          at: fileURL,
-          idleTimeouts: idleTimeouts,
-          retryBackoff: retryBackoff
-        )
+        try FileManager.default.startDownloadingUbiquitousItem(at: fileURL)
       } catch {
-        if let timeoutError = mapTimeoutError(
+        let mapped = mapFileNotFoundError(
           error,
           operation: "readInPlaceBytes",
           relativePath: relativePath
-        ) {
-          result(timeoutError)
-          return
-        }
-        result(nativeCodeError(
+        ) ?? nativeCodeError(
           error,
           operation: "readInPlaceBytes",
           relativePath: relativePath
-        ))
+        )
+        result(mapped)
         return
       }
 
-      readInPlaceBinaryDocument(at: fileURL) { [self] contents, error in
-        if let error = error {
-          let mapped = mapFileNotFoundError(
-            error,
-            operation: "readInPlaceBytes",
-            relativePath: relativePath
-          ) ?? nativeCodeError(
-            error,
-            operation: "readInPlaceBytes",
-            relativePath: relativePath
+      Task { @MainActor [self] in
+        do {
+          try await waitForDownloadCompletion(
+            at: fileURL,
+            idleTimeouts: idleTimeouts,
+            retryBackoff: retryBackoff
           )
-          result(mapped)
+        } catch {
+          if let timeoutError = mapTimeoutError(
+            error,
+            operation: "readInPlaceBytes",
+            relativePath: relativePath
+          ) {
+            result(timeoutError)
+            return
+          }
+          result(nativeCodeError(
+            error,
+            operation: "readInPlaceBytes",
+            relativePath: relativePath
+          ))
           return
         }
 
-        if let contents {
-          result(FlutterStandardTypedData(bytes: contents))
-        } else {
-          result(nil)
+        readInPlaceBinaryDocument(at: fileURL) { [self] contents, error in
+          if let error = error {
+            let mapped = mapFileNotFoundError(
+              error,
+              operation: "readInPlaceBytes",
+              relativePath: relativePath
+            ) ?? nativeCodeError(
+              error,
+              operation: "readInPlaceBytes",
+              relativePath: relativePath
+            )
+            result(mapped)
+            return
+          }
+
+          if let contents {
+            result(FlutterStandardTypedData(bytes: contents))
+          } else {
+            result(nil)
+          }
         }
       }
     }
@@ -940,17 +959,15 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
     
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(
-        operation: "documentExists",
-        relativePath: relativePath
-      ))
-      return
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "documentExists",
+      relativePath: relativePath,
+      result: result
+    ) { containerURL in
+      let fileURL = containerURL.appendingPathComponent(relativePath)
+      result(FileManager.default.fileExists(atPath: fileURL.path))
     }
-
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-    result(FileManager.default.fileExists(atPath: fileURL.path))
   }
 
   /// Get file or directory metadata without downloading content.
@@ -964,44 +981,42 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
     
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(
-        operation: "getDocumentMetadata",
-        relativePath: relativePath
-      ))
-      return
-    }
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "getDocumentMetadata",
+      relativePath: relativePath,
+      result: result
+    ) { [self] containerURL in
+      let fileURL = containerURL.appendingPathComponent(relativePath)
+      guard FileManager.default.fileExists(atPath: fileURL.path) else {
+        result(nil)
+        return
+      }
 
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-    guard FileManager.default.fileExists(atPath: fileURL.path) else {
-      result(nil)
-      return
-    }
-
-    do {
-      let values = try fileURL.resourceValues(forKeys: [
-        .isDirectoryKey,
-        .fileSizeKey,
-        .creationDateKey,
-        .contentModificationDateKey,
-        .ubiquitousItemDownloadingStatusKey,
-        .ubiquitousItemIsDownloadingKey,
-        .ubiquitousItemIsUploadedKey,
-        .ubiquitousItemIsUploadingKey,
-        .ubiquitousItemHasUnresolvedConflictsKey,
-      ])
-      result(mapResourceValues(
-        fileURL: fileURL,
-        values: values,
-        containerPath: containerURL.standardizedFileURL.path
-      ))
-    } catch {
-      result(nativeCodeError(
-        error,
-        operation: "getDocumentMetadata",
-        relativePath: relativePath
-      ))
+      do {
+        let values = try fileURL.resourceValues(forKeys: [
+          .isDirectoryKey,
+          .fileSizeKey,
+          .creationDateKey,
+          .contentModificationDateKey,
+          .ubiquitousItemDownloadingStatusKey,
+          .ubiquitousItemIsDownloadingKey,
+          .ubiquitousItemIsUploadedKey,
+          .ubiquitousItemIsUploadingKey,
+          .ubiquitousItemHasUnresolvedConflictsKey,
+        ])
+        result(mapResourceValues(
+          fileURL: fileURL,
+          values: values,
+          containerPath: containerURL.standardizedFileURL.path
+        ))
+      } catch {
+        result(nativeCodeError(
+          error,
+          operation: "getDocumentMetadata",
+          relativePath: relativePath
+        ))
+      }
     }
   }
 
@@ -1019,50 +1034,47 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
-    guard let containerURL = FileManager.default.url(
-      forUbiquityContainerIdentifier: containerId
-    ) else {
-      result(containerAccessError(
-        operation: "getItemMetadata",
-        relativePath: relativePath
-      ))
-      return
-    }
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "getItemMetadata",
+      relativePath: relativePath,
+      result: result
+    ) { [self] containerURL in
+      let fileURL = containerURL.appendingPathComponent(relativePath)
+      guard FileManager.default.fileExists(atPath: fileURL.path) else {
+        result(nil)
+        return
+      }
 
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-    guard FileManager.default.fileExists(atPath: fileURL.path) else {
-      result(nil)
-      return
-    }
-
-    do {
-      let values = try fileURL.resourceValues(forKeys: [
-        .isDirectoryKey,
-        .fileSizeKey,
-        .creationDateKey,
-        .contentModificationDateKey,
-        .ubiquitousItemDownloadingStatusKey,
-        .ubiquitousItemIsDownloadingKey,
-        .ubiquitousItemIsUploadedKey,
-        .ubiquitousItemIsUploadingKey,
-        .ubiquitousItemHasUnresolvedConflictsKey,
-      ])
-      let containerPath = containerURL.standardizedFileURL.path
-      var metadata = mapResourceValues(
-        fileURL: fileURL,
-        values: values,
-        containerPath: containerPath
-      )
-      metadata["downloadStatus"] = normalizeDownloadStatus(
-        values.ubiquitousItemDownloadingStatus
-      ) ?? values.ubiquitousItemDownloadingStatus?.rawValue
-      result(metadata)
-    } catch {
-      result(nativeCodeError(
-        error,
-        operation: "getItemMetadata",
-        relativePath: relativePath
-      ))
+      do {
+        let values = try fileURL.resourceValues(forKeys: [
+          .isDirectoryKey,
+          .fileSizeKey,
+          .creationDateKey,
+          .contentModificationDateKey,
+          .ubiquitousItemDownloadingStatusKey,
+          .ubiquitousItemIsDownloadingKey,
+          .ubiquitousItemIsUploadedKey,
+          .ubiquitousItemIsUploadingKey,
+          .ubiquitousItemHasUnresolvedConflictsKey,
+        ])
+        let containerPath = containerURL.standardizedFileURL.path
+        var metadata = mapResourceValues(
+          fileURL: fileURL,
+          values: values,
+          containerPath: containerPath
+        )
+        metadata["downloadStatus"] = normalizeDownloadStatus(
+          values.ubiquitousItemDownloadingStatus
+        ) ?? values.ubiquitousItemDownloadingStatus?.rawValue
+        result(metadata)
+      } catch {
+        result(nativeCodeError(
+          error,
+          operation: "getItemMetadata",
+          relativePath: relativePath
+        ))
+      }
     }
   }
   
@@ -1085,87 +1097,87 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
 
     let subdir = args["relativePath"] as? String
 
-    guard let containerURL = FileManager.default
-      .url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(operation: "listContents", relativePath: subdir))
-      return
-    }
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "listContents",
+      relativePath: subdir,
+      result: result
+    ) { [self] containerURL in
+      let listURL = subdir != nil
+        ? containerURL.appendingPathComponent(subdir!)
+        : containerURL
 
-    let listURL = subdir != nil
-      ? containerURL.appendingPathComponent(subdir!)
-      : containerURL
+      let keys: [URLResourceKey] = [
+        .isDirectoryKey,
+        .ubiquitousItemDownloadingStatusKey,
+        .ubiquitousItemIsDownloadingKey,
+        .ubiquitousItemIsUploadedKey,
+        .ubiquitousItemIsUploadingKey,
+        .ubiquitousItemHasUnresolvedConflictsKey,
+      ]
 
-    let keys: [URLResourceKey] = [
-      .isDirectoryKey,
-      .ubiquitousItemDownloadingStatusKey,
-      .ubiquitousItemIsDownloadingKey,
-      .ubiquitousItemIsUploadedKey,
-      .ubiquitousItemIsUploadingKey,
-      .ubiquitousItemHasUnresolvedConflictsKey,
-    ]
-
-    DispatchQueue.global(qos: .userInitiated).async {
-      do {
-        let contents = try FileManager.default.contentsOfDirectory(
-          at: listURL,
-          includingPropertiesForKeys: keys,
-          // Do NOT use .skipsHiddenFiles — iCloud placeholders
-          // have a leading dot and would be filtered out.
-          options: []
-        )
-
-        let containerPath = containerURL.standardizedFileURL.path
-        let keysSet = Set(keys)
-        let parentRelative = self.relativePath(
-          for: listURL, containerPath: containerPath
-        )
-        var items: [[String: Any?]] = []
-
-        for fileURL in contents {
-          let diskName = fileURL.lastPathComponent
-          let resolvedName = self.resolveICloudPlaceholderName(diskName)
-
-          // Skip system hidden files (.DS_Store, .Trash, etc.).
-          // Placeholder files (.foo.icloud) have already been resolved
-          // to their real name, so they pass through this filter.
-          if resolvedName.hasPrefix(".") { continue }
-
-          let values = try fileURL.resourceValues(
-            forKeys: keysSet
+      DispatchQueue.global(qos: .userInitiated).async {
+        do {
+          let contents = try FileManager.default.contentsOfDirectory(
+            at: listURL,
+            includingPropertiesForKeys: keys,
+            // Do NOT use .skipsHiddenFiles — iCloud placeholders
+            // have a leading dot and would be filtered out.
+            options: []
           )
 
-          // Build relative path from the container root so the
-          // result is usable with other plugin methods.
-          let itemRelativePath = parentRelative.isEmpty
-            ? resolvedName
-            : parentRelative + "/" + resolvedName
+          let containerPath = containerURL.standardizedFileURL.path
+          let keysSet = Set(keys)
+          let parentRelative = self.relativePath(
+            for: listURL, containerPath: containerPath
+          )
+          var items: [[String: Any?]] = []
 
-          items.append([
-            "relativePath": itemRelativePath,
-            "isDirectory": values.isDirectory ?? false,
-            "downloadStatus": self.normalizeDownloadStatus(
-              values.ubiquitousItemDownloadingStatus
-            ),
-            "isDownloading":
-              values.ubiquitousItemIsDownloading ?? false,
-            "isUploaded":
-              values.ubiquitousItemIsUploaded ?? false,
-            "isUploading":
-              values.ubiquitousItemIsUploading ?? false,
-            "hasUnresolvedConflicts":
-              values.ubiquitousItemHasUnresolvedConflicts ?? false,
-          ])
-        }
+          for fileURL in contents {
+            let diskName = fileURL.lastPathComponent
+            let resolvedName = self.resolveICloudPlaceholderName(diskName)
 
-        DispatchQueue.main.async { result(items) }
-      } catch {
-        DispatchQueue.main.async {
-          result(self.nativeCodeError(
-            error,
-            operation: "listContents",
-            relativePath: subdir
-          ))
+            // Skip system hidden files (.DS_Store, .Trash, etc.).
+            // Placeholder files (.foo.icloud) have already been resolved
+            // to their real name, so they pass through this filter.
+            if resolvedName.hasPrefix(".") { continue }
+
+            let values = try fileURL.resourceValues(
+              forKeys: keysSet
+            )
+
+            // Build relative path from the container root so the
+            // result is usable with other plugin methods.
+            let itemRelativePath = parentRelative.isEmpty
+              ? resolvedName
+              : parentRelative + "/" + resolvedName
+
+            items.append([
+              "relativePath": itemRelativePath,
+              "isDirectory": values.isDirectory ?? false,
+              "downloadStatus": self.normalizeDownloadStatus(
+                values.ubiquitousItemDownloadingStatus
+              ),
+              "isDownloading":
+                values.ubiquitousItemIsDownloading ?? false,
+              "isUploaded":
+                values.ubiquitousItemIsUploaded ?? false,
+              "isUploading":
+                values.ubiquitousItemIsUploading ?? false,
+              "hasUnresolvedConflicts":
+                values.ubiquitousItemHasUnresolvedConflicts ?? false,
+            ])
+          }
+
+          DispatchQueue.main.async { result(items) }
+        } catch {
+          DispatchQueue.main.async {
+            result(self.nativeCodeError(
+              error,
+              operation: "listContents",
+              relativePath: subdir
+            ))
+          }
         }
       }
     }
@@ -1224,43 +1236,42 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
     
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(
-        operation: "delete",
-        relativePath: relativePath
-      ))
-      return
-    }
-    DebugHelper.log("containerURL: \(containerURL.path)")
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "delete",
+      relativePath: relativePath,
+      result: result
+    ) { [self] containerURL in
+      DebugHelper.log("containerURL: \(containerURL.path)")
 
-    let fileURL = containerURL.appendingPathComponent(relativePath)
-    guard FileManager.default.fileExists(atPath: fileURL.path) else {
-      result(itemNotFoundError(operation: "delete", relativePath: relativePath))
-      return
-    }
+      let fileURL = containerURL.appendingPathComponent(relativePath)
+      guard FileManager.default.fileExists(atPath: fileURL.path) else {
+        result(itemNotFoundError(operation: "delete", relativePath: relativePath))
+        return
+      }
 
-    let fileCoordinator = NSFileCoordinator(filePresenter: nil)
-    fileCoordinator.coordinate(
-      writingItemAt: fileURL,
-      options: NSFileCoordinator.WritingOptions.forDeleting,
-      error: nil
-    ) { writingURL in
-      do {
-        try FileManager.default.removeItem(at: writingURL)
-        result(nil)
-      } catch {
-        DebugHelper.log("error: \(error.localizedDescription)")
-        let mapped = mapFileNotFoundError(
-          error,
-          operation: "delete",
-          relativePath: relativePath
-        ) ?? nativeCodeError(
-          error,
-          operation: "delete",
-          relativePath: relativePath
-        )
-        result(mapped)
+      let fileCoordinator = NSFileCoordinator(filePresenter: nil)
+      fileCoordinator.coordinate(
+        writingItemAt: fileURL,
+        options: NSFileCoordinator.WritingOptions.forDeleting,
+        error: nil
+      ) { writingURL in
+        do {
+          try FileManager.default.removeItem(at: writingURL)
+          result(nil)
+        } catch {
+          DebugHelper.log("error: \(error.localizedDescription)")
+          let mapped = mapFileNotFoundError(
+            error,
+            operation: "delete",
+            relativePath: relativePath
+          ) ?? nativeCodeError(
+            error,
+            operation: "delete",
+            relativePath: relativePath
+          )
+          result(mapped)
+        }
       }
     }
   }
@@ -1276,49 +1287,48 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
     
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(
-        operation: "move",
-        relativePath: atRelativePath
-      ))
-      return
-    }
-    DebugHelper.log("containerURL: \(containerURL.path)")
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "move",
+      relativePath: atRelativePath,
+      result: result
+    ) { [self] containerURL in
+      DebugHelper.log("containerURL: \(containerURL.path)")
 
-    let atURL = containerURL.appendingPathComponent(atRelativePath)
-    guard FileManager.default.fileExists(atPath: atURL.path) else {
-      result(itemNotFoundError(operation: "move", relativePath: atRelativePath))
-      return
-    }
+      let atURL = containerURL.appendingPathComponent(atRelativePath)
+      guard FileManager.default.fileExists(atPath: atURL.path) else {
+        result(itemNotFoundError(operation: "move", relativePath: atRelativePath))
+        return
+      }
 
-    let toURL = containerURL.appendingPathComponent(toRelativePath)
-    let fileCoordinator = NSFileCoordinator(filePresenter: nil)
-    fileCoordinator.coordinate(
-      writingItemAt: atURL,
-      options: NSFileCoordinator.WritingOptions.forMoving,
-      writingItemAt: toURL,
-      options: NSFileCoordinator.WritingOptions.forReplacing,
-      error: nil
-    ) { atWritingURL, toWritingURL in
-      do {
-        let toDirURL = toWritingURL.deletingLastPathComponent()
-        if !FileManager.default.fileExists(atPath: toDirURL.path) {
-          try FileManager.default.createDirectory(
-            at: toDirURL,
-            withIntermediateDirectories: true,
-            attributes: nil
-          )
+      let toURL = containerURL.appendingPathComponent(toRelativePath)
+      let fileCoordinator = NSFileCoordinator(filePresenter: nil)
+      fileCoordinator.coordinate(
+        writingItemAt: atURL,
+        options: NSFileCoordinator.WritingOptions.forMoving,
+        writingItemAt: toURL,
+        options: NSFileCoordinator.WritingOptions.forReplacing,
+        error: nil
+      ) { atWritingURL, toWritingURL in
+        do {
+          let toDirURL = toWritingURL.deletingLastPathComponent()
+          if !FileManager.default.fileExists(atPath: toDirURL.path) {
+            try FileManager.default.createDirectory(
+              at: toDirURL,
+              withIntermediateDirectories: true,
+              attributes: nil
+            )
+          }
+          try FileManager.default.moveItem(at: atWritingURL, to: toWritingURL)
+          result(nil)
+        } catch {
+          DebugHelper.log("error: \(error.localizedDescription)")
+          result(nativeCodeError(
+            error,
+            operation: "move",
+            relativePath: atRelativePath
+          ))
         }
-        try FileManager.default.moveItem(at: atWritingURL, to: toWritingURL)
-        result(nil)
-      } catch {
-        DebugHelper.log("error: \(error.localizedDescription)")
-        result(nativeCodeError(
-          error,
-          operation: "move",
-          relativePath: atRelativePath
-        ))
       }
     }
   }
@@ -1334,113 +1344,112 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
     
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(
-        operation: "copy",
-        relativePath: fromRelativePath
-      ))
-      return
-    }
-    DebugHelper.log("containerURL: \(containerURL.path)")
-    
-    let fromURL = containerURL.appendingPathComponent(fromRelativePath)
-    guard FileManager.default.fileExists(atPath: fromURL.path) else {
-      result(itemNotFoundError(operation: "copy", relativePath: fromRelativePath))
-      return
-    }
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "copy",
+      relativePath: fromRelativePath,
+      result: result
+    ) { [self] containerURL in
+      DebugHelper.log("containerURL: \(containerURL.path)")
 
-    let toURL = containerURL.appendingPathComponent(toRelativePath)
-    let fileCoordinator = NSFileCoordinator(filePresenter: nil)
-    var handledExistingDestination = false
-    var overwriteError: Error?
-    var sourceCoordinationError: NSError?
-
-    fileCoordinator.coordinate(
-      readingItemAt: fromURL,
-      options: .withoutChanges,
-      error: &sourceCoordinationError
-    ) { fromReadingURL in
-      do {
-        handledExistingDestination = try copyOverwritingExistingItem(
-          from: fromReadingURL,
-          to: toURL
-        )
-      } catch {
-        overwriteError = error
+      let fromURL = containerURL.appendingPathComponent(fromRelativePath)
+      guard FileManager.default.fileExists(atPath: fromURL.path) else {
+        result(itemNotFoundError(operation: "copy", relativePath: fromRelativePath))
+        return
       }
-    }
 
-    if let sourceCoordinationError {
-      DebugHelper.log("copy source coordination error: \(sourceCoordinationError.localizedDescription)")
-      result(nativeCodeError(
-        sourceCoordinationError,
-        operation: "copy",
-        relativePath: fromRelativePath
-      ))
-      return
-    }
+      let toURL = containerURL.appendingPathComponent(toRelativePath)
+      let fileCoordinator = NSFileCoordinator(filePresenter: nil)
+      var handledExistingDestination = false
+      var overwriteError: Error?
+      var sourceCoordinationError: NSError?
 
-    if let overwriteError {
-      DebugHelper.log("copy error: \(overwriteError.localizedDescription)")
-      result(nativeCodeError(
-        overwriteError,
-        operation: "copy",
-        relativePath: toRelativePath
-      ))
-      return
-    }
-
-    if handledExistingDestination {
-      result(nil)
-      return
-    }
-
-    // Use reading coordination for source and writing coordination for destination
-    var copyCoordinationError: NSError?
-    fileCoordinator.coordinate(
-      readingItemAt: fromURL,
-      options: .withoutChanges,
-      writingItemAt: toURL,
-      options: .forReplacing,
-      error: &copyCoordinationError
-    ) { fromReadingURL, toWritingURL in
-      do {
-        // Create destination directory if needed
-        let toDirURL = toWritingURL.deletingLastPathComponent()
-        if !FileManager.default.fileExists(atPath: toDirURL.path) {
-          try FileManager.default.createDirectory(
-            at: toDirURL,
-            withIntermediateDirectories: true,
-            attributes: nil
+      fileCoordinator.coordinate(
+        readingItemAt: fromURL,
+        options: .withoutChanges,
+        error: &sourceCoordinationError
+      ) { fromReadingURL in
+        do {
+          handledExistingDestination = try copyOverwritingExistingItem(
+            from: fromReadingURL,
+            to: toURL
           )
+        } catch {
+          overwriteError = error
         }
-        
-        // Remove destination file if it exists
-        if FileManager.default.fileExists(atPath: toWritingURL.path) {
-          try FileManager.default.removeItem(at: toWritingURL)
-        }
-        
-        // Copy the file
-        try FileManager.default.copyItem(at: fromReadingURL, to: toWritingURL)
-        result(nil)
-      } catch {
-        DebugHelper.log("copy error: \(error.localizedDescription)")
+      }
+
+      if let sourceCoordinationError {
+        DebugHelper.log("copy source coordination error: \(sourceCoordinationError.localizedDescription)")
         result(nativeCodeError(
-          error,
+          sourceCoordinationError,
+          operation: "copy",
+          relativePath: fromRelativePath
+        ))
+        return
+      }
+
+      if let overwriteError {
+        DebugHelper.log("copy error: \(overwriteError.localizedDescription)")
+        result(nativeCodeError(
+          overwriteError,
+          operation: "copy",
+          relativePath: toRelativePath
+        ))
+        return
+      }
+
+      if handledExistingDestination {
+        result(nil)
+        return
+      }
+
+      // Use reading coordination for source and writing coordination for destination
+      var copyCoordinationError: NSError?
+      fileCoordinator.coordinate(
+        readingItemAt: fromURL,
+        options: .withoutChanges,
+        writingItemAt: toURL,
+        options: .forReplacing,
+        error: &copyCoordinationError
+      ) { fromReadingURL, toWritingURL in
+        do {
+          // Create destination directory if needed
+          let toDirURL = toWritingURL.deletingLastPathComponent()
+          if !FileManager.default.fileExists(atPath: toDirURL.path) {
+            try FileManager.default.createDirectory(
+              at: toDirURL,
+              withIntermediateDirectories: true,
+              attributes: nil
+            )
+          }
+
+          // Remove destination file if it exists
+          if FileManager.default.fileExists(atPath: toWritingURL.path) {
+            try FileManager.default.removeItem(at: toWritingURL)
+          }
+
+          // Copy the file
+          try FileManager.default.copyItem(at: fromReadingURL, to: toWritingURL)
+          result(nil)
+        } catch {
+          DebugHelper.log("copy error: \(error.localizedDescription)")
+          result(nativeCodeError(
+            error,
+            operation: "copy",
+            relativePath: toRelativePath
+          ))
+        }
+      }
+
+      if let copyCoordinationError {
+        DebugHelper.log("copy coordination error: \(copyCoordinationError.localizedDescription)")
+        result(nativeCodeError(
+          copyCoordinationError,
           operation: "copy",
           relativePath: toRelativePath
         ))
       }
-    }
-
-    if let copyCoordinationError {
-      DebugHelper.log("copy coordination error: \(copyCoordinationError.localizedDescription)")
-      result(nativeCodeError(
-        copyCoordinationError,
-        operation: "copy",
-        relativePath: toRelativePath
-      ))
     }
   }
 

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
@@ -150,14 +150,11 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
-    Task { @MainActor [self] in
-      guard let containerURL = await ubiquityContainerResolver.resolve(
-        containerId: containerId
-      ) else {
-        result(containerAccessError(operation: "gather"))
-        return
-      }
-
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "gather",
+      result: result
+    ) { [self] containerURL in
       startGather(
         containerURL: containerURL,
         eventChannelName: eventChannelName,

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
@@ -21,6 +21,15 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     queue.qualityOfService = .userInitiated
     return queue
   }()
+  private let ubiquityContainerResolver: UbiquityContainerResolver
+
+  init(
+    ubiquityContainerResolver: UbiquityContainerResolver = .live
+  ) {
+    self.ubiquityContainerResolver = ubiquityContainerResolver
+    super.init()
+  }
+
   /// Registers the plugin with the Flutter registrar.
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "icloud_storage_plus", binaryMessenger: registrar.messenger)
@@ -107,11 +116,27 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       return
     }
 
-    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId)
-    else {
-      result(containerAccessError(operation: "gather"))
-      return
+    Task { @MainActor [self] in
+      guard let containerURL = await ubiquityContainerResolver.resolve(
+        containerId: containerId
+      ) else {
+        result(containerAccessError(operation: "gather"))
+        return
+      }
+
+      startGather(
+        containerURL: containerURL,
+        eventChannelName: eventChannelName,
+        result: result
+      )
     }
+  }
+
+  private func startGather(
+    containerURL: URL,
+    eventChannelName: String,
+    result: @escaping FlutterResult
+  ) {
     DebugHelper.log("containerURL: \(containerURL.path)")
 
     // Verify event channel handler exists before registering observers

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
@@ -10,9 +10,11 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     label: "icloud_storage_plus.stream_state"
   )
   let querySearchScopes = iCloudMetadataQuerySearchScopes
-  private var queryObservers: [ObjectIdentifier: [NSObjectProtocol]] = [:]
-  private let queryObserversQueue = DispatchQueue(
-    label: "icloud_storage_plus.query_observers"
+  private var metadataQuerySessions: [
+    MetadataQuerySession.ID: MetadataQuerySession
+  ] = [:]
+  private let metadataQuerySessionsQueue = DispatchQueue(
+    label: "icloud_storage_plus.metadata_query_sessions"
   )
   private let metadataQueryOperationQueue: OperationQueue = {
     let queue = OperationQueue()
@@ -28,6 +30,15 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   ) {
     self.ubiquityContainerResolver = ubiquityContainerResolver
     super.init()
+  }
+
+  deinit {
+    let sessions = metadataQuerySessionsQueue.sync {
+      Array(metadataQuerySessions.values)
+    }
+    for session in sessions {
+      session.cancel()
+    }
   }
 
   /// Registers the plugin with the Flutter registrar.
@@ -176,30 +187,38 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     query.operationQueue = metadataQueryOperationQueue
     query.searchScopes = querySearchScopes
     query.predicate = NSPredicate(format: "%K beginswith %@", NSMetadataItemPathKey, containerURL.path)
-    addGatherFilesObservers(query: query, containerURL: containerURL, eventChannelName: eventChannelName, result: result)
+    let session = makeMetadataQuerySession(query: query)
+    addGatherFilesObservers(
+      session: session,
+      containerURL: containerURL,
+      eventChannelName: eventChannelName,
+      result: result
+    )
 
     if let streamHandler {
-      streamHandler.onCancelHandler = { [self] in
-        removeObservers(query)
-        query.stop()
-        removeStreamHandler(eventChannelName)
+      streamHandler.onCancelHandler = { [weak self, weak session] in
+        session?.cancel()
+        self?.removeStreamHandler(eventChannelName)
       }
     }
-    query.start()
+    session.start()
   }
   
   /// Adds observers for metadata gather and update notifications.
-  private func addGatherFilesObservers(query: NSMetadataQuery, containerURL: URL, eventChannelName: String, result: @escaping FlutterResult) {
-    addObserver(
-      for: query,
+  private func addGatherFilesObservers(session: MetadataQuerySession, containerURL: URL, eventChannelName: String, result: @escaping FlutterResult) {
+    session.addObserver(
       name: NSNotification.Name.NSMetadataQueryDidFinishGathering
-    ) { [self] _ in
+    ) { [weak self] session, query, _ in
+      guard let self else { return }
       query.disableUpdates()
-      defer { query.enableUpdates() }
+      defer {
+        if !session.isCancelled {
+          query.enableUpdates()
+        }
+      }
       let results = query.results.compactMap { $0 as? NSMetadataItem }
       if eventChannelName.isEmpty {
-        removeObservers(query)
-        query.stop()
+        session.cancel()
       }
 
       let files = mapFileAttributes(items: results, containerURL: containerURL)
@@ -209,16 +228,20 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     }
     
     if !eventChannelName.isEmpty {
-      addObserver(
-        for: query,
+      session.addObserver(
         name: NSNotification.Name.NSMetadataQueryDidUpdate
-      ) { [self] _ in
+      ) { [weak self] session, query, _ in
+        guard let self else { return }
         guard hasStreamHandler(named: eventChannelName) else {
           return
         }
 
         query.disableUpdates()
-        defer { query.enableUpdates() }
+        defer {
+          if !session.isCancelled {
+            query.enableUpdates()
+          }
+        }
         let results = query.results.compactMap { $0 as? NSMetadataItem }
         let files = mapFileAttributes(items: results, containerURL: containerURL)
         DispatchQueue.main.async {
@@ -405,49 +428,52 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     query.operationQueue = .main
     query.searchScopes = querySearchScopes
     query.predicate = NSPredicate(format: "%K == %@", NSMetadataItemPathKey, cloudFileURL.path)
+    let session = makeMetadataQuerySession(query: query)
 
     guard let uploadStreamHandler = registeredStreamHandler(
       for: eventChannelName
     ) else {
+      session.cancel()
       return
     }
     emitProgress(10.0, eventChannelName: eventChannelName)
-    uploadStreamHandler.onCancelHandler = { [self] in
-      removeObservers(query)
-      query.stop()
-      removeStreamHandler(eventChannelName)
+    uploadStreamHandler.onCancelHandler = { [weak self, weak session] in
+      session?.cancel()
+      self?.removeStreamHandler(eventChannelName)
     }
     addUploadObservers(
-      query: query,
+      session: session,
       cloudRelativePath: cloudRelativePath,
       eventChannelName: eventChannelName
     )
 
-    query.start()
+    session.start()
   }
   
   /// Adds observers for upload progress updates.
   private func addUploadObservers(
-    query: NSMetadataQuery,
+    session: MetadataQuerySession,
     cloudRelativePath: String,
     eventChannelName: String
   ) {
-    addObserver(
-      for: query,
+    session.addObserver(
       name: NSNotification.Name.NSMetadataQueryDidFinishGathering
-    ) { [self] _ in
+    ) { [weak self] session, query, _ in
+      guard let self else { return }
       onUploadQueryNotification(
+        session: session,
         query: query,
         cloudRelativePath: cloudRelativePath,
         eventChannelName: eventChannelName
       )
     }
     
-    addObserver(
-      for: query,
+    session.addObserver(
       name: NSNotification.Name.NSMetadataQueryDidUpdate
-    ) { [self] _ in
+    ) { [weak self] session, query, _ in
+      guard let self else { return }
       onUploadQueryNotification(
+        session: session,
         query: query,
         cloudRelativePath: cloudRelativePath,
         eventChannelName: eventChannelName
@@ -457,11 +483,12 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   
   /// Emits upload progress updates to the event channel.
   private func onUploadQueryNotification(
+    session: MetadataQuerySession,
     query: NSMetadataQuery,
     cloudRelativePath: String,
     eventChannelName: String
   ) {
-    if !query.isStarted {
+    if session.isCancelled || !query.isStarted {
       return
     }
 
@@ -488,8 +515,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
         relativePath: cloudRelativePath
       ))
       streamHandler.setEvent(FlutterEndOfEventStream)
-      removeObservers(query)
-      query.stop()
+      session.cancel()
       removeStreamHandler(eventChannelName)
       return
     }
@@ -503,8 +529,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           return
         }
         streamHandler.setEvent(FlutterEndOfEventStream)
-        removeObservers(query)
-        query.stop()
+        session.cancel()
         removeStreamHandler(eventChannelName)
       }
     }
@@ -556,7 +581,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
         result(value)
       }
 
-      let query: NSMetadataQuery? = eventChannelName.isEmpty
+      let downloadSession: MetadataQuerySession? = eventChannelName.isEmpty
         ? nil
         : {
             let query = NSMetadataQuery()
@@ -567,31 +592,31 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
               NSMetadataItemPathKey,
               cloudFileURL.path
             )
-            return query
+            return makeMetadataQuerySession(query: query)
           }()
 
       let downloadStreamHandler = registeredStreamHandler(for: eventChannelName)
-      downloadStreamHandler?.onCancelHandler = { [self] in
-        if let query {
-          removeObservers(query)
-          query.stop()
-        }
-        removeStreamHandler(eventChannelName)
-        completeOnce(
-          FlutterError(
-            code: "E_CANCEL",
-            message: "Download canceled",
-            details: nil
+      if let downloadSession {
+        downloadStreamHandler?.onCancelHandler = {
+          [weak self, weak downloadSession] in
+          downloadSession?.cancel()
+          self?.removeStreamHandler(eventChannelName)
+          completeOnce(
+            FlutterError(
+              code: "E_CANCEL",
+              message: "Download canceled",
+              details: nil
+            )
           )
-        )
+        }
       }
 
-      if let query {
+      if let downloadSession {
         addDownloadObservers(
-          query: query,
+          session: downloadSession,
           eventChannelName: eventChannelName
         )
-        query.start()
+        downloadSession.start()
       }
       if downloadStreamHandler != nil {
         emitProgress(10.0, eventChannelName: eventChannelName)
@@ -614,10 +639,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           )
           downloadStreamHandler?.setEvent(mapped)
           downloadStreamHandler?.setEvent(FlutterEndOfEventStream)
-          if let query {
-            removeObservers(query)
-            query.stop()
-          }
+          downloadSession?.cancel()
           removeStreamHandler(eventChannelName)
           completeOnce(mapped)
           return
@@ -625,10 +647,7 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
 
         emitProgress(100.0, eventChannelName: eventChannelName)
         downloadStreamHandler?.setEvent(FlutterEndOfEventStream)
-        if let query {
-          removeObservers(query)
-          query.stop()
-        }
+        downloadSession?.cancel()
         removeStreamHandler(eventChannelName)
         completeOnce(nil)
       }
@@ -910,24 +929,26 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   
   /// Adds observers for download progress updates.
   private func addDownloadObservers(
-    query: NSMetadataQuery,
+    session: MetadataQuerySession,
     eventChannelName: String
   ) {
-    addObserver(
-      for: query,
+    session.addObserver(
       name: NSNotification.Name.NSMetadataQueryDidFinishGathering
-    ) { [self] _ in
+    ) { [weak self] session, query, _ in
+      guard let self else { return }
       emitDownloadProgress(
+        session: session,
         query: query,
         eventChannelName: eventChannelName
       )
     }
     
-    addObserver(
-      for: query,
+    session.addObserver(
       name: NSNotification.Name.NSMetadataQueryDidUpdate
-    ) { [self] _ in
+    ) { [weak self] session, query, _ in
+      guard let self else { return }
       emitDownloadProgress(
+        session: session,
         query: query,
         eventChannelName: eventChannelName
       )
@@ -936,10 +957,11 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   
   /// Emits download progress updates.
   private func emitDownloadProgress(
+    session: MetadataQuerySession,
     query: NSMetadataQuery,
     eventChannelName: String
   ) {
-    if !query.isStarted {
+    if session.isCancelled || !query.isStarted {
       return
     }
     guard let fileItem = query.results.first as? NSMetadataItem else { return }
@@ -1514,38 +1536,26 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     return true
   }
   
-  /// Adds an observers for a metadata query.
-  private func addObserver(
-    for query: NSMetadataQuery,
-    name: Notification.Name,
-    using block: @escaping (Notification) -> Void
-  ) {
-    let token = NotificationCenter.default.addObserver(
-      forName: name,
-      object: query,
-      queue: query.operationQueue,
-      using: block
-    )
-    let key = ObjectIdentifier(query)
-    queryObserversQueue.sync {
-      var tokens = queryObservers[key] ?? []
-      tokens.append(token)
-      queryObservers[key] = tokens
+  /// Creates and retains a metadata query session until cleanup completes.
+  private func makeMetadataQuerySession(
+    query: NSMetadataQuery
+  ) -> MetadataQuerySession {
+    let session = MetadataQuerySession(query: query) { [weak self] session in
+      self?.releaseMetadataQuerySession(session)
     }
+    metadataQuerySessionsQueue.sync {
+      metadataQuerySessions[session.id] = session
+    }
+    return session
   }
 
-  /// Removes all observers for a metadata query.
-  private func removeObservers(_ query: NSMetadataQuery) {
-    let key = ObjectIdentifier(query)
-    let tokens: [NSObjectProtocol]? = queryObserversQueue.sync {
-      queryObservers[key]
-    }
-    guard let tokens else { return }
-    for token in tokens {
-      NotificationCenter.default.removeObserver(token)
-    }
-    queryObserversQueue.sync {
-      queryObservers.removeValue(forKey: key)
+  /// Releases a metadata query session after observers have been removed and
+  /// the query has been stopped.
+  private func releaseMetadataQuerySession(
+    _ session: MetadataQuerySession
+  ) {
+    metadataQuerySessionsQueue.sync {
+      metadataQuerySessions.removeValue(forKey: session.id)
     }
   }
   

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift
@@ -80,6 +80,7 @@ extension CoordinatedReplaceWriter {
     static let itemNotDownloadedReplaceStateCode = 2
     static let downloadInProgressReplaceStateCode = 3
     static let directoryReplaceStateCode = 4
+    static let coordinationReplaceStateCode = 5
     static let autoResolveFailedDescriptionMarker = "auto-resolution failed"
 
     static func fileDestinationError(isDirectory: Bool) -> NSError? {
@@ -160,6 +161,18 @@ extension CoordinatedReplaceWriter {
                     + "\(autoResolveFailedDescriptionMarker) — "
                     + underlyingNSError.localizedDescription,
                 NSUnderlyingErrorKey: underlyingNSError,
+            ]
+        )
+    }
+
+    static func coordinationError(underlying: NSError) -> NSError {
+        NSError(
+            domain: replaceStateErrorDomain,
+            code: coordinationReplaceStateCode,
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "File coordination failed while replacing an iCloud item.",
+                NSUnderlyingErrorKey: underlying,
             ]
         )
     }
@@ -274,7 +287,9 @@ extension CoordinatedReplaceWriter {
                 }
 
                 if let coordinationError {
-                    continuation.resume(throwing: coordinationError)
+                    continuation.resume(throwing: Self.coordinationError(
+                        underlying: coordinationError
+                    ))
                     return
                 }
                 if let accessError {

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/MetadataQuerySession.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/MetadataQuerySession.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// Owns an NSMetadataQuery and its NotificationCenter observer tokens for
+/// the full query lifecycle.
+final class MetadataQuerySession {
+    typealias ID = UUID
+    typealias Cleanup = (MetadataQuerySession) -> Void
+    typealias Observer = (
+        MetadataQuerySession,
+        NSMetadataQuery,
+        Notification
+    ) -> Void
+
+    let id = ID()
+    let query: NSMetadataQuery
+
+    private let stateQueue = DispatchQueue(
+        label: "icloud_storage_plus.metadata_query_session"
+    )
+    private var observerTokens: [NSObjectProtocol] = []
+    private var cancelled = false
+    private var cleanupFinished = false
+    private let onCleanup: Cleanup
+
+    var isCancelled: Bool {
+        stateQueue.sync { cancelled }
+    }
+
+    init(
+        query: NSMetadataQuery,
+        onCleanup: @escaping Cleanup
+    ) {
+        self.query = query
+        self.onCleanup = onCleanup
+    }
+
+    @discardableResult
+    func addObserver(
+        name: Notification.Name,
+        using observer: @escaping Observer
+    ) -> Bool {
+        let token = NotificationCenter.default.addObserver(
+            forName: name,
+            object: query,
+            queue: query.operationQueue
+        ) { [weak self] notification in
+            guard let self else { return }
+            observer(self, self.query, notification)
+        }
+
+        let shouldKeepToken = stateQueue.sync {
+            guard !cancelled else { return false }
+            observerTokens.append(token)
+            return true
+        }
+
+        if !shouldKeepToken {
+            NotificationCenter.default.removeObserver(token)
+        }
+        return shouldKeepToken
+    }
+
+    func start() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, !self.isCancelled else { return }
+            self.query.start()
+        }
+    }
+
+    func cancel() {
+        let tokens = stateQueue.sync { () -> [NSObjectProtocol]? in
+            guard !cancelled else { return nil }
+            cancelled = true
+            let tokens = observerTokens
+            observerTokens.removeAll()
+            return tokens
+        }
+
+        guard let tokens else { return }
+        for token in tokens {
+            NotificationCenter.default.removeObserver(token)
+        }
+
+        let stopAndFinish = { [self] in
+            if query.isStarted {
+                query.stop()
+            }
+            finishCleanup()
+        }
+
+        if Thread.isMainThread {
+            stopAndFinish()
+        } else {
+            DispatchQueue.main.async(execute: stopAndFinish)
+        }
+    }
+
+    private func finishCleanup() {
+        let shouldCleanup = stateQueue.sync { () -> Bool in
+            guard !cleanupFinished else { return false }
+            cleanupFinished = true
+            return true
+        }
+
+        if shouldCleanup {
+            onCleanup(self)
+        }
+    }
+}

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -760,6 +760,31 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
         )
     }
 
+    func testCoordinationErrorPreservesUnderlyingNativeSignature() {
+        let underlying = NSError(
+            domain: NSCocoaErrorDomain,
+            code: NSFileWriteUnknownError,
+            userInfo: [NSLocalizedDescriptionKey: "coordination failed"]
+        )
+
+        let wrapped = CoordinatedReplaceWriter.coordinationError(
+            underlying: underlying
+        )
+
+        XCTAssertEqual(
+            wrapped.domain,
+            CoordinatedReplaceWriter.replaceStateErrorDomain
+        )
+        XCTAssertEqual(
+            wrapped.code,
+            CoordinatedReplaceWriter.coordinationReplaceStateCode
+        )
+        XCTAssertEqual(
+            wrapped.userInfo[NSUnderlyingErrorKey] as? NSError,
+            underlying
+        )
+    }
+
     // MARK: - Slice C: deadlock-free coord bridge contract
 
     func testLiveCoordinateReplaceDoesNotStarveCooperativePool() async throws {

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/MetadataQuerySessionTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/MetadataQuerySessionTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import XCTest
+@testable import icloud_storage_plus_foundation
+
+final class MetadataQuerySessionTests: XCTestCase {
+    func testCancelRemovesObserversAndRunsCleanupOnce() {
+        let query = NSMetadataQuery()
+        let notificationName = Notification.Name(
+            "MetadataQuerySessionTests.cancel"
+        )
+        let cleanup = expectation(description: "cleanup")
+        var cleanupCount = 0
+        var notificationCount = 0
+
+        let session = MetadataQuerySession(query: query) { _ in
+            cleanupCount += 1
+            cleanup.fulfill()
+        }
+        session.addObserver(name: notificationName) { _, _, _ in
+            notificationCount += 1
+        }
+
+        NotificationCenter.default.post(name: notificationName, object: query)
+        XCTAssertEqual(notificationCount, 1)
+
+        session.cancel()
+        session.cancel()
+
+        wait(for: [cleanup], timeout: 1.0)
+        NotificationCenter.default.post(name: notificationName, object: query)
+
+        XCTAssertTrue(session.isCancelled)
+        XCTAssertEqual(cleanupCount, 1)
+        XCTAssertEqual(notificationCount, 1)
+    }
+
+    func testAddObserverAfterCancelIsImmediatelyRemoved() {
+        let query = NSMetadataQuery()
+        let notificationName = Notification.Name(
+            "MetadataQuerySessionTests.addAfterCancel"
+        )
+        let cleanup = expectation(description: "cleanup")
+        var notificationCount = 0
+
+        let session = MetadataQuerySession(query: query) { _ in
+            cleanup.fulfill()
+        }
+        session.cancel()
+        wait(for: [cleanup], timeout: 1.0)
+
+        let wasAdded = session.addObserver(name: notificationName) { _, _, _ in
+            notificationCount += 1
+        }
+        NotificationCenter.default.post(name: notificationName, object: query)
+
+        XCTAssertFalse(wasAdded)
+        XCTAssertEqual(notificationCount, 0)
+    }
+}

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/UbiquityContainerResolverTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/UbiquityContainerResolverTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import XCTest
+@testable import icloud_storage_plus_foundation
+
+final class UbiquityContainerResolverTests: XCTestCase {
+    func testLiveResolveRunsBlockingLookupOffMainThread() async throws {
+        let temporaryDirectory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let expectation = expectation(description: "container lookup ran")
+        let lock = NSLock()
+        var observedMainThreadState: Bool?
+        let resolver = UbiquityContainerResolver(
+            execute: UbiquityContainerResolver.live.execute,
+            resolveContainerURL: { _ in
+                lock.lock()
+                observedMainThreadState = Thread.isMainThread
+                lock.unlock()
+                expectation.fulfill()
+                return temporaryDirectory
+            },
+            delay: { _ in XCTFail("should not retry") },
+            retryDelay: UbiquityContainerResolver.maximumRetryDelay
+        )
+
+        let containerURL = await resolver.resolve(containerId: "container")
+
+        await fulfillment(of: [expectation], timeout: 1.0)
+        XCTAssertEqual(containerURL?.path, temporaryDirectory.path)
+        XCTAssertEqual(observedMainThreadState, false)
+    }
+
+    func testResolveRetriesOnceAfterNilResult() async throws {
+        let temporaryDirectory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        var attempts = 0
+        var delays: [TimeInterval] = []
+        let resolver = UbiquityContainerResolver(
+            execute: { work in work() },
+            resolveContainerURL: { _ in
+                attempts += 1
+                if attempts == 2 {
+                    return temporaryDirectory
+                }
+                return nil
+            },
+            delay: { delays.append($0) },
+            retryDelay: UbiquityContainerResolver.maximumRetryDelay
+        )
+
+        let containerURL = await resolver.resolve(containerId: "container")
+
+        XCTAssertEqual(containerURL?.path, temporaryDirectory.path)
+        XCTAssertEqual(attempts, UbiquityContainerResolver.maxAttempts)
+        XCTAssertEqual(
+            delays,
+            [UbiquityContainerResolver.maximumRetryDelay]
+        )
+    }
+
+    func testResolveReturnsNilAfterPersistentNilResults() async {
+        var attempts = 0
+        var delays: [TimeInterval] = []
+        let resolver = UbiquityContainerResolver(
+            execute: { work in work() },
+            resolveContainerURL: { _ in
+                attempts += 1
+                return nil
+            },
+            delay: { delays.append($0) },
+            retryDelay: UbiquityContainerResolver.maximumRetryDelay
+        )
+
+        let containerURL = await resolver.resolve(containerId: "missing")
+
+        XCTAssertNil(containerURL)
+        XCTAssertEqual(attempts, UbiquityContainerResolver.maxAttempts)
+        XCTAssertEqual(
+            delays,
+            [UbiquityContainerResolver.maximumRetryDelay]
+        )
+    }
+
+    func testRetryDelayIsClampedTo150Milliseconds() async {
+        var delays: [TimeInterval] = []
+        let resolver = UbiquityContainerResolver(
+            execute: { work in work() },
+            resolveContainerURL: { _ in nil },
+            delay: { delays.append($0) },
+            retryDelay: 1
+        )
+
+        _ = await resolver.resolve(containerId: "missing")
+
+        XCTAssertEqual(
+            delays,
+            [UbiquityContainerResolver.maximumRetryDelay]
+        )
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: temporaryDirectory,
+            withIntermediateDirectories: true
+        )
+        return temporaryDirectory
+    }
+}

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/UbiquityContainerResolverTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/UbiquityContainerResolverTests.swift
@@ -99,6 +99,24 @@ final class UbiquityContainerResolverTests: XCTestCase {
         )
     }
 
+    func testResolveStopsAfterCancelledRetryDelay() async {
+        var attempts = 0
+        let resolver = UbiquityContainerResolver(
+            execute: { work in work() },
+            resolveContainerURL: { _ in
+                attempts += 1
+                return nil
+            },
+            delay: { _ in throw CancellationError() },
+            retryDelay: UbiquityContainerResolver.maximumRetryDelay
+        )
+
+        let containerURL = await resolver.resolve(containerId: "cancelled")
+
+        XCTAssertNil(containerURL)
+        XCTAssertEqual(attempts, 1)
+    }
+
     private func makeTemporaryDirectory() throws -> URL {
         let temporaryDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/WriteEntrypointPreflightTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/WriteEntrypointPreflightTests.swift
@@ -17,13 +17,18 @@ final class WriteEntrypointPreflightTests: XCTestCase {
 
         let preflight = WriteEntrypointPreflight(
             execute: WriteEntrypointPreflight.live.execute,
-            resolveContainerURL: { _ in
-                lock.lock()
-                observedMainThreadStates.append(Thread.isMainThread)
-                lock.unlock()
-                expectation.fulfill()
-                return temporaryDirectory
-            },
+            ubiquityContainerResolver: UbiquityContainerResolver(
+                execute: UbiquityContainerResolver.live.execute,
+                resolveContainerURL: { _ in
+                    lock.lock()
+                    observedMainThreadStates.append(Thread.isMainThread)
+                    lock.unlock()
+                    expectation.fulfill()
+                    return temporaryDirectory
+                },
+                delay: { _ in XCTFail("should not retry") },
+                retryDelay: UbiquityContainerResolver.maximumRetryDelay
+            ),
             createDirectory: { directoryURL in
                 lock.lock()
                 observedMainThreadStates.append(Thread.isMainThread)
@@ -50,7 +55,12 @@ final class WriteEntrypointPreflightTests: XCTestCase {
     func testPrepareThrowsTypedContainerUnavailableError() async {
         let preflight = WriteEntrypointPreflight(
             execute: { work in try work() },
-            resolveContainerURL: { _ in nil },
+            ubiquityContainerResolver: UbiquityContainerResolver(
+                execute: { work in work() },
+                resolveContainerURL: { _ in nil },
+                delay: { _ in },
+                retryDelay: UbiquityContainerResolver.maximumRetryDelay
+            ),
             createDirectory: { _ in XCTFail("should not create directory") }
         )
 
@@ -79,7 +89,12 @@ final class WriteEntrypointPreflightTests: XCTestCase {
         var createDirectoryCalled = false
         let preflight = WriteEntrypointPreflight(
             execute: { work in try work() },
-            resolveContainerURL: { _ in temporaryDirectory },
+            ubiquityContainerResolver: UbiquityContainerResolver(
+                execute: { work in work() },
+                resolveContainerURL: { _ in temporaryDirectory },
+                delay: { _ in XCTFail("should not retry") },
+                retryDelay: UbiquityContainerResolver.maximumRetryDelay
+            ),
             createDirectory: { _ in createDirectoryCalled = true }
         )
 
@@ -106,11 +121,16 @@ final class WriteEntrypointPreflightTests: XCTestCase {
         var observedMainThreadState: Bool?
         let preflight = WriteEntrypointPreflight(
             execute: WriteEntrypointPreflight.live.execute,
-            resolveContainerURL: { _ in
-                observedMainThreadState = Thread.isMainThread
-                expectation.fulfill()
-                return temporaryDirectory
-            },
+            ubiquityContainerResolver: UbiquityContainerResolver(
+                execute: UbiquityContainerResolver.live.execute,
+                resolveContainerURL: { _ in
+                    observedMainThreadState = Thread.isMainThread
+                    expectation.fulfill()
+                    return temporaryDirectory
+                },
+                delay: { _ in XCTFail("should not retry") },
+                retryDelay: UbiquityContainerResolver.maximumRetryDelay
+            ),
             createDirectory: { _ in XCTFail("should not create directory") }
         )
 
@@ -121,6 +141,51 @@ final class WriteEntrypointPreflightTests: XCTestCase {
         await fulfillment(of: [expectation], timeout: 1.0)
         XCTAssertEqual(containerURL.path, temporaryDirectory.path)
         XCTAssertEqual(observedMainThreadState, false)
+    }
+
+    func testPrepareSucceedsWhenInitialContainerLookupIsNil() async throws {
+        let temporaryDirectory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        var attempts = 0
+        var delays: [TimeInterval] = []
+        var createdDirectory: URL?
+        let preflight = WriteEntrypointPreflight(
+            execute: { work in try work() },
+            ubiquityContainerResolver: UbiquityContainerResolver(
+                execute: { work in work() },
+                resolveContainerURL: { _ in
+                    attempts += 1
+                    return attempts == 2 ? temporaryDirectory : nil
+                },
+                delay: { delays.append($0) },
+                retryDelay: UbiquityContainerResolver.maximumRetryDelay
+            ),
+            createDirectory: { createdDirectory = $0 }
+        )
+
+        let fileURL = try await preflight.prepare(
+            containerId: "container",
+            relativePath: "nested/file.txt"
+        )
+
+        XCTAssertEqual(attempts, UbiquityContainerResolver.maxAttempts)
+        XCTAssertEqual(
+            delays,
+            [UbiquityContainerResolver.maximumRetryDelay]
+        )
+        XCTAssertEqual(
+            fileURL.path,
+            temporaryDirectory
+                .appendingPathComponent("nested/file.txt")
+                .path
+        )
+        XCTAssertEqual(
+            createdDirectory?.path,
+            temporaryDirectory
+                .appendingPathComponent("nested", isDirectory: true)
+                .path
+        )
     }
 
     private func makeTemporaryDirectory() throws -> URL {

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/UbiquityContainerResolver.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/UbiquityContainerResolver.swift
@@ -6,7 +6,7 @@ struct UbiquityContainerResolver {
         @escaping @Sendable () -> URL?
     ) async -> URL?
     typealias ResolveContainerURL = (String) -> URL?
-    typealias Delay = (TimeInterval) async -> Void
+    typealias Delay = (TimeInterval) async throws -> Void
 
     static let maxAttempts = 2
     static let maximumRetryDelay: TimeInterval = 0.15
@@ -25,7 +25,13 @@ struct UbiquityContainerResolver {
             }
 
             if attempt < Self.maxAttempts - 1 {
-                await delay(clampedRetryDelay)
+                do {
+                    try await delay(clampedRetryDelay)
+                } catch is CancellationError {
+                    return nil
+                } catch {
+                    return nil
+                }
             }
         }
 
@@ -53,7 +59,7 @@ extension UbiquityContainerResolver {
         },
         delay: { delay in
             let nanoseconds = UInt64(delay * 1_000_000_000)
-            try? await Task.sleep(nanoseconds: nanoseconds)
+            try await Task.sleep(nanoseconds: nanoseconds)
         },
         retryDelay: maximumRetryDelay
     )

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/UbiquityContainerResolver.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/UbiquityContainerResolver.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+@available(macOS 10.15, iOS 13.0, *)
+struct UbiquityContainerResolver {
+    typealias Execute = (
+        @escaping @Sendable () -> URL?
+    ) async -> URL?
+    typealias ResolveContainerURL = (String) -> URL?
+    typealias Delay = (TimeInterval) async -> Void
+
+    static let maxAttempts = 2
+    static let maximumRetryDelay: TimeInterval = 0.15
+
+    let execute: Execute
+    let resolveContainerURL: ResolveContainerURL
+    let delay: Delay
+    let retryDelay: TimeInterval
+
+    func resolve(containerId: String) async -> URL? {
+        for attempt in 0..<Self.maxAttempts {
+            if let containerURL = await execute({
+                resolveContainerURL(containerId)
+            }) {
+                return containerURL
+            }
+
+            if attempt < Self.maxAttempts - 1 {
+                await delay(clampedRetryDelay)
+            }
+        }
+
+        return nil
+    }
+
+    private var clampedRetryDelay: TimeInterval {
+        max(0, min(retryDelay, Self.maximumRetryDelay))
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, *)
+extension UbiquityContainerResolver {
+    static let live = UbiquityContainerResolver(
+        execute: { work in
+            await withCheckedContinuation {
+                (continuation: CheckedContinuation<URL?, Never>) in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    continuation.resume(returning: work())
+                }
+            }
+        },
+        resolveContainerURL: {
+            FileManager.default.url(forUbiquityContainerIdentifier: $0)
+        },
+        delay: { delay in
+            let nanoseconds = UInt64(delay * 1_000_000_000)
+            try? await Task.sleep(nanoseconds: nanoseconds)
+        },
+        retryDelay: maximumRetryDelay
+    )
+}

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/WriteEntrypointPreflight.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/WriteEntrypointPreflight.swift
@@ -5,21 +5,20 @@ struct WriteEntrypointPreflight {
     typealias Execute = (
         @escaping @Sendable () throws -> URL
     ) async throws -> URL
-    typealias ResolveContainerURL = (String) -> URL?
     typealias CreateDirectory = (URL) throws -> Void
 
     let execute: Execute
-    let resolveContainerURL: ResolveContainerURL
+    let ubiquityContainerResolver: UbiquityContainerResolver
     let createDirectory: CreateDirectory
 
     func containerURL(containerId: String) async throws -> URL {
-        try await execute {
-            guard let containerURL = resolveContainerURL(containerId) else {
-                throw Self.containerUnavailableError()
-            }
-
-            return containerURL
+        guard let containerURL = await ubiquityContainerResolver.resolve(
+            containerId: containerId
+        ) else {
+            throw Self.containerUnavailableError()
         }
+
+        return containerURL
     }
 
     func itemURL(
@@ -41,11 +40,8 @@ struct WriteEntrypointPreflight {
         containerId: String,
         relativePath: String
     ) async throws -> URL {
-        try await execute {
-            guard let containerURL = resolveContainerURL(containerId) else {
-                throw Self.containerUnavailableError()
-            }
-
+        let containerURL = try await containerURL(containerId: containerId)
+        return try await execute {
             let fileURL = containerURL.appendingPathComponent(relativePath)
             try createDirectory(fileURL.deletingLastPathComponent())
             return fileURL
@@ -88,9 +84,7 @@ extension WriteEntrypointPreflight {
                 }
             }
         },
-        resolveContainerURL: {
-            FileManager.default.url(forUbiquityContainerIdentifier: $0)
-        },
+        ubiquityContainerResolver: .live,
         createDirectory: { directoryURL in
             try FileManager.default.createDirectory(
                 at: directoryURL,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: icloud_storage_plus
 description: Flutter plugin for iCloud document storage that syncs across devices with safe file operations and Files app integration.
-version: 2.1.2
+version: 2.1.3
 homepage: https://github.com/kingdomseed/icloud_storage_plus
 
 environment:

--- a/test/icloud_storage_method_channel_test.dart
+++ b/test/icloud_storage_method_channel_test.dart
@@ -412,6 +412,56 @@ void main() {
         throwsA(isA<ICloudInvalidArgumentException>()),
       );
     });
+
+    test('writeInPlace preserves unknown native write enrichment', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (methodCall) async {
+        if (methodCall.method == 'writeInPlace') {
+          throw PlatformException(
+            code: PlatformExceptionCode.nativeCodeError,
+            message: 'Native Code Error',
+            details: {
+              'category': 'unknownNative',
+              'operation': 'writeInPlace',
+              'retryable': false,
+              'relativePath': 'Documents/test.json',
+              'pathKind': 'temporaryReplacement',
+              'nativeDomain': 'NSCocoaErrorDomain',
+              'nativeCode': 640,
+              'nativeDescription': 'The volume is out of space.',
+            },
+          );
+        }
+        return null;
+      });
+
+      await expectLater(
+        () => platform.writeInPlace(
+          containerId: containerId,
+          relativePath: 'Documents/test.json',
+          contents: '{"ok":true}',
+        ),
+        throwsA(
+          isA<ICloudUnknownNativeException>()
+              .having(
+                (error) => error.operation,
+                'operation',
+                'writeInPlace',
+              )
+              .having(
+                (error) => error.pathKind,
+                'pathKind',
+                'temporaryReplacement',
+              )
+              .having(
+                (error) => error.nativeDomain,
+                'nativeDomain',
+                'NSCocoaErrorDomain',
+              )
+              .having((error) => error.nativeCode, 'nativeCode', 640),
+        ),
+      );
+    });
   });
 
   group('writeInPlaceBytes tests:', () {
@@ -452,6 +502,47 @@ void main() {
           contents: Uint8List.fromList([4, 5, 6]),
         ),
         throwsA(isA<ICloudTimeoutException>()),
+      );
+    });
+
+    test('writeInPlaceBytes maps structured coordination payloads', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (methodCall) async {
+        if (methodCall.method == 'writeInPlaceBytes') {
+          throw PlatformException(
+            code: PlatformExceptionCode.coordination,
+            message: 'File coordination failed while replacing an iCloud item.',
+            details: {
+              'category': 'coordination',
+              'operation': 'writeInPlaceBytes',
+              'retryable': false,
+              'relativePath': 'Documents/data.bin',
+              'pathKind': 'destination',
+              'nativeDomain': 'ICloudStoragePlusErrorDomain',
+              'nativeCode': 5,
+              'nativeDescription':
+                  'File coordination failed while replacing an iCloud item.',
+            },
+          );
+        }
+        return null;
+      });
+
+      await expectLater(
+        () => platform.writeInPlaceBytes(
+          containerId: containerId,
+          relativePath: 'Documents/data.bin',
+          contents: Uint8List.fromList([4, 5, 6]),
+        ),
+        throwsA(
+          isA<ICloudCoordinationException>()
+              .having(
+                (error) => error.operation,
+                'operation',
+                'writeInPlaceBytes',
+              )
+              .having((error) => error.pathKind, 'pathKind', 'destination'),
+        ),
       );
     });
   });

--- a/test/icloud_storage_method_channel_test.dart
+++ b/test/icloud_storage_method_channel_test.dart
@@ -165,6 +165,35 @@ void main() {
       expect(eventChannelName, isNotNull);
       expect(eventChannelName, isNotEmpty);
     });
+
+    test('maps structured container access failures', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (methodCall) async {
+        if (methodCall.method == 'gather') {
+          throw PlatformException(
+            code: PlatformExceptionCode.iCloudConnectionOrPermission,
+            message: 'Container unavailable',
+            details: {
+              'category': 'containerAccess',
+              'operation': 'gather',
+              'retryable': false,
+            },
+          );
+        }
+        return null;
+      });
+
+      await expectLater(
+        () => platform.gather(containerId: containerId),
+        throwsA(
+          isA<ICloudContainerAccessException>().having(
+            (error) => error.operation,
+            'operation',
+            'gather',
+          ),
+        ),
+      );
+    });
   });
 
   group('uploadFile tests:', () {

--- a/test/icloud_storage_method_channel_test.dart
+++ b/test/icloud_storage_method_channel_test.dart
@@ -902,6 +902,77 @@ void main() {
     },
   );
 
+  test('documentExists maps structured container access payloads', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (methodCall) async {
+      if (methodCall.method == 'documentExists') {
+        throw PlatformException(
+          code: PlatformExceptionCode.iCloudConnectionOrPermission,
+          message: 'Container unavailable',
+          details: {
+            'category': 'containerAccess',
+            'operation': 'documentExists',
+            'retryable': false,
+            'relativePath': 'file',
+          },
+        );
+      }
+      return null;
+    });
+
+    await expectLater(
+      () => platform.documentExists(
+        containerId: containerId,
+        relativePath: 'file',
+      ),
+      throwsA(
+        isA<ICloudContainerAccessException>()
+            .having(
+              (error) => error.operation,
+              'operation',
+              'documentExists',
+            )
+            .having((error) => error.relativePath, 'relativePath', 'file'),
+      ),
+    );
+  });
+
+  test('writeInPlace maps structured container access payloads', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (methodCall) async {
+      if (methodCall.method == 'writeInPlace') {
+        throw PlatformException(
+          code: PlatformExceptionCode.iCloudConnectionOrPermission,
+          message: 'Container unavailable',
+          details: {
+            'category': 'containerAccess',
+            'operation': 'writeInPlace',
+            'retryable': false,
+            'relativePath': 'file',
+          },
+        );
+      }
+      return null;
+    });
+
+    await expectLater(
+      () => platform.writeInPlace(
+        containerId: containerId,
+        relativePath: 'file',
+        contents: 'contents',
+      ),
+      throwsA(
+        isA<ICloudContainerAccessException>()
+            .having(
+              (error) => error.operation,
+              'operation',
+              'writeInPlace',
+            )
+            .having((error) => error.relativePath, 'relativePath', 'file'),
+      ),
+    );
+  });
+
   test(
     'legacy code only getContainerPath PlatformException is preserved',
     () async {

--- a/test/models/exceptions_test.dart
+++ b/test/models/exceptions_test.dart
@@ -13,6 +13,7 @@ void main() {
           'operation': 'readInPlace',
           'retryable': true,
           'relativePath': 'Documents/file.txt',
+          'pathKind': 'containerRelative',
           'nativeDomain': 'NSCocoaErrorDomain',
           'nativeCode': 42,
           'nativeDescription': 'Description',
@@ -25,6 +26,14 @@ void main() {
       final exception = mapICloudPlatformException(buildError('conflict'));
 
       expect(exception, isA<ICloudConflictException>());
+    });
+
+    test('preserves non-PII native path kind enrichment', () {
+      final exception = mapICloudPlatformException(buildError('unknownNative'));
+
+      expect(exception.pathKind, 'containerRelative');
+      expect(exception.nativeDomain, 'NSCocoaErrorDomain');
+      expect(exception.nativeCode, 42);
     });
 
     test('maps itemNotFound category to ICloudItemNotFoundException', () {


### PR DESCRIPTION
## Summary
- Routes iOS/macOS container lookups through a retrying ubiquity-container resolver, including gather/container operations.
- Retains native metadata query sessions for their full query lifetime.
- Preserves structured native write error context for typed Dart exceptions without exposing local paths.
- Prepares the package metadata for `2.1.3` review only; this PR does not publish to pub.dev.

## Release Review Checklist
- [x] Bumped `pubspec.yaml` to `2.1.3`.
- [x] Bumped iOS and macOS podspec versions to `2.1.3`.
- [x] Added `CHANGELOG.md` entry dated `2026-05-03`.
- [x] `flutter pub publish --dry-run` reports `Package has 0 warnings`.

## Validation
- [x] `flutter pub get`
- [x] `flutter test`
- [x] `swift test` in `ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation`
- [x] `swift test` in `macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation`
- [x] `flutter pub publish --dry-run`

## Post-Merge Publish Steps
- Confirm the merged release commit is clean and reviewed.
- Run the same validation on `main`.
- Create/push the `2.1.3` tag according to the package release process.
- Publish `2.1.3` to pub.dev only after review approval and final validation.

Note: I intentionally did not run plugin lint/analyze because the known Flutter module analyzer failure is expected for this package and should not be changed as part of this release prep.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This release-prep PR introduces three focused improvements: a retrying `UbiquityContainerResolver` that routes all container lookups through a single async helper with up to one 150 ms retry, a `MetadataQuerySession` wrapper that retains query objects and their observer tokens for their full lifetime rather than relying on the plugin to outlive the query, and `pathKind` enrichment on structured native write errors so Dart callers can classify the affected path without seeing local filesystem paths. All changes are symmetric across iOS and macOS, well-tested with new unit tests, and metadata (`pubspec.yaml`, podspecs, CHANGELOG) is bumped to 2.1.3.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

PR is safe to merge — no blocking issues found; all three feature areas (resolver retry, session lifetime, pathKind enrichment) are well-implemented and tested.

No P0 or P1 findings. The threading model in MetadataQuerySession is correct (stateQueue serializes cancel/addObserver; cancel is idempotent). The UbiquityContainerResolver properly propagates CancellationError. Error mapping for E_COORDINATION and pathKind enrichment is complete and symmetric across iOS/macOS. New unit tests cover the critical paths.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/UbiquityContainerResolver.swift | New file: implements retrying container resolver with up to 2 attempts, 150 ms max delay, injectable execute/delay/resolve closures. CancellationError is now handled explicitly after addressing the previous review comment. |
| ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/MetadataQuerySession.swift | New file: owns NSMetadataQuery and its NotificationCenter tokens for the full query lifetime; cancel is idempotent and thread-safe via stateQueue; cleanup callback fires exactly once. |
| ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift | All container-accessing operations now route through the shared resolveContainerURL helper; MetadataQuerySession replaces raw query+observer pairs; nativeWritePathKind and mapNativeWriteError added for structured error enrichment; E_COORDINATION and E_ARG cases added to nativeCodeError. |
| ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/WriteEntrypointPreflight.swift | Replaces the inline resolveContainerURL closure with UbiquityContainerResolver; containerURL() no longer wraps resolution in the execute block since the resolver handles its own threading. |
| ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift | Adds coordinationReplaceStateCode = 5 and a coordinationError() factory that wraps raw NSFileCoordinator errors in the replaceStateErrorDomain so they surface as E_COORDINATION on the Dart side. |
| lib/models/exceptions.dart | Adds nullable pathKind field to ICloudOperationException and all subclasses; propagated through mapICloudPlatformException and _ICloudOperationExceptionData. |
| test/icloud_storage_method_channel_test.dart | New tests cover structured container-access failures for gather/documentExists/writeInPlace, pathKind round-trip for writeInPlace/writeInPlaceBytes, and E_COORDINATION mapping for writeInPlaceBytes. |
| ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/UbiquityContainerResolverTests.swift | Comprehensive tests: off-main-thread execution, single retry on nil, persistent nil returns nil, delay clamping, and CancellationError stops at first attempt. |
| ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/MetadataQuerySessionTests.swift | Tests verify cancel idempotency, observer removal after cancel, and that addObserver after cancel is immediately cleaned up. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Flutter as Flutter (Dart)
    participant Plugin as ICloudStoragePlugin
    participant Resolver as UbiquityContainerResolver
    participant FM as FileManager
    participant MQS as MetadataQuerySession
    participant NC as NotificationCenter

    Flutter->>Plugin: resolveContainerURL(containerId)
    Plugin->>Plugin: Task { @MainActor }
    Plugin->>Resolver: resolve(containerId)
    loop up to 2 attempts (150ms delay)
        Resolver->>FM: url(forUbiquityContainerIdentifier:)
        FM-->>Resolver: URL? (off main thread)
    end
    alt resolved
        Resolver-->>Plugin: URL
        Plugin->>Plugin: onResolved(containerURL)
        Plugin->>MQS: makeMetadataQuerySession(query)
        MQS->>NC: addObserver(forName:)
        MQS-->>Plugin: session
        Plugin->>MQS: session.start()
        MQS->>MQS: DispatchQueue.main: query.start()
        NC-->>MQS: NSMetadataQueryDidFinishGathering
        MQS->>Plugin: observer(session, query, notification)
        Plugin-->>Flutter: result(files)
        Plugin->>MQS: session.cancel()
        MQS->>NC: removeObserver(tokens)
        MQS->>MQS: query.stop()
        MQS->>Plugin: onCleanup -> releaseMetadataQuerySession
    else unavailable
        Resolver-->>Plugin: nil
        Plugin-->>Flutter: FlutterError(E_CONTAINER_ACCESS)
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift`, line 341-345 ([link](https://github.com/kingdomseed/icloud_storage_plus/blob/fc26e44882b7fac62e2ac81ea214df0d3eb78daf/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift#L341-L345)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`uploadFile` included in `isFileContentWriteOperation` but doesn't use `mapNativeWriteError`**

   `isFileContentWriteOperation` returns `true` for `"uploadFile"`, which causes `nativeCodeError` to map `NSFileWriteInvalidFileNameError` / `NSFileWriteUnsupportedSchemeError` to `E_ARG` for upload failures. However, `uploadFile` goes through `CoordinatedReplaceWriter` (which has its own structured error codes) rather than a direct `UIDocument.writeInPlace` path — so it won't independently produce `mapNativeWriteError`-style enrichment. The `E_ARG` mapping for the two Cocoa codes is probably still desirable for upload, but a brief comment explaining why `uploadFile` is included would clarify intent for maintainers.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kingdomseed%2Ficloud_storage_plus%22%20on%20the%20existing%20branch%20%22codex%2Fsentry-icloud-resolver-phase1%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fsentry-icloud-resolver-phase1%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20ios%2Ficloud_storage_plus%2FSources%2Ficloud_storage_plus%2FiOSICloudStoragePlugin.swift%0ALine%3A%20341-345%0A%0AComment%3A%0A**%60uploadFile%60%20included%20in%20%60isFileContentWriteOperation%60%20but%20doesn't%20use%20%60mapNativeWriteError%60**%0A%0A%60isFileContentWriteOperation%60%20returns%20%60true%60%20for%20%60%22uploadFile%22%60%2C%20which%20causes%20%60nativeCodeError%60%20to%20map%20%60NSFileWriteInvalidFileNameError%60%20%2F%20%60NSFileWriteUnsupportedSchemeError%60%20to%20%60E_ARG%60%20for%20upload%20failures.%20However%2C%20%60uploadFile%60%20goes%20through%20%60CoordinatedReplaceWriter%60%20%28which%20has%20its%20own%20structured%20error%20codes%29%20rather%20than%20a%20direct%20%60UIDocument.writeInPlace%60%20path%20%E2%80%94%20so%20it%20won't%20independently%20produce%20%60mapNativeWriteError%60-style%20enrichment.%20The%20%60E_ARG%60%20mapping%20for%20the%20two%20Cocoa%20codes%20is%20probably%20still%20desirable%20for%20upload%2C%20but%20a%20brief%20comment%20explaining%20why%20%60uploadFile%60%20is%20included%20would%20clarify%20intent%20for%20maintainers.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["docs: update 2.1.3 changelog"](https://github.com/kingdomseed/icloud_storage_plus/commit/660488fad72ce49c71a4c33f9d88aca325a823e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30619543)</sub>

<!-- /greptile_comment -->