### PR TITLE
⚡ perf: move synchronous file I/O off MainActor in getDocumentMetadata

### DIFF
--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
@@ -1098,35 +1098,40 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       result: result
     ) { [self] containerURL in
       let fileURL = containerURL.appendingPathComponent(relativePath)
-      guard FileManager.default.fileExists(atPath: fileURL.path) else {
-        result(nil)
-        return
-      }
 
-      do {
-        let values = try fileURL.resourceValues(forKeys: [
-          .isDirectoryKey,
-          .fileSizeKey,
-          .creationDateKey,
-          .contentModificationDateKey,
-          .ubiquitousItemDownloadingStatusKey,
-          .ubiquitousItemIsDownloadingKey,
-          .ubiquitousItemIsUploadedKey,
-          .ubiquitousItemIsUploadingKey,
-          .ubiquitousItemHasUnresolvedConflictsKey,
-        ])
-        let containerPath = containerURL.standardizedFileURL.path
-        result(mapResourceValues(
-          fileURL: fileURL,
-          values: values,
-          containerPath: containerPath
-        ))
-      } catch {
-        result(nativeCodeError(
-          error,
-          operation: "getDocumentMetadata",
-          relativePath: relativePath
-        ))
+      DispatchQueue.global(qos: .userInitiated).async {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+          DispatchQueue.main.async { result(nil) }
+          return
+        }
+
+        do {
+          let values = try fileURL.resourceValues(forKeys: [
+            .isDirectoryKey,
+            .fileSizeKey,
+            .creationDateKey,
+            .contentModificationDateKey,
+            .ubiquitousItemDownloadingStatusKey,
+            .ubiquitousItemIsDownloadingKey,
+            .ubiquitousItemIsUploadedKey,
+            .ubiquitousItemIsUploadingKey,
+            .ubiquitousItemHasUnresolvedConflictsKey,
+          ])
+          let containerPath = containerURL.standardizedFileURL.path
+          let mapped = self.mapResourceValues(
+            fileURL: fileURL,
+            values: values,
+            containerPath: containerPath
+          )
+          DispatchQueue.main.async { result(mapped) }
+        } catch {
+          let nativeError = self.nativeCodeError(
+            error,
+            operation: "getDocumentMetadata",
+            relativePath: relativePath
+          )
+          DispatchQueue.main.async { result(nativeError) }
+        }
       }
     }
   }
@@ -1152,39 +1157,43 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       result: result
     ) { [self] containerURL in
       let fileURL = containerURL.appendingPathComponent(relativePath)
-      guard FileManager.default.fileExists(atPath: fileURL.path) else {
-        result(nil)
-        return
-      }
 
-      do {
-        let values = try fileURL.resourceValues(forKeys: [
-          .isDirectoryKey,
-          .fileSizeKey,
-          .creationDateKey,
-          .contentModificationDateKey,
-          .ubiquitousItemDownloadingStatusKey,
-          .ubiquitousItemIsDownloadingKey,
-          .ubiquitousItemIsUploadedKey,
-          .ubiquitousItemIsUploadingKey,
-          .ubiquitousItemHasUnresolvedConflictsKey,
-        ])
-        let containerPath = containerURL.standardizedFileURL.path
-        var metadata = mapResourceValues(
-          fileURL: fileURL,
-          values: values,
-          containerPath: containerPath
-        )
-        metadata["downloadStatus"] = normalizeDownloadStatus(
-          values.ubiquitousItemDownloadingStatus
-        ) ?? values.ubiquitousItemDownloadingStatus?.rawValue
-        result(metadata)
-      } catch {
-        result(nativeCodeError(
-          error,
-          operation: "getItemMetadata",
-          relativePath: relativePath
-        ))
+      DispatchQueue.global(qos: .userInitiated).async {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+          DispatchQueue.main.async { result(nil) }
+          return
+        }
+
+        do {
+          let values = try fileURL.resourceValues(forKeys: [
+            .isDirectoryKey,
+            .fileSizeKey,
+            .creationDateKey,
+            .contentModificationDateKey,
+            .ubiquitousItemDownloadingStatusKey,
+            .ubiquitousItemIsDownloadingKey,
+            .ubiquitousItemIsUploadedKey,
+            .ubiquitousItemIsUploadingKey,
+            .ubiquitousItemHasUnresolvedConflictsKey,
+          ])
+          let containerPath = containerURL.standardizedFileURL.path
+          var metadata = self.mapResourceValues(
+            fileURL: fileURL,
+            values: values,
+            containerPath: containerPath
+          )
+          metadata["downloadStatus"] = self.normalizeDownloadStatus(
+            values.ubiquitousItemDownloadingStatus
+          ) ?? values.ubiquitousItemDownloadingStatus?.rawValue
+          DispatchQueue.main.async { result(metadata) }
+        } catch {
+          let nativeError = self.nativeCodeError(
+            error,
+            operation: "getItemMetadata",
+            relativePath: relativePath
+          )
+          DispatchQueue.main.async { result(nativeError) }
+        }
       }
     }
   }

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
@@ -1063,34 +1063,39 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       result: result
     ) { [self] containerURL in
       let fileURL = containerURL.appendingPathComponent(relativePath)
-      guard FileManager.default.fileExists(atPath: fileURL.path) else {
-        result(nil)
-        return
-      }
 
-      do {
-        let values = try fileURL.resourceValues(forKeys: [
-          .isDirectoryKey,
-          .fileSizeKey,
-          .creationDateKey,
-          .contentModificationDateKey,
-          .ubiquitousItemDownloadingStatusKey,
-          .ubiquitousItemIsDownloadingKey,
-          .ubiquitousItemIsUploadedKey,
-          .ubiquitousItemIsUploadingKey,
-          .ubiquitousItemHasUnresolvedConflictsKey,
-        ])
-        result(mapResourceValues(
-          fileURL: fileURL,
-          values: values,
-          containerPath: containerURL.standardizedFileURL.path
-        ))
-      } catch {
-        result(nativeCodeError(
-          error,
-          operation: "getDocumentMetadata",
-          relativePath: relativePath
-        ))
+      DispatchQueue.global(qos: .userInitiated).async {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+          DispatchQueue.main.async { result(nil) }
+          return
+        }
+
+        do {
+          let values = try fileURL.resourceValues(forKeys: [
+            .isDirectoryKey,
+            .fileSizeKey,
+            .creationDateKey,
+            .contentModificationDateKey,
+            .ubiquitousItemDownloadingStatusKey,
+            .ubiquitousItemIsDownloadingKey,
+            .ubiquitousItemIsUploadedKey,
+            .ubiquitousItemIsUploadingKey,
+            .ubiquitousItemHasUnresolvedConflictsKey,
+          ])
+          let mapped = self.mapResourceValues(
+            fileURL: fileURL,
+            values: values,
+            containerPath: containerURL.standardizedFileURL.path
+          )
+          DispatchQueue.main.async { result(mapped) }
+        } catch {
+          let nativeError = self.nativeCodeError(
+            error,
+            operation: "getDocumentMetadata",
+            relativePath: relativePath
+          )
+          DispatchQueue.main.async { result(nativeError) }
+        }
       }
     }
   }
@@ -1116,39 +1121,43 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       result: result
     ) { [self] containerURL in
       let fileURL = containerURL.appendingPathComponent(relativePath)
-      guard FileManager.default.fileExists(atPath: fileURL.path) else {
-        result(nil)
-        return
-      }
 
-      do {
-        let values = try fileURL.resourceValues(forKeys: [
-          .isDirectoryKey,
-          .fileSizeKey,
-          .creationDateKey,
-          .contentModificationDateKey,
-          .ubiquitousItemDownloadingStatusKey,
-          .ubiquitousItemIsDownloadingKey,
-          .ubiquitousItemIsUploadedKey,
-          .ubiquitousItemIsUploadingKey,
-          .ubiquitousItemHasUnresolvedConflictsKey,
-        ])
-        let containerPath = containerURL.standardizedFileURL.path
-        var metadata = mapResourceValues(
-          fileURL: fileURL,
-          values: values,
-          containerPath: containerPath
-        )
-        metadata["downloadStatus"] = normalizeDownloadStatus(
-          values.ubiquitousItemDownloadingStatus
-        ) ?? values.ubiquitousItemDownloadingStatus?.rawValue
-        result(metadata)
-      } catch {
-        result(nativeCodeError(
-          error,
-          operation: "getItemMetadata",
-          relativePath: relativePath
-        ))
+      DispatchQueue.global(qos: .userInitiated).async {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+          DispatchQueue.main.async { result(nil) }
+          return
+        }
+
+        do {
+          let values = try fileURL.resourceValues(forKeys: [
+            .isDirectoryKey,
+            .fileSizeKey,
+            .creationDateKey,
+            .contentModificationDateKey,
+            .ubiquitousItemDownloadingStatusKey,
+            .ubiquitousItemIsDownloadingKey,
+            .ubiquitousItemIsUploadedKey,
+            .ubiquitousItemIsUploadingKey,
+            .ubiquitousItemHasUnresolvedConflictsKey,
+          ])
+          let containerPath = containerURL.standardizedFileURL.path
+          var metadata = self.mapResourceValues(
+            fileURL: fileURL,
+            values: values,
+            containerPath: containerPath
+          )
+          metadata["downloadStatus"] = self.normalizeDownloadStatus(
+            values.ubiquitousItemDownloadingStatus
+          ) ?? values.ubiquitousItemDownloadingStatus?.rawValue
+          DispatchQueue.main.async { result(metadata) }
+        } catch {
+          let nativeError = self.nativeCodeError(
+            error,
+            operation: "getItemMetadata",
+            relativePath: relativePath
+          )
+          DispatchQueue.main.async { result(nativeError) }
+        }
       }
     }
   }

--- a/test_perf.swift
+++ b/test_perf.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+func testGetDocumentMetadataPerf() {
+    let containerURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("test_container")
+    try? FileManager.default.createDirectory(at: containerURL, withIntermediateDirectories: true)
+
+    let fileURL = containerURL.appendingPathComponent("test_file.txt")
+    FileManager.default.createFile(atPath: fileURL.path, contents: Data([1,2,3]))
+
+    let iterations = 1000
+
+    // Warmup
+    for _ in 0..<100 {
+        _ = try? fileURL.resourceValues(forKeys: [.isDirectoryKey, .fileSizeKey])
+    }
+
+    let start = CFAbsoluteTimeGetCurrent()
+
+    for _ in 0..<iterations {
+        _ = FileManager.default.fileExists(atPath: fileURL.path)
+        let _ = try? fileURL.resourceValues(forKeys: [
+          .isDirectoryKey,
+          .fileSizeKey,
+          .creationDateKey,
+          .contentModificationDateKey,
+          .ubiquitousItemDownloadingStatusKey,
+          .ubiquitousItemIsDownloadingKey,
+          .ubiquitousItemIsUploadedKey,
+          .ubiquitousItemIsUploadingKey,
+          .ubiquitousItemHasUnresolvedConflictsKey,
+        ])
+        _ = containerURL.standardizedFileURL.path
+    }
+
+    let end = CFAbsoluteTimeGetCurrent()
+    print("Time taken for \(iterations) synchronous file I/O operations: \(end - start) seconds")
+}
+
+testGetDocumentMetadataPerf()


### PR DESCRIPTION
💡 **What:**
Moved synchronous file I/O operations inside `getDocumentMetadata` and `getItemMetadata` (for both iOS and macOS plugins) off the main thread by wrapping them in `DispatchQueue.global(qos: .userInitiated).async`. The Flutter `result` callback is explicitly dispatched back to `DispatchQueue.main.async` to ensure thread safety.

🎯 **Why:**
Previously, `resolveContainerURL` executed its callback on the `MainActor`, meaning subsequent file checks (`FileManager.default.fileExists`) and property lookups (`try fileURL.resourceValues`) ran synchronously on the main UI thread. This optimization prevents blocking the UI, especially critical when reading metadata for remote iCloud files which could stall the app.

📊 **Measured Improvement:**
Since the `swift` compiler is unavailable in the provided Linux environment, a standalone executable benchmark could not be run. However, the theoretical baseline improvement is clear: it reduces main thread stall time from the duration of an I/O request (potentially several milliseconds or more) to zero, allowing the UI to remain responsive during metadata queries. Ensure functionality is preserved through the successful execution of existing `flutter test` checks.

---
*PR created automatically by Jules for task [1773966710348158229](https://jules.google.com/task/1773966710348158229) started by @kingdomseed*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kingdomseed/icloud_storage_plus/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->