### PR TITLE
⚡ [Performance] Move NSFileCoordinator delete to background queue

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -102,3 +102,52 @@ directory-enumeration loop was removed:
 - `mapFileAttributesFromQuery(query:containerURL:)` (Implementation updated)
 - `getDocumentMetadata` (Implementation updated)
 - `listContents` (Loop optimized in both iOS and macOS plugins)
+
+## Performance Optimization: Non-blocking NSFileCoordinator operations
+
+## Issue
+Synchronous operations such as `NSFileCoordinator.coordinate(writingItemAt:options:error:byAccessor:)` block the thread they are called on while waiting for access to the specified file. When called on the MainActor (main thread), this can lead to UI stutters or complete freezes, especially if the file is being downloaded from iCloud, is locked by another process, or involves high I/O latency.
+
+In our case, the `delete` method was executing its file coordination block directly on the main thread, leading to potential UI blocking.
+
+## Optimization
+We moved the `NSFileCoordinator` invocation and the actual file removal operation to a background queue (`DispatchQueue.global(qos: .userInitiated)`). The `FlutterResult` callback is then dispatched back to the main queue to ensure thread safety when communicating with the Flutter framework.
+
+## Performance Impact
+This optimization reduces the main thread block time from the latency of file coordination + I/O operation (which could be hundreds of milliseconds or even seconds in case of iCloud synchronization waits) to approximately 0 ms (just the dispatch overhead). This vastly improves the responsiveness of the Flutter application's UI when initiating file deletions.
+
+## Micro-benchmark (optional)
+To demonstrate the UI unblocking effect, here is a conceptual Swift snippet that simulates file coordination blocking.
+
+```swift
+import Foundation
+
+func performDeleteSynchronously(fileURL: URL, completion: @escaping () -> Void) {
+    let coordinator = NSFileCoordinator(filePresenter: nil)
+    // Blocks the current thread
+    coordinator.coordinate(writingItemAt: fileURL, options: .forDeleting, error: nil) { url in
+        // Simulate I/O latency
+        Thread.sleep(forTimeInterval: 0.5)
+        completion()
+    }
+}
+
+func performDeleteAsynchronously(fileURL: URL, completion: @escaping () -> Void) {
+    DispatchQueue.global(qos: .userInitiated).async {
+        let coordinator = NSFileCoordinator(filePresenter: nil)
+        coordinator.coordinate(writingItemAt: fileURL, options: .forDeleting, error: nil) { url in
+            // Simulate I/O latency
+            Thread.sleep(forTimeInterval: 0.5)
+            DispatchQueue.main.async {
+                completion()
+            }
+        }
+    }
+}
+
+// In a UI application, calling performDeleteSynchronously would freeze the UI for > 0.5 seconds.
+// Calling performDeleteAsynchronously returns immediately, allowing 60fps scrolling to continue.
+```
+
+## Affected Methods
+- `delete` (in both iOS and macOS plugins)

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
@@ -1361,27 +1361,29 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
         return
       }
 
-      let fileCoordinator = NSFileCoordinator(filePresenter: nil)
-      fileCoordinator.coordinate(
-        writingItemAt: fileURL,
-        options: NSFileCoordinator.WritingOptions.forDeleting,
-        error: nil
-      ) { writingURL in
-        do {
-          try FileManager.default.removeItem(at: writingURL)
-          result(nil)
-        } catch {
-          DebugHelper.log("error: \(error.localizedDescription)")
-          let mapped = mapFileNotFoundError(
-            error,
-            operation: "delete",
-            relativePath: relativePath
-          ) ?? nativeCodeError(
-            error,
-            operation: "delete",
-            relativePath: relativePath
-          )
-          result(mapped)
+      DispatchQueue.global(qos: .userInitiated).async {
+        let fileCoordinator = NSFileCoordinator(filePresenter: nil)
+        fileCoordinator.coordinate(
+          writingItemAt: fileURL,
+          options: NSFileCoordinator.WritingOptions.forDeleting,
+          error: nil
+        ) { writingURL in
+          do {
+            try FileManager.default.removeItem(at: writingURL)
+            DispatchQueue.main.async { result(nil) }
+          } catch {
+            DebugHelper.log("error: \(error.localizedDescription)")
+            let mapped = self.mapFileNotFoundError(
+              error,
+              operation: "delete",
+              relativePath: relativePath
+            ) ?? self.nativeCodeError(
+              error,
+              operation: "delete",
+              relativePath: relativePath
+            )
+            DispatchQueue.main.async { result(mapped) }
+          }
         }
       }
     }

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
@@ -1325,27 +1325,29 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
         return
       }
 
-      let fileCoordinator = NSFileCoordinator(filePresenter: nil)
-      fileCoordinator.coordinate(
-        writingItemAt: fileURL,
-        options: NSFileCoordinator.WritingOptions.forDeleting,
-        error: nil
-      ) { writingURL in
-        do {
-          try FileManager.default.removeItem(at: writingURL)
-          result(nil)
-        } catch {
-          DebugHelper.log("error: \(error.localizedDescription)")
-          let mapped = mapFileNotFoundError(
-            error,
-            operation: "delete",
-            relativePath: relativePath
-          ) ?? nativeCodeError(
-            error,
-            operation: "delete",
-            relativePath: relativePath
-          )
-          result(mapped)
+      DispatchQueue.global(qos: .userInitiated).async {
+        let fileCoordinator = NSFileCoordinator(filePresenter: nil)
+        fileCoordinator.coordinate(
+          writingItemAt: fileURL,
+          options: NSFileCoordinator.WritingOptions.forDeleting,
+          error: nil
+        ) { writingURL in
+          do {
+            try FileManager.default.removeItem(at: writingURL)
+            DispatchQueue.main.async { result(nil) }
+          } catch {
+            DebugHelper.log("error: \(error.localizedDescription)")
+            let mapped = self.mapFileNotFoundError(
+              error,
+              operation: "delete",
+              relativePath: relativePath
+            ) ?? self.nativeCodeError(
+              error,
+              operation: "delete",
+              relativePath: relativePath
+            )
+            DispatchQueue.main.async { result(mapped) }
+          }
         }
       }
     }


### PR DESCRIPTION
💡 **What:** Moved `NSFileCoordinator.coordinate(writingItemAt:options:...)` operations for the `delete` method into a background `DispatchQueue.global(qos: .userInitiated)` queue on both iOS and macOS implementations, ensuring the resulting `FlutterResult` is routed back to the main thread securely.

🎯 **Why:** `NSFileCoordinator` blocks the executing thread synchronously until access is granted. Running it on the MainActor (which is standard for Flutter channel method handling) will freeze the application UI until the synchronization lock, potential iCloud download, and I/O processes finish. Moving it to the background unblocks the UI completely.

📊 **Measured Improvement:** As the provided Linux sandbox lacks the native compilers (`swift`, `xcodebuild`) needed to run standalone macro-benchmarks over native Swift file lock coordination behavior, exact timing cannot be definitively measured here. However, the theoretical main thread block time is reduced from the latency of file coordination + disk I/O (often ~100-500ms depending on conditions) to ~0ms (only the overhead of dispatching to the background queue). A detailed micro-benchmark script illustrating the logic and unblocking effect has been appended to `BENCHMARK.md`.

---
*PR created automatically by Jules for task [4686768747889599894](https://jules.google.com/task/4686768747889599894) started by @kingdomseed*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kingdomseed/icloud_storage_plus/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->