### PR TITLE
fix(MYT-1314): stale copy-coordination tests + single-shot ubiquity container resolve

### DIFF
--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -102,34 +102,42 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
     func testIOSCopyPropagatesSourceReadCoordinationErrors() throws {
         let pluginSource = try iOSPluginSource()
 
+        // The M1 CoordinatedIO refactor replaced the pre-CoordinatedIO
+        // `var X: NSError?` / `error: &X` / `if let X` surfacing in the
+        // copy channel block with `CoordinateBridgeError` enum-pattern
+        // surfacing. These assertions verify the CURRENT source surfaces
+        // the source-read coordination failure distinctly (R14).
         XCTAssertTrue(
-            pluginSource.contains("var sourceCoordinationError: NSError?"),
-            "copy() should capture read coordination failures before "
-                + "falling through to destination handling."
+            pluginSource.contains("case .coordination(let sourceCoordinationError):"),
+            "copy() should surface a failed source read coordination via "
+                + "the CoordinateBridgeError.coordination enum case instead "
+                + "of continuing silently."
         )
         XCTAssertTrue(
-            pluginSource.contains("error: &sourceCoordinationError"),
-            "copy() should pass a read coordination error pointer instead "
-                + "of discarding coordination failures."
+            pluginSource.contains("sourceCoordinationError.localizedDescription"),
+            "copy() should inspect the surfaced source-read coordination "
+                + "error instead of discarding it."
         )
         XCTAssertTrue(
-            pluginSource.contains("if let sourceCoordinationError"),
-            "copy() should surface a failed source read coordination "
-                + "instead of continuing silently."
+            pluginSource.contains("case .accessor(let overwriteError):"),
+            "copy() should surface the source-read inner IO failure "
+                + "distinctly from the coordination failure (R14)."
         )
         XCTAssertTrue(
-            pluginSource.contains("var copyCoordinationError: NSError?"),
-            "copy() should also capture read/write coordination failures in "
-                + "the non-overwrite path."
+            pluginSource.contains("case .coordination(let copyCoordinationError):"),
+            "copy() should surface a failed combined read/write "
+                + "coordination via the CoordinateBridgeError.coordination "
+                + "enum case in the non-overwrite path."
         )
         XCTAssertTrue(
-            pluginSource.contains("error: &copyCoordinationError"),
-            "copy() should not discard the combined read/write "
-                + "coordination error."
+            pluginSource.contains("copyCoordinationError.localizedDescription"),
+            "copy() should inspect the surfaced combined coordination "
+                + "error instead of discarding it."
         )
         XCTAssertTrue(
-            pluginSource.contains("if let copyCoordinationError"),
-            "copy() should surface a failed combined coordination instead "
+            pluginSource.contains("case .accessor(let copyIOError):"),
+            "copy() should surface the combined-path inner IO failure "
+                + "distinctly from the coordination failure (R14) instead "
                 + "of leaving the Flutter call without a result."
         )
     }

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/UbiquityContainerResolverTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/UbiquityContainerResolverTests.swift
@@ -18,9 +18,7 @@ final class UbiquityContainerResolverTests: XCTestCase {
                 lock.unlock()
                 expectation.fulfill()
                 return temporaryDirectory
-            },
-            delay: { _ in XCTFail("should not retry") },
-            retryDelay: UbiquityContainerResolver.maximumRetryDelay
+            }
         )
 
         let containerURL = await resolver.resolve(containerId: "container")
@@ -30,91 +28,44 @@ final class UbiquityContainerResolverTests: XCTestCase {
         XCTAssertEqual(observedMainThreadState, false)
     }
 
-    func testResolveRetriesOnceAfterNilResult() async throws {
+    /// VAL-INV-006: the resolver performs exactly ONE ubiquity container
+    /// lookup (single-shot) and returns the URL on success.
+    func testResolveReturnsContainerURLOnSingleSuccessfulLookup() async throws {
         let temporaryDirectory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
 
-        var attempts = 0
-        var delays: [TimeInterval] = []
+        var lookupCount = 0
         let resolver = UbiquityContainerResolver(
             execute: { work in work() },
             resolveContainerURL: { _ in
-                attempts += 1
-                if attempts == 2 {
-                    return temporaryDirectory
-                }
-                return nil
-            },
-            delay: { delays.append($0) },
-            retryDelay: UbiquityContainerResolver.maximumRetryDelay
+                lookupCount += 1
+                return temporaryDirectory
+            }
         )
 
         let containerURL = await resolver.resolve(containerId: "container")
 
         XCTAssertEqual(containerURL?.path, temporaryDirectory.path)
-        XCTAssertEqual(attempts, UbiquityContainerResolver.maxAttempts)
-        XCTAssertEqual(
-            delays,
-            [UbiquityContainerResolver.maximumRetryDelay]
-        )
+        XCTAssertEqual(lookupCount, 1, "resolver must be single-shot")
     }
 
-    func testResolveReturnsNilAfterPersistentNilResults() async {
-        var attempts = 0
-        var delays: [TimeInterval] = []
+    /// VAL-INV-006: a nil lookup result is terminal — the resolver
+    /// performs a single lookup only and returns nil, so the caller
+    /// throws the same typed container-unavailable error it always has.
+    func testResolveReturnsNilAfterSingleShotNilResult() async {
+        var lookupCount = 0
         let resolver = UbiquityContainerResolver(
             execute: { work in work() },
             resolveContainerURL: { _ in
-                attempts += 1
+                lookupCount += 1
                 return nil
-            },
-            delay: { delays.append($0) },
-            retryDelay: UbiquityContainerResolver.maximumRetryDelay
+            }
         )
 
         let containerURL = await resolver.resolve(containerId: "missing")
 
         XCTAssertNil(containerURL)
-        XCTAssertEqual(attempts, UbiquityContainerResolver.maxAttempts)
-        XCTAssertEqual(
-            delays,
-            [UbiquityContainerResolver.maximumRetryDelay]
-        )
-    }
-
-    func testRetryDelayIsClampedTo150Milliseconds() async {
-        var delays: [TimeInterval] = []
-        let resolver = UbiquityContainerResolver(
-            execute: { work in work() },
-            resolveContainerURL: { _ in nil },
-            delay: { delays.append($0) },
-            retryDelay: 1
-        )
-
-        _ = await resolver.resolve(containerId: "missing")
-
-        XCTAssertEqual(
-            delays,
-            [UbiquityContainerResolver.maximumRetryDelay]
-        )
-    }
-
-    func testResolveStopsAfterCancelledRetryDelay() async {
-        var attempts = 0
-        let resolver = UbiquityContainerResolver(
-            execute: { work in work() },
-            resolveContainerURL: { _ in
-                attempts += 1
-                return nil
-            },
-            delay: { _ in throw CancellationError() },
-            retryDelay: UbiquityContainerResolver.maximumRetryDelay
-        )
-
-        let containerURL = await resolver.resolve(containerId: "cancelled")
-
-        XCTAssertNil(containerURL)
-        XCTAssertEqual(attempts, 1)
+        XCTAssertEqual(lookupCount, 1, "resolver must be single-shot")
     }
 
     private func makeTemporaryDirectory() throws -> URL {

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/WriteEntrypointPreflightTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/WriteEntrypointPreflightTests.swift
@@ -25,9 +25,7 @@ final class WriteEntrypointPreflightTests: XCTestCase {
                     lock.unlock()
                     expectation.fulfill()
                     return temporaryDirectory
-                },
-                delay: { _ in XCTFail("should not retry") },
-                retryDelay: UbiquityContainerResolver.maximumRetryDelay
+                }
             ),
             createDirectory: { directoryURL in
                 lock.lock()
@@ -57,9 +55,7 @@ final class WriteEntrypointPreflightTests: XCTestCase {
             execute: { work in try work() },
             ubiquityContainerResolver: UbiquityContainerResolver(
                 execute: { work in work() },
-                resolveContainerURL: { _ in nil },
-                delay: { _ in },
-                retryDelay: UbiquityContainerResolver.maximumRetryDelay
+                resolveContainerURL: { _ in nil }
             ),
             createDirectory: { _ in XCTFail("should not create directory") }
         )
@@ -91,9 +87,7 @@ final class WriteEntrypointPreflightTests: XCTestCase {
             execute: { work in try work() },
             ubiquityContainerResolver: UbiquityContainerResolver(
                 execute: { work in work() },
-                resolveContainerURL: { _ in temporaryDirectory },
-                delay: { _ in XCTFail("should not retry") },
-                retryDelay: UbiquityContainerResolver.maximumRetryDelay
+                resolveContainerURL: { _ in temporaryDirectory }
             ),
             createDirectory: { _ in createDirectoryCalled = true }
         )
@@ -127,9 +121,7 @@ final class WriteEntrypointPreflightTests: XCTestCase {
                     observedMainThreadState = Thread.isMainThread
                     expectation.fulfill()
                     return temporaryDirectory
-                },
-                delay: { _ in XCTFail("should not retry") },
-                retryDelay: UbiquityContainerResolver.maximumRetryDelay
+                }
             ),
             createDirectory: { _ in XCTFail("should not create directory") }
         )
@@ -143,49 +135,40 @@ final class WriteEntrypointPreflightTests: XCTestCase {
         XCTAssertEqual(observedMainThreadState, false)
     }
 
-    func testPrepareSucceedsWhenInitialContainerLookupIsNil() async throws {
-        let temporaryDirectory = try makeTemporaryDirectory()
-        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
-
-        var attempts = 0
-        var delays: [TimeInterval] = []
-        var createdDirectory: URL?
+    /// VAL-INV-006: the resolver is single-shot, so a nil container
+    /// lookup is terminal — `prepare` throws the same typed
+    /// container-unavailable error (same domain + code) it always has
+    /// after a single lookup, with no directory creation.
+    func testPrepareThrowsContainerUnavailableErrorWhenLookupIsNil() async {
+        var lookupCount = 0
         let preflight = WriteEntrypointPreflight(
             execute: { work in try work() },
             ubiquityContainerResolver: UbiquityContainerResolver(
                 execute: { work in work() },
                 resolveContainerURL: { _ in
-                    attempts += 1
-                    return attempts == 2 ? temporaryDirectory : nil
-                },
-                delay: { delays.append($0) },
-                retryDelay: UbiquityContainerResolver.maximumRetryDelay
+                    lookupCount += 1
+                    return nil
+                }
             ),
-            createDirectory: { createdDirectory = $0 }
+            createDirectory: { _ in XCTFail("should not create directory") }
         )
 
-        let fileURL = try await preflight.prepare(
-            containerId: "container",
-            relativePath: "nested/file.txt"
-        )
+        do {
+            _ = try await preflight.prepare(
+                containerId: "container",
+                relativePath: "nested/file.txt"
+            )
+            XCTFail("expected prepare to throw")
+        } catch {
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.domain, WriteEntrypointPreflight.errorDomain)
+            XCTAssertEqual(
+                nsError.code,
+                WriteEntrypointPreflight.containerUnavailableErrorCode
+            )
+        }
 
-        XCTAssertEqual(attempts, UbiquityContainerResolver.maxAttempts)
-        XCTAssertEqual(
-            delays,
-            [UbiquityContainerResolver.maximumRetryDelay]
-        )
-        XCTAssertEqual(
-            fileURL.path,
-            temporaryDirectory
-                .appendingPathComponent("nested/file.txt")
-                .path
-        )
-        XCTAssertEqual(
-            createdDirectory?.path,
-            temporaryDirectory
-                .appendingPathComponent("nested", isDirectory: true)
-                .path
-        )
+        XCTAssertEqual(lookupCount, 1, "resolver must be single-shot")
     }
 
     private func makeTemporaryDirectory() throws -> URL {

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/UbiquityContainerResolver.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/UbiquityContainerResolver.swift
@@ -6,40 +6,18 @@ struct UbiquityContainerResolver {
         @escaping @Sendable () -> URL?
     ) async -> URL?
     typealias ResolveContainerURL = (String) -> URL?
-    typealias Delay = (TimeInterval) async throws -> Void
-
-    static let maxAttempts = 2
-    static let maximumRetryDelay: TimeInterval = 0.15
 
     let execute: Execute
     let resolveContainerURL: ResolveContainerURL
-    let delay: Delay
-    let retryDelay: TimeInterval
 
+    /// Single-shot ubiquity container lookup. On failure the resolver
+    /// returns `nil`; the caller (`WriteEntrypointPreflight`) throws the
+    /// same typed `containerUnavailableError` with the same channel code
+    /// it always has.
     func resolve(containerId: String) async -> URL? {
-        for attempt in 0..<Self.maxAttempts {
-            if let containerURL = await execute({
-                resolveContainerURL(containerId)
-            }) {
-                return containerURL
-            }
-
-            if attempt < Self.maxAttempts - 1 {
-                do {
-                    try await delay(clampedRetryDelay)
-                } catch is CancellationError {
-                    return nil
-                } catch {
-                    return nil
-                }
-            }
+        await execute {
+            resolveContainerURL(containerId)
         }
-
-        return nil
-    }
-
-    private var clampedRetryDelay: TimeInterval {
-        max(0, min(retryDelay, Self.maximumRetryDelay))
     }
 }
 
@@ -56,11 +34,6 @@ extension UbiquityContainerResolver {
         },
         resolveContainerURL: {
             FileManager.default.url(forUbiquityContainerIdentifier: $0)
-        },
-        delay: { delay in
-            let nanoseconds = UInt64(delay * 1_000_000_000)
-            try await Task.sleep(nanoseconds: nanoseconds)
-        },
-        retryDelay: maximumRetryDelay
+        }
     )
 }

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/CoordinatedReplaceWriterTests.swift
@@ -102,34 +102,42 @@ final class CoordinatedReplaceWriterTests: XCTestCase {
     func testMacOSCopyPropagatesSourceReadCoordinationErrors() throws {
         let pluginSource = try macOSPluginSource()
 
+        // The M1 CoordinatedIO refactor replaced the pre-CoordinatedIO
+        // `var X: NSError?` / `error: &X` / `if let X` surfacing in the
+        // copy channel block with `CoordinateBridgeError` enum-pattern
+        // surfacing. These assertions verify the CURRENT source surfaces
+        // the source-read coordination failure distinctly (R14).
         XCTAssertTrue(
-            pluginSource.contains("var sourceCoordinationError: NSError?"),
-            "copy() should capture read coordination failures before "
-                + "falling through to destination handling."
+            pluginSource.contains("case .coordination(let sourceCoordinationError):"),
+            "copy() should surface a failed source read coordination via "
+                + "the CoordinateBridgeError.coordination enum case instead "
+                + "of continuing silently."
         )
         XCTAssertTrue(
-            pluginSource.contains("error: &sourceCoordinationError"),
-            "copy() should pass a read coordination error pointer instead "
-                + "of discarding coordination failures."
+            pluginSource.contains("sourceCoordinationError.localizedDescription"),
+            "copy() should inspect the surfaced source-read coordination "
+                + "error instead of discarding it."
         )
         XCTAssertTrue(
-            pluginSource.contains("if let sourceCoordinationError"),
-            "copy() should surface a failed source read coordination "
-                + "instead of continuing silently."
+            pluginSource.contains("case .accessor(let overwriteError):"),
+            "copy() should surface the source-read inner IO failure "
+                + "distinctly from the coordination failure (R14)."
         )
         XCTAssertTrue(
-            pluginSource.contains("var copyCoordinationError: NSError?"),
-            "copy() should also capture read/write coordination failures in "
-                + "the non-overwrite path."
+            pluginSource.contains("case .coordination(let copyCoordinationError):"),
+            "copy() should surface a failed combined read/write "
+                + "coordination via the CoordinateBridgeError.coordination "
+                + "enum case in the non-overwrite path."
         )
         XCTAssertTrue(
-            pluginSource.contains("error: &copyCoordinationError"),
-            "copy() should not discard the combined read/write "
-                + "coordination error."
+            pluginSource.contains("copyCoordinationError.localizedDescription"),
+            "copy() should inspect the surfaced combined coordination "
+                + "error instead of discarding it."
         )
         XCTAssertTrue(
-            pluginSource.contains("if let copyCoordinationError"),
-            "copy() should surface a failed combined coordination instead "
+            pluginSource.contains("case .accessor(let copyIOError):"),
+            "copy() should surface the combined-path inner IO failure "
+                + "distinctly from the coordination failure (R14) instead "
                 + "of leaving the Flutter call without a result."
         )
     }

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/UbiquityContainerResolverTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/UbiquityContainerResolverTests.swift
@@ -18,9 +18,7 @@ final class UbiquityContainerResolverTests: XCTestCase {
                 lock.unlock()
                 expectation.fulfill()
                 return temporaryDirectory
-            },
-            delay: { _ in XCTFail("should not retry") },
-            retryDelay: UbiquityContainerResolver.maximumRetryDelay
+            }
         )
 
         let containerURL = await resolver.resolve(containerId: "container")
@@ -30,91 +28,44 @@ final class UbiquityContainerResolverTests: XCTestCase {
         XCTAssertEqual(observedMainThreadState, false)
     }
 
-    func testResolveRetriesOnceAfterNilResult() async throws {
+    /// VAL-INV-006: the resolver performs exactly ONE ubiquity container
+    /// lookup (single-shot) and returns the URL on success.
+    func testResolveReturnsContainerURLOnSingleSuccessfulLookup() async throws {
         let temporaryDirectory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
 
-        var attempts = 0
-        var delays: [TimeInterval] = []
+        var lookupCount = 0
         let resolver = UbiquityContainerResolver(
             execute: { work in work() },
             resolveContainerURL: { _ in
-                attempts += 1
-                if attempts == 2 {
-                    return temporaryDirectory
-                }
-                return nil
-            },
-            delay: { delays.append($0) },
-            retryDelay: UbiquityContainerResolver.maximumRetryDelay
+                lookupCount += 1
+                return temporaryDirectory
+            }
         )
 
         let containerURL = await resolver.resolve(containerId: "container")
 
         XCTAssertEqual(containerURL?.path, temporaryDirectory.path)
-        XCTAssertEqual(attempts, UbiquityContainerResolver.maxAttempts)
-        XCTAssertEqual(
-            delays,
-            [UbiquityContainerResolver.maximumRetryDelay]
-        )
+        XCTAssertEqual(lookupCount, 1, "resolver must be single-shot")
     }
 
-    func testResolveReturnsNilAfterPersistentNilResults() async {
-        var attempts = 0
-        var delays: [TimeInterval] = []
+    /// VAL-INV-006: a nil lookup result is terminal — the resolver
+    /// performs a single lookup only and returns nil, so the caller
+    /// throws the same typed container-unavailable error it always has.
+    func testResolveReturnsNilAfterSingleShotNilResult() async {
+        var lookupCount = 0
         let resolver = UbiquityContainerResolver(
             execute: { work in work() },
             resolveContainerURL: { _ in
-                attempts += 1
+                lookupCount += 1
                 return nil
-            },
-            delay: { delays.append($0) },
-            retryDelay: UbiquityContainerResolver.maximumRetryDelay
+            }
         )
 
         let containerURL = await resolver.resolve(containerId: "missing")
 
         XCTAssertNil(containerURL)
-        XCTAssertEqual(attempts, UbiquityContainerResolver.maxAttempts)
-        XCTAssertEqual(
-            delays,
-            [UbiquityContainerResolver.maximumRetryDelay]
-        )
-    }
-
-    func testRetryDelayIsClampedTo150Milliseconds() async {
-        var delays: [TimeInterval] = []
-        let resolver = UbiquityContainerResolver(
-            execute: { work in work() },
-            resolveContainerURL: { _ in nil },
-            delay: { delays.append($0) },
-            retryDelay: 1
-        )
-
-        _ = await resolver.resolve(containerId: "missing")
-
-        XCTAssertEqual(
-            delays,
-            [UbiquityContainerResolver.maximumRetryDelay]
-        )
-    }
-
-    func testResolveStopsAfterCancelledRetryDelay() async {
-        var attempts = 0
-        let resolver = UbiquityContainerResolver(
-            execute: { work in work() },
-            resolveContainerURL: { _ in
-                attempts += 1
-                return nil
-            },
-            delay: { _ in throw CancellationError() },
-            retryDelay: UbiquityContainerResolver.maximumRetryDelay
-        )
-
-        let containerURL = await resolver.resolve(containerId: "cancelled")
-
-        XCTAssertNil(containerURL)
-        XCTAssertEqual(attempts, 1)
+        XCTAssertEqual(lookupCount, 1, "resolver must be single-shot")
     }
 
     private func makeTemporaryDirectory() throws -> URL {

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/WriteEntrypointPreflightTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/WriteEntrypointPreflightTests.swift
@@ -25,9 +25,7 @@ final class WriteEntrypointPreflightTests: XCTestCase {
                     lock.unlock()
                     expectation.fulfill()
                     return temporaryDirectory
-                },
-                delay: { _ in XCTFail("should not retry") },
-                retryDelay: UbiquityContainerResolver.maximumRetryDelay
+                }
             ),
             createDirectory: { directoryURL in
                 lock.lock()
@@ -57,9 +55,7 @@ final class WriteEntrypointPreflightTests: XCTestCase {
             execute: { work in try work() },
             ubiquityContainerResolver: UbiquityContainerResolver(
                 execute: { work in work() },
-                resolveContainerURL: { _ in nil },
-                delay: { _ in },
-                retryDelay: UbiquityContainerResolver.maximumRetryDelay
+                resolveContainerURL: { _ in nil }
             ),
             createDirectory: { _ in XCTFail("should not create directory") }
         )
@@ -91,9 +87,7 @@ final class WriteEntrypointPreflightTests: XCTestCase {
             execute: { work in try work() },
             ubiquityContainerResolver: UbiquityContainerResolver(
                 execute: { work in work() },
-                resolveContainerURL: { _ in temporaryDirectory },
-                delay: { _ in XCTFail("should not retry") },
-                retryDelay: UbiquityContainerResolver.maximumRetryDelay
+                resolveContainerURL: { _ in temporaryDirectory }
             ),
             createDirectory: { _ in createDirectoryCalled = true }
         )
@@ -127,9 +121,7 @@ final class WriteEntrypointPreflightTests: XCTestCase {
                     observedMainThreadState = Thread.isMainThread
                     expectation.fulfill()
                     return temporaryDirectory
-                },
-                delay: { _ in XCTFail("should not retry") },
-                retryDelay: UbiquityContainerResolver.maximumRetryDelay
+                }
             ),
             createDirectory: { _ in XCTFail("should not create directory") }
         )
@@ -143,49 +135,40 @@ final class WriteEntrypointPreflightTests: XCTestCase {
         XCTAssertEqual(observedMainThreadState, false)
     }
 
-    func testPrepareSucceedsWhenInitialContainerLookupIsNil() async throws {
-        let temporaryDirectory = try makeTemporaryDirectory()
-        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
-
-        var attempts = 0
-        var delays: [TimeInterval] = []
-        var createdDirectory: URL?
+    /// VAL-INV-006: the resolver is single-shot, so a nil container
+    /// lookup is terminal — `prepare` throws the same typed
+    /// container-unavailable error (same domain + code) it always has
+    /// after a single lookup, with no directory creation.
+    func testPrepareThrowsContainerUnavailableErrorWhenLookupIsNil() async {
+        var lookupCount = 0
         let preflight = WriteEntrypointPreflight(
             execute: { work in try work() },
             ubiquityContainerResolver: UbiquityContainerResolver(
                 execute: { work in work() },
                 resolveContainerURL: { _ in
-                    attempts += 1
-                    return attempts == 2 ? temporaryDirectory : nil
-                },
-                delay: { delays.append($0) },
-                retryDelay: UbiquityContainerResolver.maximumRetryDelay
+                    lookupCount += 1
+                    return nil
+                }
             ),
-            createDirectory: { createdDirectory = $0 }
+            createDirectory: { _ in XCTFail("should not create directory") }
         )
 
-        let fileURL = try await preflight.prepare(
-            containerId: "container",
-            relativePath: "nested/file.txt"
-        )
+        do {
+            _ = try await preflight.prepare(
+                containerId: "container",
+                relativePath: "nested/file.txt"
+            )
+            XCTFail("expected prepare to throw")
+        } catch {
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.domain, WriteEntrypointPreflight.errorDomain)
+            XCTAssertEqual(
+                nsError.code,
+                WriteEntrypointPreflight.containerUnavailableErrorCode
+            )
+        }
 
-        XCTAssertEqual(attempts, UbiquityContainerResolver.maxAttempts)
-        XCTAssertEqual(
-            delays,
-            [UbiquityContainerResolver.maximumRetryDelay]
-        )
-        XCTAssertEqual(
-            fileURL.path,
-            temporaryDirectory
-                .appendingPathComponent("nested/file.txt")
-                .path
-        )
-        XCTAssertEqual(
-            createdDirectory?.path,
-            temporaryDirectory
-                .appendingPathComponent("nested", isDirectory: true)
-                .path
-        )
+        XCTAssertEqual(lookupCount, 1, "resolver must be single-shot")
     }
 
     private func makeTemporaryDirectory() throws -> URL {

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/UbiquityContainerResolver.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/UbiquityContainerResolver.swift
@@ -6,40 +6,18 @@ struct UbiquityContainerResolver {
         @escaping @Sendable () -> URL?
     ) async -> URL?
     typealias ResolveContainerURL = (String) -> URL?
-    typealias Delay = (TimeInterval) async throws -> Void
-
-    static let maxAttempts = 2
-    static let maximumRetryDelay: TimeInterval = 0.15
 
     let execute: Execute
     let resolveContainerURL: ResolveContainerURL
-    let delay: Delay
-    let retryDelay: TimeInterval
 
+    /// Single-shot ubiquity container lookup. On failure the resolver
+    /// returns `nil`; the caller (`WriteEntrypointPreflight`) throws the
+    /// same typed `containerUnavailableError` with the same channel code
+    /// it always has.
     func resolve(containerId: String) async -> URL? {
-        for attempt in 0..<Self.maxAttempts {
-            if let containerURL = await execute({
-                resolveContainerURL(containerId)
-            }) {
-                return containerURL
-            }
-
-            if attempt < Self.maxAttempts - 1 {
-                do {
-                    try await delay(clampedRetryDelay)
-                } catch is CancellationError {
-                    return nil
-                } catch {
-                    return nil
-                }
-            }
+        await execute {
+            resolveContainerURL(containerId)
         }
-
-        return nil
-    }
-
-    private var clampedRetryDelay: TimeInterval {
-        max(0, min(retryDelay, Self.maximumRetryDelay))
     }
 }
 
@@ -56,11 +34,6 @@ extension UbiquityContainerResolver {
         },
         resolveContainerURL: {
             FileManager.default.url(forUbiquityContainerIdentifier: $0)
-        },
-        delay: { delay in
-            let nanoseconds = UInt64(delay * 1_000_000_000)
-            try await Task.sleep(nanoseconds: nanoseconds)
-        },
-        retryDelay: maximumRetryDelay
+        }
     )
 }


### PR DESCRIPTION
M1 (MYT-1314) user-testing remediation — two independent foundation-package fixes in one tandem cycle (iOS + macOS mirrored).

## (A) Stale source-text copy-coordination tests (flips VAL-MUT-016 / VAL-MUT-050)
`CoordinatedReplaceWriterTests.swift` had 6 stale source-text-introspection assertions **per platform** inside `testIOS/MacOSCopyPropagatesSourceReadCoordinationErrors` that still asserted the OLD pre-CoordinatedIO syntax (`var X: NSError?` / `error: &X` / `if let X`). The M1 lane-fix CoordinatedIO refactor already replaced that with `CoordinateBridgeError` enum-pattern surfacing (`case .coordination(let X):` / `case .accessor(let Y):`). The copy error-propagation **behavior is already correct**; only the brittle introspection assertions were stale. Updated the 6 assertions per platform to match the CURRENT channel source (parity in intent). **No production code change for part (A).**

## (B) R18 container-retry removal (flips VAL-INV-006)
`UbiquityContainerResolver.swift` had a 2-attempt retry loop (`maxAttempts = 2`, `retryDelay` clamped by `maximumRetryDelay`, a `for attempt in 0..<maxAttempts` loop, and an inter-attempt `Task.sleep` delay) — a real R18 violation (Cove readiness-retry pattern). Collapsed to a **single-shot** container lookup: removed the attempt loop, `maxAttempts`, `retryDelay`, `maximumRetryDelay`, the `Delay` typealias, and the inter-attempt delay. On failure the resolver still returns `nil`, so `WriteEntrypointPreflight.containerURL` still throws the SAME typed `containerUnavailableError` (domain `ICloudStoragePlusWriteEntrypointPreflight`, code 1) with the SAME channel code — **error semantics preserved byte-for-byte; only the retry scheduling was removed.** Updated `UbiquityContainerResolverTests` + `WriteEntrypointPreflightTests` to assert single-shot. Byte-identical across `ios/` and `macos/` foundation packages.

After the change `rg -ni "retry|attempt|backoff|reschedul" ios/ macos/` shows no active scheduling construct (only the advisory `retryable` exception-payload flag remains, per VAL-INV-006's FLAG).

## Verification
- `swift test` foundation green: **59 iOS / 61 macOS**, 0 failures.
- `flutter build macos --debug` on the plugin `example/` app → exit 0 (channel layer compiles with the resolver change).
- `flutter build ios --debug --no-codesign` on the plugin `example/` app → exit 0.
- `swift-icloud-plugin-expert` review (review mode): **APPROVED**, 0 Critical / 0 Important / 0 Suggestion; parity, R18-grep, and part-(A) staleness checks all PASS.

## Tandem
Plugin-first. The consuming app (MythicGME2e) pin-bump PR to this merged commit follows in the app repo (current app pin is `1a3b25d` via app PR #1554 — superseded by this fix's merged hash). Override is NOT removed (that is M8 / MYT-1321).

Closes MYT-1314 (M1 user-testing remediation).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Jason-Holt-Digital/codesmith/icloud_storage_plus/pr/44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->