### PR TITLE
fix(MYT-1314): stop PerPathMutationLane + delete/move/copy blocking the cooperative pool

### DIFF
--- a/ios/icloud_storage_plus.podspec
+++ b/ios/icloud_storage_plus.podspec
@@ -16,6 +16,7 @@ container, with document coordination via UIDocument/NSDocument.
   s.source           = { :path => '.' }
   s.source_files = [
     'icloud_storage_plus/Sources/icloud_storage_plus/**/*.{h,m,swift}',
+    'icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedIO.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/MetadataQuerySupport.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/MetadataQuerySession.swift',

--- a/ios/icloud_storage_plus/Package.swift
+++ b/ios/icloud_storage_plus/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
             ],
             sources: [
                 "icloud_storage_plus",
+                "icloud_storage_plus_foundation/CoordinatedIO.swift",
                 "icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift",
                 "icloud_storage_plus_foundation/MetadataQuerySupport.swift",
                 "icloud_storage_plus_foundation/MetadataQuerySession.swift",

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
@@ -1492,7 +1492,11 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
 
   /// Coordinated delete honoring the coordinator closure URL. Throws a
   /// typed `FlutterError` on coordination or IO failure (coordErr ??
-  /// ioErr — never a silent null/false success).
+  /// ioErr — never a silent null/false success). The blocking
+  /// `NSFileCoordinator.coordinate(...)` is hopped onto a
+  /// `DispatchQueue.global` worker via `CoordinatedIO` so it never
+  /// blocks the Swift cooperative pool (same pattern as
+  /// `CoordinatedReplaceWriter.liveCoordinateReplace`).
   private func deleteCoordinated(
     fileURL: URL,
     relativePath: String
@@ -1501,39 +1505,32 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       throw itemNotFoundError(operation: "delete", relativePath: relativePath)
     }
 
-    let coordinator = NSFileCoordinator(filePresenter: nil)
-    var coordinationError: NSError?
-    var ioError: Error?
-
-    coordinator.coordinate(
-      writingItemAt: fileURL,
-      options: NSFileCoordinator.WritingOptions.forDeleting,
-      error: &coordinationError
-    ) { writingURL in
-      do {
+    do {
+      try await CoordinatedIO.coordinateWriting(
+        at: fileURL,
+        options: NSFileCoordinator.WritingOptions.forDeleting
+      ) { writingURL in
         try FileManager.default.removeItem(at: writingURL)
-      } catch {
-        ioError = error
       }
-    }
-
-    if let coordinationError {
-      throw nativeCodeError(
-        coordinationError,
-        operation: "delete",
-        relativePath: relativePath
-      )
-    }
-    if let ioError {
-      throw mapFileNotFoundError(
-        ioError,
-        operation: "delete",
-        relativePath: relativePath
-      ) ?? nativeCodeError(
-        ioError,
-        operation: "delete",
-        relativePath: relativePath
-      )
+    } catch let bridgeError as CoordinateBridgeError {
+      switch bridgeError {
+      case .coordination(let coordinationError):
+        throw nativeCodeError(
+          coordinationError,
+          operation: "delete",
+          relativePath: relativePath
+        )
+      case .accessor(let ioError):
+        throw mapFileNotFoundError(
+          ioError,
+          operation: "delete",
+          relativePath: relativePath
+        ) ?? nativeCodeError(
+          ioError,
+          operation: "delete",
+          relativePath: relativePath
+        )
+      }
     }
     return nil
   }
@@ -1589,7 +1586,10 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   /// Coordinated move honoring both coordinator closure URLs. Creates
   /// the destination parent directory as needed. Throws a typed
   /// `FlutterError` on coordination or IO failure; preserves the source
-  /// on mid-stage failure (VAL-MUT-054).
+  /// on mid-stage failure (VAL-MUT-054). The blocking
+  /// `NSFileCoordinator.coordinate(...)` is hopped onto a
+  /// `DispatchQueue.global` worker via `CoordinatedIO` so it never
+  /// blocks the Swift cooperative pool.
   private func moveCoordinated(
     atURL: URL,
     toURL: URL,
@@ -1599,18 +1599,13 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       throw itemNotFoundError(operation: "move", relativePath: atRelativePath)
     }
 
-    let coordinator = NSFileCoordinator(filePresenter: nil)
-    var coordinationError: NSError?
-    var ioError: Error?
-
-    coordinator.coordinate(
-      writingItemAt: atURL,
-      options: NSFileCoordinator.WritingOptions.forMoving,
-      writingItemAt: toURL,
-      options: NSFileCoordinator.WritingOptions.forReplacing,
-      error: &coordinationError
-    ) { atWritingURL, toWritingURL in
-      do {
+    do {
+      try await CoordinatedIO.coordinateWritingTwo(
+        writingAt: atURL,
+        options: NSFileCoordinator.WritingOptions.forMoving,
+        writingAt: toURL,
+        options: NSFileCoordinator.WritingOptions.forReplacing
+      ) { atWritingURL, toWritingURL in
         let toDirURL = toWritingURL.deletingLastPathComponent()
         if !FileManager.default.fileExists(atPath: toDirURL.path) {
           try FileManager.default.createDirectory(
@@ -1620,24 +1615,22 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           )
         }
         try FileManager.default.moveItem(at: atWritingURL, to: toWritingURL)
-      } catch {
-        ioError = error
       }
-    }
-
-    if let coordinationError {
-      throw nativeCodeError(
-        coordinationError,
-        operation: "move",
-        relativePath: atRelativePath
-      )
-    }
-    if let ioError {
-      throw nativeCodeError(
-        ioError,
-        operation: "move",
-        relativePath: atRelativePath
-      )
+    } catch let bridgeError as CoordinateBridgeError {
+      switch bridgeError {
+      case .coordination(let coordinationError):
+        throw nativeCodeError(
+          coordinationError,
+          operation: "move",
+          relativePath: atRelativePath
+        )
+      case .accessor(let ioError):
+        throw nativeCodeError(
+          ioError,
+          operation: "move",
+          relativePath: atRelativePath
+        )
+      }
     }
     return nil
   }
@@ -1695,7 +1688,9 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   /// source-read coordination errors distinctly from destination write
   /// errors (coordErr ?? ioErr). Throws a typed `FlutterError` on
   /// failure; leaves no partial destination on mid-stage failure
-  /// (VAL-MUT-054).
+  /// (VAL-MUT-054). The blocking `NSFileCoordinator.coordinate(...)`
+  /// calls are hopped onto a `DispatchQueue.global` worker via
+  /// `CoordinatedIO` so they never block the Swift cooperative pool.
   private func copyCoordinated(
     fromURL: URL,
     toURL: URL,
@@ -1706,42 +1701,34 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       throw itemNotFoundError(operation: "copy", relativePath: fromRelativePath)
     }
 
-    let fileCoordinator = NSFileCoordinator(filePresenter: nil)
-    var handledExistingDestination = false
-    var overwriteError: Error?
-    var sourceCoordinationError: NSError?
-
-    fileCoordinator.coordinate(
-      readingItemAt: fromURL,
-      options: .withoutChanges,
-      error: &sourceCoordinationError
-    ) { fromReadingURL in
-      do {
-        handledExistingDestination = try copyOverwritingExistingItem(
+    let handledExistingDestination: Bool
+    do {
+      handledExistingDestination = try await CoordinatedIO.coordinateReadingReturning(
+        at: fromURL,
+        options: .withoutChanges
+      ) { fromReadingURL in
+        try self.copyOverwritingExistingItem(
           from: fromReadingURL,
           to: toURL
         )
-      } catch {
-        overwriteError = error
       }
-    }
-
-    if let sourceCoordinationError {
-      DebugHelper.log("copy source coordination error: \(sourceCoordinationError.localizedDescription)")
-      throw nativeCodeError(
-        sourceCoordinationError,
-        operation: "copy",
-        relativePath: fromRelativePath
-      )
-    }
-
-    if let overwriteError {
-      DebugHelper.log("copy error: \(overwriteError.localizedDescription)")
-      throw nativeCodeError(
-        overwriteError,
-        operation: "copy",
-        relativePath: toRelativePath
-      )
+    } catch let bridgeError as CoordinateBridgeError {
+      switch bridgeError {
+      case .coordination(let sourceCoordinationError):
+        DebugHelper.log("copy source coordination error: \(sourceCoordinationError.localizedDescription)")
+        throw nativeCodeError(
+          sourceCoordinationError,
+          operation: "copy",
+          relativePath: fromRelativePath
+        )
+      case .accessor(let overwriteError):
+        DebugHelper.log("copy error: \(overwriteError.localizedDescription)")
+        throw nativeCodeError(
+          overwriteError,
+          operation: "copy",
+          relativePath: toRelativePath
+        )
+      }
     }
 
     if handledExistingDestination {
@@ -1750,17 +1737,13 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
 
     // Use reading coordination for source and writing coordination for
     // destination.
-    var copyCoordinationError: NSError?
-    var copyIOError: Error?
-
-    fileCoordinator.coordinate(
-      readingItemAt: fromURL,
-      options: .withoutChanges,
-      writingItemAt: toURL,
-      options: .forReplacing,
-      error: &copyCoordinationError
-    ) { fromReadingURL, toWritingURL in
-      do {
+    do {
+      try await CoordinatedIO.coordinateReadingAndWriting(
+        readingAt: fromURL,
+        readingOptions: .withoutChanges,
+        writingAt: toURL,
+        writingOptions: .forReplacing
+      ) { fromReadingURL, toWritingURL in
         // Create destination directory if needed.
         let toDirURL = toWritingURL.deletingLastPathComponent()
         if !FileManager.default.fileExists(atPath: toDirURL.path) {
@@ -1778,26 +1761,24 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
 
         // Copy the file.
         try FileManager.default.copyItem(at: fromReadingURL, to: toWritingURL)
-      } catch {
-        copyIOError = error
       }
-    }
-
-    if let copyCoordinationError {
-      DebugHelper.log("copy coordination error: \(copyCoordinationError.localizedDescription)")
-      throw nativeCodeError(
-        copyCoordinationError,
-        operation: "copy",
-        relativePath: toRelativePath
-      )
-    }
-    if let copyIOError {
-      DebugHelper.log("copy error: \(copyIOError.localizedDescription)")
-      throw nativeCodeError(
-        copyIOError,
-        operation: "copy",
-        relativePath: toRelativePath
-      )
+    } catch let bridgeError as CoordinateBridgeError {
+      switch bridgeError {
+      case .coordination(let copyCoordinationError):
+        DebugHelper.log("copy coordination error: \(copyCoordinationError.localizedDescription)")
+        throw nativeCodeError(
+          copyCoordinationError,
+          operation: "copy",
+          relativePath: toRelativePath
+        )
+      case .accessor(let copyIOError):
+        DebugHelper.log("copy error: \(copyIOError.localizedDescription)")
+        throw nativeCodeError(
+          copyIOError,
+          operation: "copy",
+          relativePath: toRelativePath
+        )
+      }
     }
     return nil
   }

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedIO.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedIO.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+/// Distinctly surfaces coordinator failures vs inner-IO failures across
+/// the `DispatchQueue.global`-bridged continuation so callers can map
+/// each kind to the appropriate stable channel error (R14:
+/// coordinator-error vs inner-IO-error, never collapsed, never a silent
+/// null/false success).
+enum CoordinateBridgeError: Error {
+    /// `NSFileCoordinator.coordinate(...)` reported a coordination
+    /// failure; the accessor closure never ran.
+    case coordination(NSError)
+    /// The accessor closure threw an inner IO error.
+    case accessor(Error)
+}
+
+/// Async bridges for `NSFileCoordinator.coordinate(...)` (synchronous,
+/// blocking) that hop the blocking call onto a `DispatchQueue.global`
+/// worker via a single-resume continuation, so the Swift cooperative
+/// pool is never blocked by coordination.
+///
+/// This is the SAME deadlock-free pattern as
+/// `CoordinatedReplaceWriter.liveCoordinateReplace`: the accessor runs
+/// synchronously on the dispatch worker per Apple's contract; no
+/// `DispatchSemaphore`, no inner `Task`, no cooperative-pool starvation
+/// surface. The cooperative-pool task suspends at the continuation
+/// while coordination runs on a libdispatch worker, so even a burst of
+/// concurrent coordinated delete/move/copy ops cannot starve other
+/// Swift async work.
+///
+/// Failures are surfaced as `CoordinateBridgeError` so callers can
+/// distinguish coordination failure from inner-IO failure and map them
+/// to distinct stable channel codes/messages byte-for-byte.
+enum CoordinatedIO {
+    /// Bridges `coordinate(writingItemAt:options:error:byAccessor:)`.
+    static func coordinateWriting(
+        at url: URL,
+        options: NSFileCoordinator.WritingOptions,
+        qos: DispatchQoS.QoSClass = .userInitiated,
+        accessor: @escaping @Sendable (URL) throws -> Void
+    ) async throws {
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<Void, Error>) in
+            DispatchQueue.global(qos: qos).async {
+                let coordinator = NSFileCoordinator(filePresenter: nil)
+                var coordinationError: NSError?
+                var accessError: Error?
+
+                coordinator.coordinate(
+                    writingItemAt: url,
+                    options: options,
+                    error: &coordinationError
+                ) { coordinatedURL in
+                    do {
+                        try accessor(coordinatedURL)
+                    } catch {
+                        accessError = error
+                    }
+                }
+
+                Self.resume(continuation, coordination: coordinationError, access: accessError)
+            }
+        }
+    }
+
+    /// Bridges
+    /// `coordinate(writingItemAt:options:writingItemAt:options:error:byAccessor:)`
+    /// (two writing endpoints — used for coordinated move).
+    static func coordinateWritingTwo(
+        writingAt firstURL: URL,
+        options firstOptions: NSFileCoordinator.WritingOptions,
+        writingAt secondURL: URL,
+        options secondOptions: NSFileCoordinator.WritingOptions,
+        qos: DispatchQoS.QoSClass = .userInitiated,
+        accessor: @escaping @Sendable (URL, URL) throws -> Void
+    ) async throws {
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<Void, Error>) in
+            DispatchQueue.global(qos: qos).async {
+                let coordinator = NSFileCoordinator(filePresenter: nil)
+                var coordinationError: NSError?
+                var accessError: Error?
+
+                coordinator.coordinate(
+                    writingItemAt: firstURL,
+                    options: firstOptions,
+                    writingItemAt: secondURL,
+                    options: secondOptions,
+                    error: &coordinationError
+                ) { firstCoordinatedURL, secondCoordinatedURL in
+                    do {
+                        try accessor(firstCoordinatedURL, secondCoordinatedURL)
+                    } catch {
+                        accessError = error
+                    }
+                }
+
+                Self.resume(continuation, coordination: coordinationError, access: accessError)
+            }
+        }
+    }
+
+    /// Bridges `coordinate(readingItemAt:options:error:byAccessor:)`
+    /// and returns a value computed inside the accessor (used for the
+    /// copy overwrite-pre-check, which reports whether an existing
+    /// destination was overwritten).
+    static func coordinateReadingReturning<T: Sendable>(
+        at url: URL,
+        options: NSFileCoordinator.ReadingOptions,
+        qos: DispatchQoS.QoSClass = .userInitiated,
+        accessor: @escaping @Sendable (URL) throws -> T
+    ) async throws -> T {
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<T, Error>) in
+            DispatchQueue.global(qos: qos).async {
+                let coordinator = NSFileCoordinator(filePresenter: nil)
+                var coordinationError: NSError?
+                var accessError: Error?
+                var result: T?
+
+                coordinator.coordinate(
+                    readingItemAt: url,
+                    options: options,
+                    error: &coordinationError
+                ) { coordinatedURL in
+                    do {
+                        result = try accessor(coordinatedURL)
+                    } catch {
+                        accessError = error
+                    }
+                }
+
+                if let coordinationError {
+                    continuation.resume(throwing: CoordinateBridgeError.coordination(coordinationError))
+                    return
+                }
+                if let accessError {
+                    continuation.resume(throwing: CoordinateBridgeError.accessor(accessError))
+                    return
+                }
+                guard let result else {
+                    continuation.resume(throwing: CoordinateBridgeError.accessor(
+                        NSError(
+                            domain: CoordinatedReplaceWriter.replaceStateErrorDomain,
+                            code: CoordinatedReplaceWriter.coordinationReplaceStateCode,
+                            userInfo: [
+                                NSLocalizedDescriptionKey:
+                                    "Coordinated read accessor returned no value.",
+                            ]
+                        )
+                    ))
+                    return
+                }
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
+    /// Bridges
+    /// `coordinate(readingItemAt:options:writingItemAt:options:error:byAccessor:)`
+    /// (read source + write destination — used for coordinated copy).
+    static func coordinateReadingAndWriting(
+        readingAt readingURL: URL,
+        readingOptions: NSFileCoordinator.ReadingOptions,
+        writingAt writingURL: URL,
+        writingOptions: NSFileCoordinator.WritingOptions,
+        qos: DispatchQoS.QoSClass = .userInitiated,
+        accessor: @escaping @Sendable (URL, URL) throws -> Void
+    ) async throws {
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<Void, Error>) in
+            DispatchQueue.global(qos: qos).async {
+                let coordinator = NSFileCoordinator(filePresenter: nil)
+                var coordinationError: NSError?
+                var accessError: Error?
+
+                coordinator.coordinate(
+                    readingItemAt: readingURL,
+                    options: readingOptions,
+                    writingItemAt: writingURL,
+                    options: writingOptions,
+                    error: &coordinationError
+                ) { readingCoordinatedURL, writingCoordinatedURL in
+                    do {
+                        try accessor(readingCoordinatedURL, writingCoordinatedURL)
+                    } catch {
+                        accessError = error
+                    }
+                }
+
+                Self.resume(continuation, coordination: coordinationError, access: accessError)
+            }
+        }
+    }
+
+    /// Resumes the Void continuation exactly once, prioritizing the
+    /// coordination error (the accessor never ran) over the inner-IO
+    /// error, matching the original synchronous helper ordering.
+    private static func resume(
+        _ continuation: CheckedContinuation<Void, Error>,
+        coordination: NSError?,
+        access: Error?
+    ) {
+        if let coordination {
+            continuation.resume(throwing: CoordinateBridgeError.coordination(coordination))
+            return
+        }
+        if let access {
+            continuation.resume(throwing: CoordinateBridgeError.accessor(access))
+            return
+        }
+        continuation.resume()
+    }
+}

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/PerPathMutationLane.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/PerPathMutationLane.swift
@@ -14,13 +14,37 @@ import Foundation
 /// the lane's serialized closure, never the reverse, so no deadlock is
 /// possible.
 ///
-/// Implementation: each normalized path owns a serial `DispatchQueue`.
-/// The calling async task suspends at a single-resume continuation
-/// while the lane's dispatch thread runs the (possibly async) body and
-/// signals completion via a `DispatchSemaphore`. The dispatch thread is
-/// NOT a Swift cooperative-pool thread, so blocking it cannot starve
-/// the cooperative pool — the same deadlock-free bridging pattern used
-/// by `CoordinatedReplaceWriter.liveCoordinateReplace`.
+/// Implementation: each normalized path owns a cooperative async mutex
+/// (a `withCheckedContinuation`-based binary semaphore with a FIFO
+/// waiter queue). The calling async task SUSPENDS cooperatively (it
+/// does NOT block any thread) while waiting for its lane turn, then
+/// runs the (possibly async) body on the Swift cooperative pool. No
+/// `DispatchSemaphore` is used to bridge the body, and no libdispatch
+/// worker thread is blocked for the body's full duration — so
+/// high-fan-out bulk mutations cannot exhaust the libdispatch worker
+/// pool, and a burst of concurrent distinct-path ops cannot starve
+/// other Swift async work.
+///
+/// The blocking `NSFileCoordinator.coordinate(...)` call itself is
+/// never run on a cooperative-pool thread: the coordinated
+/// delete/move/copy helpers hop it onto a `DispatchQueue.global`
+/// worker via a continuation (see `CoordinatedIO` and
+/// `CoordinatedReplaceWriter.liveCoordinateReplace`), so coordination
+/// blocks a libdispatch worker, not a cooperative-pool thread. With
+/// both the cooperative lane acquisition and the coordinated hop, there
+/// is no `DispatchSemaphore.wait()` held for a body's duration and no
+/// cooperative-pool starvation surface.
+///
+/// A counting-semaphore bound on in-flight lanes was considered and
+/// rejected: on a per-path serial-`DispatchQueue` design a global
+/// in-flight bound either fails to reduce blocked worker threads (the
+/// thread is claimed when the block is dispatched, before the bound is
+/// checked) or, if acquired before dispatch, lets a burst of same-path
+/// ops exhaust the bound and starve unrelated cross-path work
+/// (violating no-starvation). Eliminating the per-body thread blocking
+/// entirely (this async-mutex design) bounds thread usage by
+/// construction without breaking the per-path-serial /
+/// cross-path-concurrent / FIFO / no-starvation invariants.
 ///
 /// Idle lanes (no queued and no in-flight op) are reclaimed so the lane
 /// map does not grow unbounded over a long session.
@@ -28,7 +52,7 @@ final class PerPathMutationLane: @unchecked Sendable {
     static let shared = PerPathMutationLane()
 
     private let lock = NSLock()
-    private var lanes: [String: DispatchQueue] = [:]
+    private var lanes: [String: Lane] = [:]
     private var pending: [String: Int] = [:]
 
     /// Test/inspection hook: the number of lanes currently retained.
@@ -57,12 +81,17 @@ final class PerPathMutationLane: @unchecked Sendable {
         perform body: @escaping @Sendable () async throws -> T
     ) async throws -> T {
         let key = Self.normalizationKey(for: url)
-        let queue = acquireLane(key)
-        return try await withCheckedThrowingContinuation {
-            (cont: CheckedContinuation<T, Error>) in
-            queue.async {
-                self.runAsyncBody(body, on: key, resume: cont)
-            }
+        let lane = acquireLane(key)
+        await lane.mutex.acquire()
+        do {
+            let value = try await body()
+            releaseLane(key)
+            lane.mutex.release()
+            return value
+        } catch {
+            releaseLane(key)
+            lane.mutex.release()
+            throw error
         }
     }
 
@@ -83,45 +112,46 @@ final class PerPathMutationLane: @unchecked Sendable {
         }
 
         let (first, second) = keyA < keyB ? (keyA, keyB) : (keyB, keyA)
-        let queueFirst = acquireLane(first)
-
-        return try await withCheckedThrowingContinuation {
-            (cont: CheckedContinuation<T, Error>) in
-            queueFirst.async {
-                // Acquire the second lane and run the body on it. The
-                // first lane's thread blocks here until the body
-                // completes, so BOTH lanes are held for the body's full
-                // duration (cross-path serialization).
-                let queueSecond = self.acquireLane(second)
-                let firstDone = DispatchSemaphore(value: 0)
-                queueSecond.async {
-                    self.runAsyncBody(body, on: second, resume: cont) {
-                        firstDone.signal()
-                    }
-                }
-                firstDone.wait()
-                self.releaseLane(first)
-            }
+        let laneFirst = acquireLane(first)
+        await laneFirst.mutex.acquire()
+        let laneSecond = acquireLane(second)
+        await laneSecond.mutex.acquire()
+        do {
+            let value = try await body()
+            releaseLane(second)
+            laneSecond.mutex.release()
+            releaseLane(first)
+            laneFirst.mutex.release()
+            return value
+        } catch {
+            releaseLane(second)
+            laneSecond.mutex.release()
+            releaseLane(first)
+            laneFirst.mutex.release()
+            throw error
         }
     }
 
     // MARK: - Private
 
-    private func acquireLane(_ key: String) -> DispatchQueue {
+    private func acquireLane(_ key: String) -> Lane {
         lock.lock()
         defer { lock.unlock() }
         pending[key, default: 0] += 1
         if let existing = lanes[key] { return existing }
-        let queue = DispatchQueue(
-            label: "icloud_storage_plus.mutation_lane.\(key)"
-        )
-        lanes[key] = queue
-        return queue
+        let lane = Lane()
+        lanes[key] = lane
+        return lane
     }
 
+    /// Decrements the pending count for `key` and reclaims the lane
+    /// when no op is queued or in flight on it. The mutex itself is
+    /// released separately (by the caller) so its FIFO hand-off to the
+    /// next waiter is preserved; a lane is only reclaimed when pending
+    /// hits zero (no waiters), which is the only safe moment to drop
+    /// the mutex from the map.
     private func releaseLane(_ key: String) {
         lock.lock()
-        defer { lock.unlock() }
         let next = (pending[key] ?? 0) - 1
         if next <= 0 {
             pending.removeValue(forKey: key)
@@ -129,32 +159,56 @@ final class PerPathMutationLane: @unchecked Sendable {
         } else {
             pending[key] = next
         }
+        lock.unlock()
     }
 
-    /// Runs an async `body` while blocking the lane's dispatch thread
-    /// until completion (semaphore-bridged). The continuation is resumed
-    /// exactly once from the async body's Task; the dispatch thread only
-    /// performs lane bookkeeping after the body completes. `onRelease`
-    /// runs after the body completes (used to release the outer lane in
-    /// the cross-path case).
-    private func runAsyncBody<T: Sendable>(
-        _ body: @escaping @Sendable () async throws -> T,
-        on key: String,
-        resume cont: CheckedContinuation<T, Error>,
-        onRelease: () -> Void = {}
-    ) {
-        let semaphore = DispatchSemaphore(value: 0)
-        Task {
-            do {
-                let value = try await body()
-                cont.resume(returning: value)
-            } catch {
-                cont.resume(throwing: error)
+    /// Per-path lane state: a cooperative async mutex.
+    private final class Lane: @unchecked Sendable {
+        let mutex = AsyncMutex()
+    }
+}
+
+/// Cooperative binary mutex with FIFO waiter ordering. Acquisition
+/// SUSPENDS the calling async task (it does NOT block any thread);
+/// release hands off to the earliest waiter or marks the mutex
+/// available. Used by `PerPathMutationLane` to serialize per path
+/// without occupying a libdispatch worker for a body's duration.
+private final class AsyncMutex: @unchecked Sendable {
+    private let lock = NSLock()
+    private var available = true
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func acquire() async {
+        // The availability check and the waiter registration happen
+        // atomically under `lock`, inside the (synchronous) continuation
+        // closure, so no `release()` can sneak in between and lose the
+        // hand-off. Resuming immediately when available is safe: a
+        // concurrent `release()` cannot run while there is no holder
+        // (available == true means nothing is holding the mutex).
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            lock.lock()
+            if available {
+                available = false
+                lock.unlock()
+                cont.resume()
+            } else {
+                waiters.append(cont)
+                lock.unlock()
             }
-            semaphore.signal()
         }
-        semaphore.wait()
-        releaseLane(key)
-        onRelease()
+    }
+
+    func release() {
+        lock.lock()
+        if let next = waiters.first {
+            waiters.removeFirst()
+            lock.unlock()
+            // Hand-off: the resumed waiter becomes the holder; the
+            // mutex stays unavailable so a new acquirer queues behind.
+            next.resume()
+        } else {
+            available = true
+            lock.unlock()
+        }
     }
 }

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/PerPathMutationLaneTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/PerPathMutationLaneTests.swift
@@ -23,6 +23,40 @@ private final class LockedEventLog: @unchecked Sendable {
     }
 }
 
+/// `NSLock`-guarded tracker for concurrent in-flight coordinated-body
+/// executions, used by the cooperative-pool stress test to assert that
+/// cross-path ops overlap and that no op starves.
+private final class OverlapTracker: @unchecked Sendable {
+    private let lock = NSLock()
+    private var inFlight = 0
+    private var maxConcurrent = 0
+    private var completed = 0
+
+    var maxConcurrentValue: Int {
+        lock.lock(); defer { lock.unlock() }
+        return maxConcurrent
+    }
+
+    var completedValue: Int {
+        lock.lock(); defer { lock.unlock() }
+        return completed
+    }
+
+    func enter() {
+        lock.lock()
+        inFlight += 1
+        if inFlight > maxConcurrent { maxConcurrent = inFlight }
+        lock.unlock()
+    }
+
+    func exit() {
+        lock.lock()
+        inFlight -= 1
+        completed += 1
+        lock.unlock()
+    }
+}
+
 final class PerPathMutationLaneTests: XCTestCase {
     private func makeLane() -> PerPathMutationLane {
         PerPathMutationLane()
@@ -398,5 +432,120 @@ final class PerPathMutationLaneTests: XCTestCase {
         }
         _ = try await interactive
         _ = await bulkTask.value
+    }
+
+    /// Cooperative-pool / libdispatch-worker stress test
+    /// (VAL-MUT-052): fans out WELL BEYOND core-count concurrent
+    /// distinct-path delete/move ops with a REAL (non-instant)
+    /// coordinated body and asserts:
+    ///   - no starvation: every op completes,
+    ///   - cross-path overlap: at least two distinct ops are in their
+    ///     coordinated accessor concurrently,
+    ///   - genuine concurrency: total elapsed is well under the serial
+    ///     sum (ops run in parallel, not serially).
+    ///
+    /// The existing suite uses fast injected closures and never
+    /// exercises cooperative-pool/worker saturation. This test drives
+    /// the real `CoordinatedIO` hop (blocking `NSFileCoordinator`
+    /// coordinate on a `DispatchQueue.global` worker, not on a
+    /// cooperative-pool thread) combined with the non-blocking async
+    /// lane, so a burst of distinct-path coordinated ops cannot starve
+    /// other Swift async work or exhaust the libdispatch worker pool.
+    func testStressBeyondCoreCountNoStarvationAndCrossPathOverlap() async throws {
+        let cores = ProcessInfo.processInfo.processorCount
+        // Well beyond core-count.
+        let count = max(cores * 4, 32)
+        let lane = PerPathMutationLane()
+        let tracker = OverlapTracker()
+
+        let tmpRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "lane-stress-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: tmpRoot,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: tmpRoot) }
+
+        var urls: [URL] = []
+        for index in 0..<count {
+            let url = tmpRoot.appendingPathComponent("file-\(index).json")
+            try "seed-\(index)".write(
+                to: url, atomically: true, encoding: .utf8
+            )
+            urls.append(url)
+        }
+
+        // Each coordinated body is non-instant (~20ms inside the
+        // accessor). The serial sum is the time if every op ran one at
+        // a time; genuine cross-path concurrency must beat it by a wide
+        // margin.
+        let perBodySeconds: Double = 0.02
+        let serialSum = Double(count) * perBodySeconds
+
+        let start = Date()
+        await withTaskGroup(of: Void.self) { group in
+            for index in 0..<count {
+                let url = urls[index]
+                if index.isMultiple(of: 2) {
+                    // "delete" verb: single-lane coordinated write.
+                    group.addTask {
+                        _ = try? await lane.withLane(for: url) {
+                            try await CoordinatedIO.coordinateWriting(
+                                at: url,
+                                options: .forReplacing
+                            ) { coordinatedURL in
+                                tracker.enter()
+                                Thread.sleep(forTimeInterval: perBodySeconds)
+                                try "updated-\(index)".write(
+                                    to: coordinatedURL,
+                                    atomically: true,
+                                    encoding: .utf8
+                                )
+                                tracker.exit()
+                            }
+                        }
+                    }
+                } else {
+                    // "move" verb: cross-path (two-lane) coordinated
+                    // write against a distinct second endpoint.
+                    let other = urls[(index + 1) % count]
+                    group.addTask {
+                        _ = try? await lane.withLanes(for: url, and: other) {
+                            try await CoordinatedIO.coordinateWritingTwo(
+                                writingAt: url, options: .forMoving,
+                                writingAt: other, options: .forReplacing
+                            ) { _, _ in
+                                tracker.enter()
+                                Thread.sleep(forTimeInterval: perBodySeconds)
+                                tracker.exit()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        let elapsed = Date().timeIntervalSince(start)
+
+        // No starvation: every op completed.
+        XCTAssertEqual(
+            tracker.completedValue, count,
+            "all \(count) ops must complete (no starvation)"
+        )
+        // Cross-path overlap: at least two ops were in their coordinated
+        // accessor concurrently.
+        XCTAssertGreaterThanOrEqual(
+            tracker.maxConcurrentValue, 2,
+            "cross-path ops must overlap (maxConcurrent="
+                + "\(tracker.maxConcurrentValue))"
+        )
+        // Genuine concurrency: elapsed well under the serial sum.
+        XCTAssertLessThan(
+            elapsed, serialSum,
+            "ops must run concurrently (elapsed=\(elapsed)s, "
+                + "serialSum=\(serialSum)s)"
+        )
     }
 }

--- a/macos/icloud_storage_plus.podspec
+++ b/macos/icloud_storage_plus.podspec
@@ -17,6 +17,7 @@ container, with document coordination via UIDocument/NSDocument.
   s.source           = { :path => '.' }
   s.source_files     = [
     'icloud_storage_plus/Sources/icloud_storage_plus/**/*.{h,m,swift}',
+    'icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedIO.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/MetadataQuerySupport.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/MetadataQuerySession.swift',

--- a/macos/icloud_storage_plus/Package.swift
+++ b/macos/icloud_storage_plus/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
             ],
             sources: [
                 "icloud_storage_plus",
+                "icloud_storage_plus_foundation/CoordinatedIO.swift",
                 "icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift",
                 "icloud_storage_plus_foundation/MetadataQuerySupport.swift",
                 "icloud_storage_plus_foundation/MetadataQuerySession.swift",

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
@@ -1456,7 +1456,11 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
 
   /// Coordinated delete honoring the coordinator closure URL. Throws a
   /// typed `FlutterError` on coordination or IO failure (coordErr ??
-  /// ioErr — never a silent null/false success).
+  /// ioErr — never a silent null/false success). The blocking
+  /// `NSFileCoordinator.coordinate(...)` is hopped onto a
+  /// `DispatchQueue.global` worker via `CoordinatedIO` so it never
+  /// blocks the Swift cooperative pool (same pattern as
+  /// `CoordinatedReplaceWriter.liveCoordinateReplace`).
   private func deleteCoordinated(
     fileURL: URL,
     relativePath: String
@@ -1465,39 +1469,32 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       throw itemNotFoundError(operation: "delete", relativePath: relativePath)
     }
 
-    let coordinator = NSFileCoordinator(filePresenter: nil)
-    var coordinationError: NSError?
-    var ioError: Error?
-
-    coordinator.coordinate(
-      writingItemAt: fileURL,
-      options: NSFileCoordinator.WritingOptions.forDeleting,
-      error: &coordinationError
-    ) { writingURL in
-      do {
+    do {
+      try await CoordinatedIO.coordinateWriting(
+        at: fileURL,
+        options: NSFileCoordinator.WritingOptions.forDeleting
+      ) { writingURL in
         try FileManager.default.removeItem(at: writingURL)
-      } catch {
-        ioError = error
       }
-    }
-
-    if let coordinationError {
-      throw nativeCodeError(
-        coordinationError,
-        operation: "delete",
-        relativePath: relativePath
-      )
-    }
-    if let ioError {
-      throw mapFileNotFoundError(
-        ioError,
-        operation: "delete",
-        relativePath: relativePath
-      ) ?? nativeCodeError(
-        ioError,
-        operation: "delete",
-        relativePath: relativePath
-      )
+    } catch let bridgeError as CoordinateBridgeError {
+      switch bridgeError {
+      case .coordination(let coordinationError):
+        throw nativeCodeError(
+          coordinationError,
+          operation: "delete",
+          relativePath: relativePath
+        )
+      case .accessor(let ioError):
+        throw mapFileNotFoundError(
+          ioError,
+          operation: "delete",
+          relativePath: relativePath
+        ) ?? nativeCodeError(
+          ioError,
+          operation: "delete",
+          relativePath: relativePath
+        )
+      }
     }
     return nil
   }
@@ -1553,7 +1550,10 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   /// Coordinated move honoring both coordinator closure URLs. Creates
   /// the destination parent directory as needed. Throws a typed
   /// `FlutterError` on coordination or IO failure; preserves the source
-  /// on mid-stage failure (VAL-MUT-054).
+  /// on mid-stage failure (VAL-MUT-054). The blocking
+  /// `NSFileCoordinator.coordinate(...)` is hopped onto a
+  /// `DispatchQueue.global` worker via `CoordinatedIO` so it never
+  /// blocks the Swift cooperative pool.
   private func moveCoordinated(
     atURL: URL,
     toURL: URL,
@@ -1563,18 +1563,13 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       throw itemNotFoundError(operation: "move", relativePath: atRelativePath)
     }
 
-    let coordinator = NSFileCoordinator(filePresenter: nil)
-    var coordinationError: NSError?
-    var ioError: Error?
-
-    coordinator.coordinate(
-      writingItemAt: atURL,
-      options: NSFileCoordinator.WritingOptions.forMoving,
-      writingItemAt: toURL,
-      options: NSFileCoordinator.WritingOptions.forReplacing,
-      error: &coordinationError
-    ) { atWritingURL, toWritingURL in
-      do {
+    do {
+      try await CoordinatedIO.coordinateWritingTwo(
+        writingAt: atURL,
+        options: NSFileCoordinator.WritingOptions.forMoving,
+        writingAt: toURL,
+        options: NSFileCoordinator.WritingOptions.forReplacing
+      ) { atWritingURL, toWritingURL in
         let toDirURL = toWritingURL.deletingLastPathComponent()
         if !FileManager.default.fileExists(atPath: toDirURL.path) {
           try FileManager.default.createDirectory(
@@ -1584,24 +1579,22 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
           )
         }
         try FileManager.default.moveItem(at: atWritingURL, to: toWritingURL)
-      } catch {
-        ioError = error
       }
-    }
-
-    if let coordinationError {
-      throw nativeCodeError(
-        coordinationError,
-        operation: "move",
-        relativePath: atRelativePath
-      )
-    }
-    if let ioError {
-      throw nativeCodeError(
-        ioError,
-        operation: "move",
-        relativePath: atRelativePath
-      )
+    } catch let bridgeError as CoordinateBridgeError {
+      switch bridgeError {
+      case .coordination(let coordinationError):
+        throw nativeCodeError(
+          coordinationError,
+          operation: "move",
+          relativePath: atRelativePath
+        )
+      case .accessor(let ioError):
+        throw nativeCodeError(
+          ioError,
+          operation: "move",
+          relativePath: atRelativePath
+        )
+      }
     }
     return nil
   }
@@ -1659,7 +1652,9 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
   /// source-read coordination errors distinctly from destination write
   /// errors (coordErr ?? ioErr). Throws a typed `FlutterError` on
   /// failure; leaves no partial destination on mid-stage failure
-  /// (VAL-MUT-054).
+  /// (VAL-MUT-054). The blocking `NSFileCoordinator.coordinate(...)`
+  /// calls are hopped onto a `DispatchQueue.global` worker via
+  /// `CoordinatedIO` so they never block the Swift cooperative pool.
   private func copyCoordinated(
     fromURL: URL,
     toURL: URL,
@@ -1670,42 +1665,34 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       throw itemNotFoundError(operation: "copy", relativePath: fromRelativePath)
     }
 
-    let fileCoordinator = NSFileCoordinator(filePresenter: nil)
-    var handledExistingDestination = false
-    var overwriteError: Error?
-    var sourceCoordinationError: NSError?
-
-    fileCoordinator.coordinate(
-      readingItemAt: fromURL,
-      options: .withoutChanges,
-      error: &sourceCoordinationError
-    ) { fromReadingURL in
-      do {
-        handledExistingDestination = try copyOverwritingExistingItem(
+    let handledExistingDestination: Bool
+    do {
+      handledExistingDestination = try await CoordinatedIO.coordinateReadingReturning(
+        at: fromURL,
+        options: .withoutChanges
+      ) { fromReadingURL in
+        try self.copyOverwritingExistingItem(
           from: fromReadingURL,
           to: toURL
         )
-      } catch {
-        overwriteError = error
       }
-    }
-
-    if let sourceCoordinationError {
-      DebugHelper.log("copy source coordination error: \(sourceCoordinationError.localizedDescription)")
-      throw nativeCodeError(
-        sourceCoordinationError,
-        operation: "copy",
-        relativePath: fromRelativePath
-      )
-    }
-
-    if let overwriteError {
-      DebugHelper.log("copy error: \(overwriteError.localizedDescription)")
-      throw nativeCodeError(
-        overwriteError,
-        operation: "copy",
-        relativePath: toRelativePath
-      )
+    } catch let bridgeError as CoordinateBridgeError {
+      switch bridgeError {
+      case .coordination(let sourceCoordinationError):
+        DebugHelper.log("copy source coordination error: \(sourceCoordinationError.localizedDescription)")
+        throw nativeCodeError(
+          sourceCoordinationError,
+          operation: "copy",
+          relativePath: fromRelativePath
+        )
+      case .accessor(let overwriteError):
+        DebugHelper.log("copy error: \(overwriteError.localizedDescription)")
+        throw nativeCodeError(
+          overwriteError,
+          operation: "copy",
+          relativePath: toRelativePath
+        )
+      }
     }
 
     if handledExistingDestination {
@@ -1714,17 +1701,13 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
 
     // Use reading coordination for source and writing coordination for
     // destination.
-    var copyCoordinationError: NSError?
-    var copyIOError: Error?
-
-    fileCoordinator.coordinate(
-      readingItemAt: fromURL,
-      options: .withoutChanges,
-      writingItemAt: toURL,
-      options: .forReplacing,
-      error: &copyCoordinationError
-    ) { fromReadingURL, toWritingURL in
-      do {
+    do {
+      try await CoordinatedIO.coordinateReadingAndWriting(
+        readingAt: fromURL,
+        readingOptions: .withoutChanges,
+        writingAt: toURL,
+        writingOptions: .forReplacing
+      ) { fromReadingURL, toWritingURL in
         // Create destination directory if needed.
         let toDirURL = toWritingURL.deletingLastPathComponent()
         if !FileManager.default.fileExists(atPath: toDirURL.path) {
@@ -1742,26 +1725,24 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
 
         // Copy the file.
         try FileManager.default.copyItem(at: fromReadingURL, to: toWritingURL)
-      } catch {
-        copyIOError = error
       }
-    }
-
-    if let copyCoordinationError {
-      DebugHelper.log("copy coordination error: \(copyCoordinationError.localizedDescription)")
-      throw nativeCodeError(
-        copyCoordinationError,
-        operation: "copy",
-        relativePath: toRelativePath
-      )
-    }
-    if let copyIOError {
-      DebugHelper.log("copy error: \(copyIOError.localizedDescription)")
-      throw nativeCodeError(
-        copyIOError,
-        operation: "copy",
-        relativePath: toRelativePath
-      )
+    } catch let bridgeError as CoordinateBridgeError {
+      switch bridgeError {
+      case .coordination(let copyCoordinationError):
+        DebugHelper.log("copy coordination error: \(copyCoordinationError.localizedDescription)")
+        throw nativeCodeError(
+          copyCoordinationError,
+          operation: "copy",
+          relativePath: toRelativePath
+        )
+      case .accessor(let copyIOError):
+        DebugHelper.log("copy error: \(copyIOError.localizedDescription)")
+        throw nativeCodeError(
+          copyIOError,
+          operation: "copy",
+          relativePath: toRelativePath
+        )
+      }
     }
     return nil
   }

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedIO.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedIO.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+/// Distinctly surfaces coordinator failures vs inner-IO failures across
+/// the `DispatchQueue.global`-bridged continuation so callers can map
+/// each kind to the appropriate stable channel error (R14:
+/// coordinator-error vs inner-IO-error, never collapsed, never a silent
+/// null/false success).
+enum CoordinateBridgeError: Error {
+    /// `NSFileCoordinator.coordinate(...)` reported a coordination
+    /// failure; the accessor closure never ran.
+    case coordination(NSError)
+    /// The accessor closure threw an inner IO error.
+    case accessor(Error)
+}
+
+/// Async bridges for `NSFileCoordinator.coordinate(...)` (synchronous,
+/// blocking) that hop the blocking call onto a `DispatchQueue.global`
+/// worker via a single-resume continuation, so the Swift cooperative
+/// pool is never blocked by coordination.
+///
+/// This is the SAME deadlock-free pattern as
+/// `CoordinatedReplaceWriter.liveCoordinateReplace`: the accessor runs
+/// synchronously on the dispatch worker per Apple's contract; no
+/// `DispatchSemaphore`, no inner `Task`, no cooperative-pool starvation
+/// surface. The cooperative-pool task suspends at the continuation
+/// while coordination runs on a libdispatch worker, so even a burst of
+/// concurrent coordinated delete/move/copy ops cannot starve other
+/// Swift async work.
+///
+/// Failures are surfaced as `CoordinateBridgeError` so callers can
+/// distinguish coordination failure from inner-IO failure and map them
+/// to distinct stable channel codes/messages byte-for-byte.
+enum CoordinatedIO {
+    /// Bridges `coordinate(writingItemAt:options:error:byAccessor:)`.
+    static func coordinateWriting(
+        at url: URL,
+        options: NSFileCoordinator.WritingOptions,
+        qos: DispatchQoS.QoSClass = .userInitiated,
+        accessor: @escaping @Sendable (URL) throws -> Void
+    ) async throws {
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<Void, Error>) in
+            DispatchQueue.global(qos: qos).async {
+                let coordinator = NSFileCoordinator(filePresenter: nil)
+                var coordinationError: NSError?
+                var accessError: Error?
+
+                coordinator.coordinate(
+                    writingItemAt: url,
+                    options: options,
+                    error: &coordinationError
+                ) { coordinatedURL in
+                    do {
+                        try accessor(coordinatedURL)
+                    } catch {
+                        accessError = error
+                    }
+                }
+
+                Self.resume(continuation, coordination: coordinationError, access: accessError)
+            }
+        }
+    }
+
+    /// Bridges
+    /// `coordinate(writingItemAt:options:writingItemAt:options:error:byAccessor:)`
+    /// (two writing endpoints — used for coordinated move).
+    static func coordinateWritingTwo(
+        writingAt firstURL: URL,
+        options firstOptions: NSFileCoordinator.WritingOptions,
+        writingAt secondURL: URL,
+        options secondOptions: NSFileCoordinator.WritingOptions,
+        qos: DispatchQoS.QoSClass = .userInitiated,
+        accessor: @escaping @Sendable (URL, URL) throws -> Void
+    ) async throws {
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<Void, Error>) in
+            DispatchQueue.global(qos: qos).async {
+                let coordinator = NSFileCoordinator(filePresenter: nil)
+                var coordinationError: NSError?
+                var accessError: Error?
+
+                coordinator.coordinate(
+                    writingItemAt: firstURL,
+                    options: firstOptions,
+                    writingItemAt: secondURL,
+                    options: secondOptions,
+                    error: &coordinationError
+                ) { firstCoordinatedURL, secondCoordinatedURL in
+                    do {
+                        try accessor(firstCoordinatedURL, secondCoordinatedURL)
+                    } catch {
+                        accessError = error
+                    }
+                }
+
+                Self.resume(continuation, coordination: coordinationError, access: accessError)
+            }
+        }
+    }
+
+    /// Bridges `coordinate(readingItemAt:options:error:byAccessor:)`
+    /// and returns a value computed inside the accessor (used for the
+    /// copy overwrite-pre-check, which reports whether an existing
+    /// destination was overwritten).
+    static func coordinateReadingReturning<T: Sendable>(
+        at url: URL,
+        options: NSFileCoordinator.ReadingOptions,
+        qos: DispatchQoS.QoSClass = .userInitiated,
+        accessor: @escaping @Sendable (URL) throws -> T
+    ) async throws -> T {
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<T, Error>) in
+            DispatchQueue.global(qos: qos).async {
+                let coordinator = NSFileCoordinator(filePresenter: nil)
+                var coordinationError: NSError?
+                var accessError: Error?
+                var result: T?
+
+                coordinator.coordinate(
+                    readingItemAt: url,
+                    options: options,
+                    error: &coordinationError
+                ) { coordinatedURL in
+                    do {
+                        result = try accessor(coordinatedURL)
+                    } catch {
+                        accessError = error
+                    }
+                }
+
+                if let coordinationError {
+                    continuation.resume(throwing: CoordinateBridgeError.coordination(coordinationError))
+                    return
+                }
+                if let accessError {
+                    continuation.resume(throwing: CoordinateBridgeError.accessor(accessError))
+                    return
+                }
+                guard let result else {
+                    continuation.resume(throwing: CoordinateBridgeError.accessor(
+                        NSError(
+                            domain: CoordinatedReplaceWriter.replaceStateErrorDomain,
+                            code: CoordinatedReplaceWriter.coordinationReplaceStateCode,
+                            userInfo: [
+                                NSLocalizedDescriptionKey:
+                                    "Coordinated read accessor returned no value.",
+                            ]
+                        )
+                    ))
+                    return
+                }
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
+    /// Bridges
+    /// `coordinate(readingItemAt:options:writingItemAt:options:error:byAccessor:)`
+    /// (read source + write destination — used for coordinated copy).
+    static func coordinateReadingAndWriting(
+        readingAt readingURL: URL,
+        readingOptions: NSFileCoordinator.ReadingOptions,
+        writingAt writingURL: URL,
+        writingOptions: NSFileCoordinator.WritingOptions,
+        qos: DispatchQoS.QoSClass = .userInitiated,
+        accessor: @escaping @Sendable (URL, URL) throws -> Void
+    ) async throws {
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<Void, Error>) in
+            DispatchQueue.global(qos: qos).async {
+                let coordinator = NSFileCoordinator(filePresenter: nil)
+                var coordinationError: NSError?
+                var accessError: Error?
+
+                coordinator.coordinate(
+                    readingItemAt: readingURL,
+                    options: readingOptions,
+                    writingItemAt: writingURL,
+                    options: writingOptions,
+                    error: &coordinationError
+                ) { readingCoordinatedURL, writingCoordinatedURL in
+                    do {
+                        try accessor(readingCoordinatedURL, writingCoordinatedURL)
+                    } catch {
+                        accessError = error
+                    }
+                }
+
+                Self.resume(continuation, coordination: coordinationError, access: accessError)
+            }
+        }
+    }
+
+    /// Resumes the Void continuation exactly once, prioritizing the
+    /// coordination error (the accessor never ran) over the inner-IO
+    /// error, matching the original synchronous helper ordering.
+    private static func resume(
+        _ continuation: CheckedContinuation<Void, Error>,
+        coordination: NSError?,
+        access: Error?
+    ) {
+        if let coordination {
+            continuation.resume(throwing: CoordinateBridgeError.coordination(coordination))
+            return
+        }
+        if let access {
+            continuation.resume(throwing: CoordinateBridgeError.accessor(access))
+            return
+        }
+        continuation.resume()
+    }
+}

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/PerPathMutationLane.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/PerPathMutationLane.swift
@@ -14,13 +14,37 @@ import Foundation
 /// the lane's serialized closure, never the reverse, so no deadlock is
 /// possible.
 ///
-/// Implementation: each normalized path owns a serial `DispatchQueue`.
-/// The calling async task suspends at a single-resume continuation
-/// while the lane's dispatch thread runs the (possibly async) body and
-/// signals completion via a `DispatchSemaphore`. The dispatch thread is
-/// NOT a Swift cooperative-pool thread, so blocking it cannot starve
-/// the cooperative pool — the same deadlock-free bridging pattern used
-/// by `CoordinatedReplaceWriter.liveCoordinateReplace`.
+/// Implementation: each normalized path owns a cooperative async mutex
+/// (a `withCheckedContinuation`-based binary semaphore with a FIFO
+/// waiter queue). The calling async task SUSPENDS cooperatively (it
+/// does NOT block any thread) while waiting for its lane turn, then
+/// runs the (possibly async) body on the Swift cooperative pool. No
+/// `DispatchSemaphore` is used to bridge the body, and no libdispatch
+/// worker thread is blocked for the body's full duration — so
+/// high-fan-out bulk mutations cannot exhaust the libdispatch worker
+/// pool, and a burst of concurrent distinct-path ops cannot starve
+/// other Swift async work.
+///
+/// The blocking `NSFileCoordinator.coordinate(...)` call itself is
+/// never run on a cooperative-pool thread: the coordinated
+/// delete/move/copy helpers hop it onto a `DispatchQueue.global`
+/// worker via a continuation (see `CoordinatedIO` and
+/// `CoordinatedReplaceWriter.liveCoordinateReplace`), so coordination
+/// blocks a libdispatch worker, not a cooperative-pool thread. With
+/// both the cooperative lane acquisition and the coordinated hop, there
+/// is no `DispatchSemaphore.wait()` held for a body's duration and no
+/// cooperative-pool starvation surface.
+///
+/// A counting-semaphore bound on in-flight lanes was considered and
+/// rejected: on a per-path serial-`DispatchQueue` design a global
+/// in-flight bound either fails to reduce blocked worker threads (the
+/// thread is claimed when the block is dispatched, before the bound is
+/// checked) or, if acquired before dispatch, lets a burst of same-path
+/// ops exhaust the bound and starve unrelated cross-path work
+/// (violating no-starvation). Eliminating the per-body thread blocking
+/// entirely (this async-mutex design) bounds thread usage by
+/// construction without breaking the per-path-serial /
+/// cross-path-concurrent / FIFO / no-starvation invariants.
 ///
 /// Idle lanes (no queued and no in-flight op) are reclaimed so the lane
 /// map does not grow unbounded over a long session.
@@ -28,7 +52,7 @@ final class PerPathMutationLane: @unchecked Sendable {
     static let shared = PerPathMutationLane()
 
     private let lock = NSLock()
-    private var lanes: [String: DispatchQueue] = [:]
+    private var lanes: [String: Lane] = [:]
     private var pending: [String: Int] = [:]
 
     /// Test/inspection hook: the number of lanes currently retained.
@@ -57,12 +81,17 @@ final class PerPathMutationLane: @unchecked Sendable {
         perform body: @escaping @Sendable () async throws -> T
     ) async throws -> T {
         let key = Self.normalizationKey(for: url)
-        let queue = acquireLane(key)
-        return try await withCheckedThrowingContinuation {
-            (cont: CheckedContinuation<T, Error>) in
-            queue.async {
-                self.runAsyncBody(body, on: key, resume: cont)
-            }
+        let lane = acquireLane(key)
+        await lane.mutex.acquire()
+        do {
+            let value = try await body()
+            releaseLane(key)
+            lane.mutex.release()
+            return value
+        } catch {
+            releaseLane(key)
+            lane.mutex.release()
+            throw error
         }
     }
 
@@ -83,45 +112,46 @@ final class PerPathMutationLane: @unchecked Sendable {
         }
 
         let (first, second) = keyA < keyB ? (keyA, keyB) : (keyB, keyA)
-        let queueFirst = acquireLane(first)
-
-        return try await withCheckedThrowingContinuation {
-            (cont: CheckedContinuation<T, Error>) in
-            queueFirst.async {
-                // Acquire the second lane and run the body on it. The
-                // first lane's thread blocks here until the body
-                // completes, so BOTH lanes are held for the body's full
-                // duration (cross-path serialization).
-                let queueSecond = self.acquireLane(second)
-                let firstDone = DispatchSemaphore(value: 0)
-                queueSecond.async {
-                    self.runAsyncBody(body, on: second, resume: cont) {
-                        firstDone.signal()
-                    }
-                }
-                firstDone.wait()
-                self.releaseLane(first)
-            }
+        let laneFirst = acquireLane(first)
+        await laneFirst.mutex.acquire()
+        let laneSecond = acquireLane(second)
+        await laneSecond.mutex.acquire()
+        do {
+            let value = try await body()
+            releaseLane(second)
+            laneSecond.mutex.release()
+            releaseLane(first)
+            laneFirst.mutex.release()
+            return value
+        } catch {
+            releaseLane(second)
+            laneSecond.mutex.release()
+            releaseLane(first)
+            laneFirst.mutex.release()
+            throw error
         }
     }
 
     // MARK: - Private
 
-    private func acquireLane(_ key: String) -> DispatchQueue {
+    private func acquireLane(_ key: String) -> Lane {
         lock.lock()
         defer { lock.unlock() }
         pending[key, default: 0] += 1
         if let existing = lanes[key] { return existing }
-        let queue = DispatchQueue(
-            label: "icloud_storage_plus.mutation_lane.\(key)"
-        )
-        lanes[key] = queue
-        return queue
+        let lane = Lane()
+        lanes[key] = lane
+        return lane
     }
 
+    /// Decrements the pending count for `key` and reclaims the lane
+    /// when no op is queued or in flight on it. The mutex itself is
+    /// released separately (by the caller) so its FIFO hand-off to the
+    /// next waiter is preserved; a lane is only reclaimed when pending
+    /// hits zero (no waiters), which is the only safe moment to drop
+    /// the mutex from the map.
     private func releaseLane(_ key: String) {
         lock.lock()
-        defer { lock.unlock() }
         let next = (pending[key] ?? 0) - 1
         if next <= 0 {
             pending.removeValue(forKey: key)
@@ -129,32 +159,56 @@ final class PerPathMutationLane: @unchecked Sendable {
         } else {
             pending[key] = next
         }
+        lock.unlock()
     }
 
-    /// Runs an async `body` while blocking the lane's dispatch thread
-    /// until completion (semaphore-bridged). The continuation is resumed
-    /// exactly once from the async body's Task; the dispatch thread only
-    /// performs lane bookkeeping after the body completes. `onRelease`
-    /// runs after the body completes (used to release the outer lane in
-    /// the cross-path case).
-    private func runAsyncBody<T: Sendable>(
-        _ body: @escaping @Sendable () async throws -> T,
-        on key: String,
-        resume cont: CheckedContinuation<T, Error>,
-        onRelease: () -> Void = {}
-    ) {
-        let semaphore = DispatchSemaphore(value: 0)
-        Task {
-            do {
-                let value = try await body()
-                cont.resume(returning: value)
-            } catch {
-                cont.resume(throwing: error)
+    /// Per-path lane state: a cooperative async mutex.
+    private final class Lane: @unchecked Sendable {
+        let mutex = AsyncMutex()
+    }
+}
+
+/// Cooperative binary mutex with FIFO waiter ordering. Acquisition
+/// SUSPENDS the calling async task (it does NOT block any thread);
+/// release hands off to the earliest waiter or marks the mutex
+/// available. Used by `PerPathMutationLane` to serialize per path
+/// without occupying a libdispatch worker for a body's duration.
+private final class AsyncMutex: @unchecked Sendable {
+    private let lock = NSLock()
+    private var available = true
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func acquire() async {
+        // The availability check and the waiter registration happen
+        // atomically under `lock`, inside the (synchronous) continuation
+        // closure, so no `release()` can sneak in between and lose the
+        // hand-off. Resuming immediately when available is safe: a
+        // concurrent `release()` cannot run while there is no holder
+        // (available == true means nothing is holding the mutex).
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            lock.lock()
+            if available {
+                available = false
+                lock.unlock()
+                cont.resume()
+            } else {
+                waiters.append(cont)
+                lock.unlock()
             }
-            semaphore.signal()
         }
-        semaphore.wait()
-        releaseLane(key)
-        onRelease()
+    }
+
+    func release() {
+        lock.lock()
+        if let next = waiters.first {
+            waiters.removeFirst()
+            lock.unlock()
+            // Hand-off: the resumed waiter becomes the holder; the
+            // mutex stays unavailable so a new acquirer queues behind.
+            next.resume()
+        } else {
+            available = true
+            lock.unlock()
+        }
     }
 }

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/PerPathMutationLaneTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/PerPathMutationLaneTests.swift
@@ -23,6 +23,40 @@ private final class LockedEventLog: @unchecked Sendable {
     }
 }
 
+/// `NSLock`-guarded tracker for concurrent in-flight coordinated-body
+/// executions, used by the cooperative-pool stress test to assert that
+/// cross-path ops overlap and that no op starves.
+private final class OverlapTracker: @unchecked Sendable {
+    private let lock = NSLock()
+    private var inFlight = 0
+    private var maxConcurrent = 0
+    private var completed = 0
+
+    var maxConcurrentValue: Int {
+        lock.lock(); defer { lock.unlock() }
+        return maxConcurrent
+    }
+
+    var completedValue: Int {
+        lock.lock(); defer { lock.unlock() }
+        return completed
+    }
+
+    func enter() {
+        lock.lock()
+        inFlight += 1
+        if inFlight > maxConcurrent { maxConcurrent = inFlight }
+        lock.unlock()
+    }
+
+    func exit() {
+        lock.lock()
+        inFlight -= 1
+        completed += 1
+        lock.unlock()
+    }
+}
+
 final class PerPathMutationLaneTests: XCTestCase {
     private func makeLane() -> PerPathMutationLane {
         PerPathMutationLane()
@@ -398,5 +432,120 @@ final class PerPathMutationLaneTests: XCTestCase {
         }
         _ = try await interactive
         _ = await bulkTask.value
+    }
+
+    /// Cooperative-pool / libdispatch-worker stress test
+    /// (VAL-MUT-052): fans out WELL BEYOND core-count concurrent
+    /// distinct-path delete/move ops with a REAL (non-instant)
+    /// coordinated body and asserts:
+    ///   - no starvation: every op completes,
+    ///   - cross-path overlap: at least two distinct ops are in their
+    ///     coordinated accessor concurrently,
+    ///   - genuine concurrency: total elapsed is well under the serial
+    ///     sum (ops run in parallel, not serially).
+    ///
+    /// The existing suite uses fast injected closures and never
+    /// exercises cooperative-pool/worker saturation. This test drives
+    /// the real `CoordinatedIO` hop (blocking `NSFileCoordinator`
+    /// coordinate on a `DispatchQueue.global` worker, not on a
+    /// cooperative-pool thread) combined with the non-blocking async
+    /// lane, so a burst of distinct-path coordinated ops cannot starve
+    /// other Swift async work or exhaust the libdispatch worker pool.
+    func testStressBeyondCoreCountNoStarvationAndCrossPathOverlap() async throws {
+        let cores = ProcessInfo.processInfo.processorCount
+        // Well beyond core-count.
+        let count = max(cores * 4, 32)
+        let lane = PerPathMutationLane()
+        let tracker = OverlapTracker()
+
+        let tmpRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "lane-stress-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: tmpRoot,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: tmpRoot) }
+
+        var urls: [URL] = []
+        for index in 0..<count {
+            let url = tmpRoot.appendingPathComponent("file-\(index).json")
+            try "seed-\(index)".write(
+                to: url, atomically: true, encoding: .utf8
+            )
+            urls.append(url)
+        }
+
+        // Each coordinated body is non-instant (~20ms inside the
+        // accessor). The serial sum is the time if every op ran one at
+        // a time; genuine cross-path concurrency must beat it by a wide
+        // margin.
+        let perBodySeconds: Double = 0.02
+        let serialSum = Double(count) * perBodySeconds
+
+        let start = Date()
+        await withTaskGroup(of: Void.self) { group in
+            for index in 0..<count {
+                let url = urls[index]
+                if index.isMultiple(of: 2) {
+                    // "delete" verb: single-lane coordinated write.
+                    group.addTask {
+                        _ = try? await lane.withLane(for: url) {
+                            try await CoordinatedIO.coordinateWriting(
+                                at: url,
+                                options: .forReplacing
+                            ) { coordinatedURL in
+                                tracker.enter()
+                                Thread.sleep(forTimeInterval: perBodySeconds)
+                                try "updated-\(index)".write(
+                                    to: coordinatedURL,
+                                    atomically: true,
+                                    encoding: .utf8
+                                )
+                                tracker.exit()
+                            }
+                        }
+                    }
+                } else {
+                    // "move" verb: cross-path (two-lane) coordinated
+                    // write against a distinct second endpoint.
+                    let other = urls[(index + 1) % count]
+                    group.addTask {
+                        _ = try? await lane.withLanes(for: url, and: other) {
+                            try await CoordinatedIO.coordinateWritingTwo(
+                                writingAt: url, options: .forMoving,
+                                writingAt: other, options: .forReplacing
+                            ) { _, _ in
+                                tracker.enter()
+                                Thread.sleep(forTimeInterval: perBodySeconds)
+                                tracker.exit()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        let elapsed = Date().timeIntervalSince(start)
+
+        // No starvation: every op completed.
+        XCTAssertEqual(
+            tracker.completedValue, count,
+            "all \(count) ops must complete (no starvation)"
+        )
+        // Cross-path overlap: at least two ops were in their coordinated
+        // accessor concurrently.
+        XCTAssertGreaterThanOrEqual(
+            tracker.maxConcurrentValue, 2,
+            "cross-path ops must overlap (maxConcurrent="
+                + "\(tracker.maxConcurrentValue))"
+        )
+        // Genuine concurrency: elapsed well under the serial sum.
+        XCTAssertLessThan(
+            elapsed, serialSum,
+            "ops must run concurrently (elapsed=\(elapsed)s, "
+                + "serialSum=\(serialSum)s)"
+        )
     }
 }


### PR DESCRIPTION
Closes MYT-1314 (plugin follow-up).

## Root cause
`PerPathMutationLane.runAsyncBody` ran the body as `Task { await body() }` on the Swift cooperative pool and blocked the lane serial `DispatchQueue` thread on `DispatchSemaphore.wait()` for the body whole duration. For the delete/move/copy verbs the body called `NSFileCoordinator.coordinate(...)` **synchronously** with no surrounding await, so that blocking `coordinate()` ran **on a cooperative-pool thread** — the hazard `CoordinatedReplaceWriter.liveCoordinateReplace` deliberately avoids (hops the blocking `coordinate()` onto `DispatchQueue.global(qos:)` via a continuation; "no DispatchSemaphore, no inner Task, no cooperative-pool starvation surface"). The lane doc-comment "even fully-saturated concurrent writes cannot starve the cooperative pool" claim was misleading. Every lane op also blocked one libdispatch worker via `semaphore.wait()` for its full duration (high-fan-out bulk → worker exhaustion).

## Fix (iOS+macOS byte-identical)
- **New `CoordinatedIO.swift` foundation bridge**: async bridges for `NSFileCoordinator.coordinate(...)` that hop the blocking call onto a `DispatchQueue.global(qos:)` worker via a single-resume continuation (same pattern as `liveCoordinateReplace`), surfacing failures as `CoordinateBridgeError { .coordination(NSError); .accessor(Error) }` so callers keep **R14 coordinator-error vs inner-IO-error distinct** mapping. Enumerated in both outer `Package.swift` sources lists and both podspecs.
- **`PerPathMutationLane` rewritten**: per-path cooperative `AsyncMutex` (FIFO waiter queue, `withCheckedContinuation`-based) replaces the serial `DispatchQueue` + `Task{}` + `DispatchSemaphore.wait()` design. The calling task **suspends** (does not block any thread) while waiting for its lane turn; the body runs on the cooperative pool; **no libdispatch worker is blocked for a body duration**, so high-fan-out bulk cannot exhaust the worker pool or starve other Swift async work. Doc-comment corrected to describe the real model and explain why a counting-semaphore in-flight bound was rejected (either fails to reduce blocked threads on a per-path-serial-queue design or breaks cross-path no-starvation).
- **Channel `deleteCoordinated`/`moveCoordinated`/`copyCoordinated`** now `await` the `CoordinatedIO` bridges instead of synchronous `coordinate(...)`. Error mapping preserved **byte-for-byte** (same `nativeCodeError`/`mapFileNotFoundError` calls, same `operation`/`relativePath`, same stable channel codes/messages).

## Preserved invariants (R15)
per-path-serial, cross-path-concurrent, reads-never-block, FIFO/no-starvation, idle-lane-cleanup, post-exception-recovery, path-normalization. R14 distinct error surfacing preserved. No channel code/message changes. No API signature changes. Deployment floors iOS 13 / macOS 10.15 respected.

## Verification
- `swift test` foundation green: **61 iOS** (60 baseline + 1 stress) / **63 macOS** (62 baseline + 1 stress).
- New `testStressBeyondCoreCountNoStarvationAndCrossPathOverlap` fans out `max(cores*4, 32)` concurrent distinct-path delete (`withLane`) + move (`withLanes`) ops with a REAL non-instant coordinated body (real `NSFileCoordinator` on temp files + 20ms accessor work via the bridge); asserts no starvation, cross-path overlap, concurrency (elapsed < serial sum).
- `flutter build macos --debug` AND `flutter build ios --debug --no-codesign` on the plugin example app: both exit 0 (channel layer compiles). Example entitlements/pbxproj temporarily stripped for compile-only then restored via `git show HEAD:`; `git status -- example/` clean.
- `swift-icloud-plugin-expert` review (review mode): **APPROVED, 0 Critical / 0 Important**; all R15 invariants + byte-identity PASS.

## Tandem
Plugin-first. Sibling app pin-bump PR (MythicGME2e) repoints `dependency_overrides.icloud_storage_plus.git.ref` to this PR merged commit (explicit immutable hash, NOT moving `main`). Override NOT removed (M8 / MYT-1321).

`droid-review.yml` is known-broken (PREPARE_ERROR CI infra); Greptile bot review is the binding signal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Jason-Holt-Digital/codesmith/icloud_storage_plus/pr/43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->