### PR TITLE
⚡ Optimize mapFileAttributesFromQuery by avoiding redundant array allocation

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -102,3 +102,17 @@ directory-enumeration loop was removed:
 - `mapFileAttributesFromQuery(query:containerURL:)` (Implementation updated)
 - `getDocumentMetadata` (Implementation updated)
 - `listContents` (Loop optimized in both iOS and macOS plugins)
+
+## Performance Optimization: Avoid Redundant Array Allocation in mapFileAttributesFromQuery
+
+### Issue
+In `ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift`, the `mapFileAttributesFromQuery` method previously iterated over `query.results` to extract `PendingQueryItem`s using `compactMap`, storing them in an intermediate array `pendingItems`. Then, it iterated over `pendingItems` using a `for` loop to build the final `[[String: Any?]]` array. This resulted in redundant array allocations and multiple passes over the data.
+
+### Optimization
+The code was refactored to combine the two passes into a single `compactMap` call. This avoids the allocation of the intermediate `pendingItems` array and reduces the number of loops from two to one, directly mapping `NSMetadataItem`s to the final dictionary format.
+
+### Performance Impact
+The time complexity remains $O(N)$, but memory allocations and redundant iterations are eliminated. This is particularly beneficial when querying directories with thousands of files, leading to faster execution times and lower memory overhead.
+
+### Benchmark
+A standalone Swift benchmark (`scripts/benchmark_map_file_attributes.swift`) was created to simulate processing 100,000 items over 10 iterations. Since the Swift compiler is unavailable in the execution environment, we rely on the logical deduction that avoiding intermediate array allocation and redundant loops strictly improves performance (reducing allocations and passes). The conceptual benchmark script is maintained in the repository for verification on macOS/iOS environments.

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
@@ -266,16 +266,12 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   
   /// Maps query results into metadata dictionaries.
   private func mapFileAttributesFromQuery(query: NSMetadataQuery, containerURL: URL) -> [[String: Any?]] {
-    var fileMaps: [[String: Any?]] = []
-    let pendingItems = query.results.compactMap { item -> PendingQueryItem? in
-      guard let fileItem = item as? NSMetadataItem else { return nil }
-      return extractPendingItem(from: fileItem)
-    }
     let containerPath = containerURL.standardizedFileURL.path
-    for item in pendingItems {
-      fileMaps.append(mapPendingItem(item, containerPath: containerPath))
+    return query.results.compactMap { item -> [String: Any?]? in
+      guard let fileItem = item as? NSMetadataItem,
+            let pendingItem = extractPendingItem(from: fileItem) else { return nil }
+      return mapPendingItem(pendingItem, containerPath: containerPath)
     }
-    return fileMaps
   }
 
   private struct PendingQueryItem {

--- a/scripts/benchmark_map_file_attributes.swift
+++ b/scripts/benchmark_map_file_attributes.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+struct PendingQueryItem {
+    let url: URL
+    let size: Any?
+}
+
+class FakeNSMetadataItem {
+    var url: URL?
+    init(url: URL?) { self.url = url }
+}
+
+let itemCount = 100_000
+let items: [Any] = (0..<itemCount).map { i in
+    FakeNSMetadataItem(url: URL(fileURLWithPath: "/tmp/\(i)"))
+}
+
+func extractPendingItem(from item: FakeNSMetadataItem) -> PendingQueryItem? {
+    guard let url = item.url else { return nil }
+    return PendingQueryItem(url: url, size: 100)
+}
+
+func mapPendingItem(_ item: PendingQueryItem, containerPath: String) -> [String: Any?] {
+    return [
+        "relativePath": item.url.path,
+        "isDirectory": false,
+        "sizeInBytes": item.size
+    ]
+}
+
+func mapFileAttributesFromQuery_original(results: [Any], containerPath: String) -> [[String: Any?]] {
+    var fileMaps: [[String: Any?]] = []
+    let pendingItems = results.compactMap { item -> PendingQueryItem? in
+      guard let fileItem = item as? FakeNSMetadataItem else { return nil }
+      return extractPendingItem(from: fileItem)
+    }
+    for item in pendingItems {
+      fileMaps.append(mapPendingItem(item, containerPath: containerPath))
+    }
+    return fileMaps
+}
+
+func mapFileAttributesFromQuery_optimized(results: [Any], containerPath: String) -> [[String: Any?]] {
+    return results.compactMap { item -> [String: Any?]? in
+      guard let fileItem = item as? FakeNSMetadataItem,
+            let pendingItem = extractPendingItem(from: fileItem) else { return nil }
+      return mapPendingItem(pendingItem, containerPath: containerPath)
+    }
+}
+
+// Warmup
+_ = mapFileAttributesFromQuery_original(results: items, containerPath: "/tmp")
+_ = mapFileAttributesFromQuery_optimized(results: items, containerPath: "/tmp")
+
+let iterations = 10
+
+let startOriginal = CFAbsoluteTimeGetCurrent()
+for _ in 0..<iterations {
+    _ = mapFileAttributesFromQuery_original(results: items, containerPath: "/tmp")
+}
+let timeOriginal = CFAbsoluteTimeGetCurrent() - startOriginal
+
+let startOptimized = CFAbsoluteTimeGetCurrent()
+for _ in 0..<iterations {
+    _ = mapFileAttributesFromQuery_optimized(results: items, containerPath: "/tmp")
+}
+let timeOptimized = CFAbsoluteTimeGetCurrent() - startOptimized
+
+print("Performance comparison for mapFileAttributesFromQuery (100,000 items, 10 iterations):")
+print("Original time: \(String(format: "%.4f", timeOriginal)) seconds")
+print("Optimized time: \(String(format: "%.4f", timeOptimized)) seconds")
+let improvement = (timeOriginal - timeOptimized) / timeOriginal * 100
+print("Improvement: \(String(format: "%.2f", improvement))%")


### PR DESCRIPTION
💡 **What:** Refactored `mapFileAttributesFromQuery` in `iOSICloudStoragePlugin.swift` to merge an intermediate array allocation (`compactMap`) and a subsequent `for` loop into a single pass.
🎯 **Why:** To improve performance and memory usage by reducing redundant iterations over `query.results` and eliminating the creation of the temporary `pendingItems` array. This is especially beneficial when handling thousands of files in large iCloud containers.
📊 **Measured Improvement:** Since `swift` is not available in the execution environment to execute standalone benchmarks, analytical reasoning was applied: merging two loops into one and avoiding memory allocation necessarily improves runtime overhead. A theoretical benchmark script `scripts/benchmark_map_file_attributes.swift` was added and `BENCHMARK.md` was updated.

---
*PR created automatically by Jules for task [5374875045378659345](https://jules.google.com/task/5374875045378659345) started by @kingdomseed*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kingdomseed/icloud_storage_plus/pull/33" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->