### PR TITLE
fix(MYT-1314): make FlutterError conform to Error so channel throws compile

### DIFF
--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
@@ -2229,3 +2229,13 @@ class DebugHelper {
     #endif
   }
 }
+
+// FlutterError is an NSObject subclass from the Flutter framework (Flutter)
+// that does not conform to Swift's `Error` protocol. The coordinated
+// delete/move/copy mutation helpers throw typed FlutterError instances at the
+// channel boundary so the outer catch sites can recover them via
+// `error as? FlutterError`. This retroactive conformance bridges the
+// Objective-C type into Swift's error machinery so `throw FlutterError`
+// compiles. If Swift 6 language mode is ever enabled, this must become
+// `extension FlutterError: @retroactive Error {}`.
+extension FlutterError: Error {}

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
@@ -2190,3 +2190,13 @@ class DebugHelper {
     #endif
   }
 }
+
+// FlutterError is an NSObject subclass from the Flutter framework (FlutterMacOS)
+// that does not conform to Swift's `Error` protocol. The coordinated
+// delete/move/copy mutation helpers throw typed FlutterError instances at the
+// channel boundary so the outer catch sites can recover them via
+// `error as? FlutterError`. This retroactive conformance bridges the
+// Objective-C type into Swift's error machinery so `throw FlutterError`
+// compiles. If Swift 6 language mode is ever enabled, this must become
+// `extension FlutterError: @retroactive Error {}`.
+extension FlutterError: Error {}


### PR DESCRIPTION
## What & why

M1 scrutiny-gate follow-up. `flutter build macos --debug` (consuming app + git-pinned plugin @ caa4a83) FAILS to compile: the coordinated delete/move/copy helpers in the channel layer `throw` typed `FlutterError` instances, but `FlutterError` (FlutterMacOS/Flutter) is a bare `NSObject` subclass that does **not** conform to Swift's `Error`, so `throw <FlutterError>` is a hard compile error.

This escaped prior gates because `swift test` only compiles the pure-Swift `icloud_storage_plus_foundation` package (no Flutter framework import) and Linux CI never builds macOS/iOS; the channel files (`iOSICloudStoragePlugin.swift` / `macOSICloudStoragePlugin.swift`) only compile under a `flutter build`.

11 throw-sites per platform, confined to deleteCoordinated/moveCoordinated/copyCoordinated. The outer catch sites already do `error as? FlutterError ?? nativeCodeError(...)`, proving the authored intent was a throwable `FlutterError`.

## Fix

Add a one-line retroactive conformance `extension FlutterError: Error {}` to BOTH platform plugin files (macOS imports FlutterMacOS, iOS imports Flutter), byte-identical across platforms, with a comment noting the `@retroactive` form is required if Swift 6 language mode is ever enabled (today both `Package.swift` are swift-tools 5.9, plain form compiles cleanly).

- No throw-site, catch-site, channel-code, or message changes.
- Stable Dart typed-exception mapping unchanged byte-for-byte (E_ARG/E_INIT/E_CTR/E_FNF/E_FNF_WRITE/E_FNF_READ/E_CONFLICT/E_COORDINATION/E_NAT).
- No behavior change. iOS/macOS parity preserved.

This is an accepted, permanent, idiomatic language-level bridge, not a compatibility shim / legacy adapter / temporary workaround (does not violate the no-workaround-debt / no-shims rule).

## Verification

- `swift test` foundation: 60 iOS / 62 macOS passed (green, unchanged).
- `flutter build macos --debug` on the plugin example app: built `icloud_storage_example.app` (channel layer compiles; only a benign Swift-6 retroactive-conformance warning, as expected).
- `flutter build ios --debug --no-codesign` on the plugin example app: built `Runner.app` (iOS channel compiles).
- `swift-icloud-plugin-expert` review (review mode): APPROVED, 0 Critical / 0 Important; parity + channel-code preservation confirmed.

## Tandem

Follow-up app PR will bump `dependency_overrides.icloud_storage_plus.git.ref` to this PR's merged commit hash (explicit immutable hash, not the moving `main` ref). Plugin PR merges FIRST, then the app pin-bump PR.

Refs MYT-1314.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Jason-Holt-Digital/codesmith/icloud_storage_plus/pr/42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->