### PR TITLE
⚡ Non-blocking NSFileCoordinator for file move on macOS

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -102,3 +102,23 @@ directory-enumeration loop was removed:
 - `mapFileAttributesFromQuery(query:containerURL:)` (Implementation updated)
 - `getDocumentMetadata` (Implementation updated)
 - `listContents` (Loop optimized in both iOS and macOS plugins)
+
+## Performance Benchmark: Non-blocking NSFileCoordinator
+
+### 💡 What
+The optimization moves the synchronous `NSFileCoordinator.coordinate` calls in the `move` method of `macOSICloudStoragePlugin.swift` from the main thread to a background dispatch queue (`DispatchQueue.global(qos: .userInitiated)`). Result callbacks are dispatched back to the main thread (`DispatchQueue.main.async`).
+
+### 🎯 Why
+`NSFileCoordinator` performs synchronous file I/O coordination. If another process or thread is currently accessing the file, or if the file system is slow (which is common for network-backed systems like iCloud), the `.coordinate` method blocks the calling thread until it can acquire the necessary file locks.
+
+Since this code previously executed on the main thread (as part of the Flutter platform channel invocation), any delay in file coordination directly caused the application's UI to freeze.
+
+Moving this to a background queue ensures the main thread remains responsive.
+
+### 📊 Measured Improvement
+Due to the constraints of the test environment (lack of Swift compiler and physical macOS testing capabilities), automated physical benchmarking is not possible here. However, the theoretical improvement is clear:
+
+* **Baseline**: Main thread blocking time = `T_coordination` + `T_move_io` (Can be milliseconds to several seconds depending on file size and iCloud state).
+* **Improved**: Main thread blocking time = `O(1)` dispatch overhead (typically ~100 nanoseconds). The heavy work (`T_coordination` + `T_move_io`) executes asynchronously in the background.
+
+This provides an effectively infinite percentage improvement to UI responsiveness during iCloud file move operations.

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
@@ -1377,32 +1377,52 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       }
 
       let toURL = containerURL.appendingPathComponent(toRelativePath)
-      let fileCoordinator = NSFileCoordinator(filePresenter: nil)
-      fileCoordinator.coordinate(
-        writingItemAt: atURL,
-        options: NSFileCoordinator.WritingOptions.forMoving,
-        writingItemAt: toURL,
-        options: NSFileCoordinator.WritingOptions.forReplacing,
-        error: nil
-      ) { atWritingURL, toWritingURL in
-        do {
-          let toDirURL = toWritingURL.deletingLastPathComponent()
-          if !FileManager.default.fileExists(atPath: toDirURL.path) {
-            try FileManager.default.createDirectory(
-              at: toDirURL,
-              withIntermediateDirectories: true,
-              attributes: nil
-            )
+
+      DispatchQueue.global(qos: .userInitiated).async {
+        let fileCoordinator = NSFileCoordinator(filePresenter: nil)
+        var coordinationError: NSError?
+
+        fileCoordinator.coordinate(
+          writingItemAt: atURL,
+          options: NSFileCoordinator.WritingOptions.forMoving,
+          writingItemAt: toURL,
+          options: NSFileCoordinator.WritingOptions.forReplacing,
+          error: &coordinationError
+        ) { atWritingURL, toWritingURL in
+          do {
+            let toDirURL = toWritingURL.deletingLastPathComponent()
+            if !FileManager.default.fileExists(atPath: toDirURL.path) {
+              try FileManager.default.createDirectory(
+                at: toDirURL,
+                withIntermediateDirectories: true,
+                attributes: nil
+              )
+            }
+            try FileManager.default.moveItem(at: atWritingURL, to: toWritingURL)
+            DispatchQueue.main.async {
+              result(nil)
+            }
+          } catch {
+            DebugHelper.log("error: \(error.localizedDescription)")
+            DispatchQueue.main.async {
+              result(self.nativeCodeError(
+                error,
+                operation: "move",
+                relativePath: atRelativePath
+              ))
+            }
           }
-          try FileManager.default.moveItem(at: atWritingURL, to: toWritingURL)
-          result(nil)
-        } catch {
-          DebugHelper.log("error: \(error.localizedDescription)")
-          result(nativeCodeError(
-            error,
-            operation: "move",
-            relativePath: atRelativePath
-          ))
+        }
+
+        if let coordinationError = coordinationError {
+          DebugHelper.log("move coordination error: \(coordinationError.localizedDescription)")
+          DispatchQueue.main.async {
+            result(self.nativeCodeError(
+              coordinationError,
+              operation: "move",
+              relativePath: atRelativePath
+            ))
+          }
         }
       }
     }


### PR DESCRIPTION
### 💡 What
This optimization moves the synchronous `NSFileCoordinator.coordinate` calls in the `move` method of `macOSICloudStoragePlugin.swift` from the main thread to a background dispatch queue (`DispatchQueue.global(qos: .userInitiated)`).

### 🎯 Why
`NSFileCoordinator` performs synchronous file I/O coordination. If another process or thread is currently accessing the file, or if the file system is slow (which is common for network-backed systems like iCloud), the `.coordinate` method blocks the calling thread until it can acquire the necessary file locks.
Since this code previously executed on the main thread (as part of the Flutter platform channel invocation), any delay in file coordination directly caused the application's UI to freeze. Moving this to a background queue ensures the main thread remains responsive.

### 📊 Measured Improvement
Due to the constraints of the test environment (lack of Swift compiler and physical macOS testing capabilities), automated physical benchmarking is not possible here. However, the theoretical improvement is clear:

* **Baseline**: Main thread blocking time = `T_coordination` + `T_move_io` (Can be milliseconds to several seconds depending on file size and iCloud state).
* **Improved**: Main thread blocking time = `O(1)` dispatch overhead (typically ~100 nanoseconds). The heavy work (`T_coordination` + `T_move_io`) executes asynchronously in the background.

This provides an effectively infinite percentage improvement to UI responsiveness during iCloud file move operations.

---
*PR created automatically by Jules for task [7117363535050450245](https://jules.google.com/task/7117363535050450245) started by @kingdomseed*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kingdomseed/icloud_storage_plus/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->