### PR TITLE
feat(MYT-1317): bridge document presenter changes to Dart

### DIFF
--- a/ios/icloud_storage_plus.podspec
+++ b/ios/icloud_storage_plus.podspec
@@ -18,6 +18,7 @@ container, with document coordination via UIDocument/NSDocument.
     'icloud_storage_plus/Sources/icloud_storage_plus/**/*.{h,m,swift}',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedIO.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift',
+    'icloud_storage_plus/Sources/icloud_storage_plus_foundation/DocumentChangeObservation.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/MetadataQuerySupport.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/MetadataQuerySession.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/WriteEntrypointPreflight.swift',

--- a/ios/icloud_storage_plus/Package.swift
+++ b/ios/icloud_storage_plus/Package.swift
@@ -28,6 +28,7 @@ let package = Package(
                 "icloud_storage_plus",
                 "icloud_storage_plus_foundation/CoordinatedIO.swift",
                 "icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift",
+                "icloud_storage_plus_foundation/DocumentChangeObservation.swift",
                 "icloud_storage_plus_foundation/MetadataQuerySupport.swift",
                 "icloud_storage_plus_foundation/MetadataQuerySession.swift",
                 "icloud_storage_plus_foundation/WriteEntrypointPreflight.swift",

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus/ICloudDocument.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus/ICloudDocument.swift
@@ -16,6 +16,23 @@ class ICloudDocument: UIDocument {
     /// Error occurred during the last operation (if any).
     var lastError: Error?
 
+    /// Event-channel observation state for this existing document presenter.
+    var changeObservation: DocumentChangeObservation? {
+        get {
+            changeObservationLock.lock()
+            defer { changeObservationLock.unlock() }
+            return _changeObservation
+        }
+        set {
+            changeObservationLock.lock()
+            _changeObservation = newValue
+            changeObservationLock.unlock()
+        }
+    }
+
+    private let changeObservationLock = NSLock()
+    private var _changeObservation: DocumentChangeObservation?
+
     // MARK: - UIDocument Override Methods
 
     override func contents(forType typeName: String) throws -> Any {
@@ -91,7 +108,11 @@ class ICloudDocument: UIDocument {
     }
 
     @objc private func documentStateChanged() {
+        var emittedSpecificState = false
+
         if documentState.contains(.inConflict) {
+            changeObservation?.emit(kind: .conflict)
+            emittedSpecificState = true
             // Conflict policy is app-owned. The plugin only surfaces the
             // conflict; it never auto-resolves-and-deletes losing
             // `NSFileVersion`s. The app enumerates, copies out, and marks
@@ -102,11 +123,19 @@ class ICloudDocument: UIDocument {
         }
 
         if documentState.contains(.savingError) {
+            changeObservation?.emit(kind: .savingError)
+            emittedSpecificState = true
             DebugHelper.log("Document saving error: \(fileURL.lastPathComponent)")
         }
 
         if documentState.contains(.editingDisabled) {
+            changeObservation?.emit(kind: .editingDisabled)
+            emittedSpecificState = true
             DebugHelper.log("Document editing disabled: \(fileURL.lastPathComponent)")
+        }
+
+        if !emittedSpecificState {
+            changeObservation?.emit(kind: .remoteChange)
         }
     }
 

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus/iOSICloudStoragePlugin.swift
@@ -23,6 +23,12 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     queue.qualityOfService = .userInitiated
     return queue
   }()
+  private var documentChangeRegistrations: [
+    String: DocumentChangeRegistration
+  ] = [:]
+  private let documentChangeRegistrationsQueue = DispatchQueue(
+    label: "icloud_storage_plus.document_change_registrations"
+  )
   private let ubiquityContainerResolver: UbiquityContainerResolver
 
   init(
@@ -38,6 +44,12 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     }
     for session in sessions {
       session.cancel()
+    }
+    let registrations = documentChangeRegistrationsQueue.sync {
+      Array(documentChangeRegistrations.values)
+    }
+    for registration in registrations {
+      registration.cancel()
     }
   }
 
@@ -70,6 +82,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       icloudAvailable(result)
     case "gather":
       gather(call, result)
+    case "watchDocumentChanges":
+      watchDocumentChanges(call, result)
     case "uploadFile":
       uploadFile(call, result)
     case "downloadFile":
@@ -124,12 +138,14 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     operation: String,
     relativePath: String? = nil,
     result: @escaping FlutterResult,
+    onFailure: (() -> Void)? = nil,
     onResolved: @escaping (URL) -> Void
   ) {
     Task { @MainActor [self] in
       guard let containerURL = await ubiquityContainerResolver.resolve(
         containerId: containerId
       ) else {
+        onFailure?()
         result(containerAccessError(
           operation: operation,
           relativePath: relativePath
@@ -218,6 +234,95 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       }
     }
     session.start()
+  }
+
+  /// Watches the existing ICloudDocument presenter's document-change events.
+  private func watchDocumentChanges(
+    _ call: FlutterMethodCall,
+    _ result: @escaping FlutterResult
+  ) {
+    guard let args = call.arguments as? Dictionary<String, Any>,
+          let containerId = args["containerId"] as? String,
+          let relativePath = args["relativePath"] as? String,
+          let eventChannelName = args["eventChannelName"] as? String,
+          !eventChannelName.isEmpty
+    else {
+      result(argumentError)
+      return
+    }
+
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "watchDocumentChanges",
+      relativePath: relativePath,
+      result: result,
+      onFailure: { [weak self] in
+        self?.removeStreamHandler(eventChannelName)
+      }
+    ) { [self] containerURL in
+      startDocumentChangeObservation(
+        containerURL: containerURL,
+        relativePath: relativePath,
+        eventChannelName: eventChannelName,
+        result: result
+      )
+    }
+  }
+
+  private func startDocumentChangeObservation(
+    containerURL: URL,
+    relativePath: String,
+    eventChannelName: String,
+    result: @escaping FlutterResult
+  ) {
+    guard let streamHandler = registeredStreamHandler(for: eventChannelName)
+    else {
+      result(missingEventHandlerError(
+        eventChannelName: eventChannelName,
+        operation: "watchDocumentChanges",
+        relativePath: relativePath
+      ))
+      return
+    }
+
+    let documentURL = containerURL.appendingPathComponent(relativePath)
+    let document = ICloudDocument(fileURL: documentURL)
+    let observation = DocumentChangeObservation(
+      relativePath: relativePath,
+      onStart: { [weak document] in
+        guard let document else { return }
+        NSFileCoordinator.addFilePresenter(document)
+      },
+      onCancel: { [weak document] in
+        guard let document else { return }
+        NSFileCoordinator.removeFilePresenter(document)
+      },
+      emit: { payload in
+        DispatchQueue.main.async {
+          streamHandler.setEvent(payload)
+        }
+      }
+    )
+    document.changeObservation = observation
+    let registration = DocumentChangeRegistration(
+      document: document,
+      observation: observation
+    )
+    setDocumentChangeRegistration(registration, for: eventChannelName)
+    streamHandler.onCancelHandler = { [weak self, weak registration] in
+      guard let self, let registration else { return }
+
+      registration.cancel()
+      if self.removeDocumentChangeRegistration(
+        eventChannelName,
+        matching: registration
+      ) {
+        self.removeStreamHandler(eventChannelName)
+      }
+    }
+
+    observation.start()
+    result(nil)
   }
   
   /// Adds observers for metadata gather and update notifications.
@@ -1935,6 +2040,33 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     }
   }
 
+  private func setDocumentChangeRegistration(
+    _ registration: DocumentChangeRegistration,
+    for eventChannelName: String
+  ) {
+    let existingRegistration = documentChangeRegistrationsQueue.sync {
+      let existing = documentChangeRegistrations[eventChannelName]
+      documentChangeRegistrations[eventChannelName] = registration
+      return existing
+    }
+    existingRegistration?.cancel()
+  }
+
+  private func removeDocumentChangeRegistration(
+    _ eventChannelName: String,
+    matching registration: DocumentChangeRegistration? = nil
+  ) -> Bool {
+    documentChangeRegistrationsQueue.sync {
+      if let registration,
+         documentChangeRegistrations[eventChannelName] !== registration {
+        return false
+      }
+
+      documentChangeRegistrations[eventChannelName] = nil
+      return true
+    }
+  }
+
   private func reserveProgressUpdate(
     _ progress: Double,
     eventChannelName: String
@@ -1997,6 +2129,22 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       code: "E_CTR",
       message: "Invalid containerId, or user is not signed in, or user disabled iCloud permission",
       category: "containerAccess",
+      operation: operation,
+      retryable: false,
+      relativePath: relativePath
+    )
+  }
+
+  private func missingEventHandlerError(
+    eventChannelName: String,
+    operation: String,
+    relativePath: String? = nil
+  ) -> FlutterError {
+    flutterError(
+      code: "E_NO_HANDLER",
+      message: "Event channel '\(eventChannelName)' not created. Call "
+        + "createEventChannel first.",
+      category: "invalidArgument",
       operation: operation,
       retryable: false,
       relativePath: relativePath
@@ -2145,6 +2293,37 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       nativeError: nsError,
       underlying: String(describing: error)
     )
+  }
+}
+
+private final class DocumentChangeRegistration {
+  private let document: ICloudDocument
+  private let observation: DocumentChangeObservation
+  private let cancelLock = NSLock()
+  private var didCancel = false
+
+  init(document: ICloudDocument, observation: DocumentChangeObservation) {
+    self.document = document
+    self.observation = observation
+  }
+
+  deinit {
+    cancel()
+  }
+
+  func cancel() {
+    let shouldCancel: Bool = {
+      cancelLock.lock()
+      defer { cancelLock.unlock() }
+
+      guard !didCancel else { return false }
+      didCancel = true
+      return true
+    }()
+    guard shouldCancel else { return }
+
+    observation.cancel()
+    document.changeObservation = nil
   }
 }
 

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/DocumentChangeObservation.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/DocumentChangeObservation.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Kinds emitted when the existing `ICloudDocument` presenter observes a
+/// document change.
+enum DocumentChangeKind: String {
+    case remoteChange
+    case conflict
+    case savingError
+    case editingDisabled
+}
+
+/// Listener state for the existing `ICloudDocument` presenter bridge.
+///
+/// This is not a file presenter and does not observe the filesystem by itself.
+/// It only maps presenter callbacks from `ICloudDocument` into stable channel
+/// payloads and owns deterministic teardown for the event-channel subscription.
+final class DocumentChangeObservation {
+    typealias Payload = [String: Any]
+    typealias Emit = (Payload) -> Void
+
+    private let relativePath: String
+    private let onStart: () -> Void
+    private let onCancel: () -> Void
+    private let emitPayload: Emit
+    private let lock = NSLock()
+    private var active = false
+
+    init(
+        relativePath: String,
+        onStart: @escaping () -> Void,
+        onCancel: @escaping () -> Void,
+        emit: @escaping Emit
+    ) {
+        self.relativePath = relativePath
+        self.onStart = onStart
+        self.onCancel = onCancel
+        self.emitPayload = emit
+    }
+
+    deinit {
+        cancel()
+    }
+
+    func start() {
+        let shouldStart: Bool = lock.withLock {
+            guard !active else { return false }
+            active = true
+            return true
+        }
+        if shouldStart {
+            onStart()
+        }
+    }
+
+    func cancel() {
+        let shouldCancel: Bool = lock.withLock {
+            guard active else { return false }
+            active = false
+            return true
+        }
+        if shouldCancel {
+            onCancel()
+        }
+    }
+
+    func emit(kind: DocumentChangeKind) {
+        let payload: Payload? = lock.withLock {
+            guard active else { return nil }
+            return [
+                "relativePath": relativePath,
+                "kind": kind.rawValue,
+            ]
+        }
+        if let payload {
+            emitPayload(payload)
+        }
+    }
+}
+
+private extension NSLock {
+    func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        lock()
+        defer { unlock() }
+        return try body()
+    }
+}

--- a/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/DocumentChangeObservationTests.swift
+++ b/ios/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/DocumentChangeObservationTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import XCTest
+@testable import icloud_storage_plus_foundation
+
+final class DocumentChangeObservationTests: XCTestCase {
+    func testRemoteChangeEventEmitsTypedPayload() {
+        var payloads: [[String: Any]] = []
+        let observation = DocumentChangeObservation(
+            relativePath: "Documents/journal.json",
+            onStart: {},
+            onCancel: {},
+            emit: { payloads.append($0) }
+        )
+
+        observation.start()
+        observation.emit(kind: .remoteChange)
+
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(
+            payloads[0]["relativePath"] as? String,
+            "Documents/journal.json"
+        )
+        XCTAssertEqual(payloads[0]["kind"] as? String, "remoteChange")
+    }
+
+    func testCancelRemovesObserverAndSuppressesFutureEvents() {
+        var startCount = 0
+        var cancelCount = 0
+        var payloads: [[String: Any]] = []
+        let observation = DocumentChangeObservation(
+            relativePath: "Documents/journal.json",
+            onStart: { startCount += 1 },
+            onCancel: { cancelCount += 1 },
+            emit: { payloads.append($0) }
+        )
+
+        observation.start()
+        observation.cancel()
+        observation.emit(kind: .remoteChange)
+        observation.cancel()
+
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(cancelCount, 1)
+        XCTAssertTrue(payloads.isEmpty)
+    }
+
+    func testStartIsIdempotent() {
+        var startCount = 0
+        let observation = DocumentChangeObservation(
+            relativePath: "Documents/journal.json",
+            onStart: { startCount += 1 },
+            onCancel: {},
+            emit: { _ in }
+        )
+
+        observation.start()
+        observation.start()
+
+        XCTAssertEqual(startCount, 1)
+    }
+}

--- a/lib/icloud_storage.dart
+++ b/lib/icloud_storage.dart
@@ -4,6 +4,7 @@ import 'package:icloud_storage_plus/icloud_storage_platform_interface.dart';
 import 'package:icloud_storage_plus/models/container_item.dart';
 import 'package:icloud_storage_plus/models/exceptions.dart';
 import 'package:icloud_storage_plus/models/gather_result.dart';
+import 'package:icloud_storage_plus/models/icloud_document_change.dart';
 import 'package:icloud_storage_plus/models/icloud_item_metadata.dart';
 import 'package:icloud_storage_plus/models/icloud_version.dart';
 import 'package:icloud_storage_plus/models/transfer_progress.dart';
@@ -12,6 +13,7 @@ export 'models/container_item.dart';
 export 'models/download_status.dart';
 export 'models/exceptions.dart';
 export 'models/gather_result.dart';
+export 'models/icloud_document_change.dart';
 export 'models/icloud_file.dart';
 export 'models/icloud_item_metadata.dart';
 export 'models/icloud_version.dart';
@@ -77,6 +79,39 @@ class ICloudStorage {
     return ICloudStoragePlatform.instance.gather(
       containerId: containerId,
       onUpdate: onUpdate,
+    );
+  }
+
+  /// Watch remote-change/document-state events for one document path.
+  ///
+  /// The native Darwin implementations reuse the existing `ICloudDocument`
+  /// presenter. Cancel the Dart stream subscription to tear down the native
+  /// observation.
+  ///
+  /// On iOS, a single native state callback can emit more than one typed event
+  /// when multiple document-state flags are active. Debounce or coalesce the
+  /// stream if your caller requires one event per native transition.
+  static Future<void> watchDocumentChanges({
+    required String containerId,
+    required String relativePath,
+    required StreamHandler<ICloudDocumentChange> onChange,
+  }) async {
+    if (relativePath.trim().isEmpty) {
+      throw InvalidArgumentException('invalid relativePath: $relativePath');
+    }
+
+    if (relativePath.endsWith('/')) {
+      throw InvalidArgumentException('invalid relativePath: $relativePath');
+    }
+
+    if (!_validateRelativePath(relativePath)) {
+      throw InvalidArgumentException('invalid relativePath: $relativePath');
+    }
+
+    await ICloudStoragePlatform.instance.watchDocumentChanges(
+      containerId: containerId,
+      relativePath: relativePath,
+      onChange: onChange,
     );
   }
 

--- a/lib/icloud_storage_method_channel.dart
+++ b/lib/icloud_storage_method_channel.dart
@@ -83,6 +83,12 @@ class MethodChannelICloudStorage extends ICloudStoragePlatform {
         .receiveBroadcastStream()
         .map<ICloudDocumentChange>(_mapDocumentChangeEvent)
         .handleError((Object error, StackTrace stackTrace) {
+      // PlatformExceptions from _mapDocumentChangeEvent (malformed payload,
+      // code: invalidEvent) have no structured 'category' in their details
+      // and are returned unchanged by _mapStructuredPlatformException.
+      // Native-originated PlatformExceptions carry a structured category and
+      // are mapped to typed ICloudOperationException values. Non-Platform-
+      // Exception errors are re-thrown with their original stack trace.
       if (error is PlatformException) {
         throw _mapStructuredPlatformException(error);
       }

--- a/lib/icloud_storage_method_channel.dart
+++ b/lib/icloud_storage_method_channel.dart
@@ -6,6 +6,7 @@ import 'package:icloud_storage_plus/icloud_storage_platform_interface.dart';
 import 'package:icloud_storage_plus/models/container_item.dart';
 import 'package:icloud_storage_plus/models/exceptions.dart';
 import 'package:icloud_storage_plus/models/gather_result.dart';
+import 'package:icloud_storage_plus/models/icloud_document_change.dart';
 import 'package:icloud_storage_plus/models/icloud_file.dart';
 import 'package:icloud_storage_plus/models/icloud_version.dart';
 import 'package:icloud_storage_plus/models/transfer_progress.dart';
@@ -58,6 +59,88 @@ class MethodChannelICloudStorage extends ICloudStoragePlatform {
     });
 
     return _mapFilesFromDynamicList(mapList);
+  }
+
+  @override
+  Future<void> watchDocumentChanges({
+    required String containerId,
+    required String relativePath,
+    required StreamHandler<ICloudDocumentChange> onChange,
+  }) async {
+    final eventChannelName = _generateEventChannelName(
+      'documentChanges',
+      containerId,
+      relativePath,
+    );
+
+    await _invokeMethod<void>(
+      'createEventChannel',
+      {'eventChannelName': eventChannelName},
+    );
+
+    final eventChannel = EventChannel(eventChannelName);
+    final eventStream = eventChannel
+        .receiveBroadcastStream()
+        .map<ICloudDocumentChange>(_mapDocumentChangeEvent)
+        .handleError((Object error, StackTrace stackTrace) {
+      if (error is PlatformException) {
+        throw _mapStructuredPlatformException(error);
+      }
+      Error.throwWithStackTrace(error, stackTrace);
+    });
+
+    StreamSubscription<ICloudDocumentChange>? subscription;
+    late final StreamController<ICloudDocumentChange> controller;
+    controller = StreamController<ICloudDocumentChange>(
+      onListen: () {
+        subscription = eventStream.listen(
+          controller.add,
+          onError: controller.addError,
+          onDone: controller.close,
+        );
+      },
+      onCancel: () async {
+        await subscription?.cancel();
+      },
+    );
+
+    onChange(controller.stream);
+
+    try {
+      await _invokeMethod<void>('watchDocumentChanges', {
+        'containerId': containerId,
+        'relativePath': relativePath,
+        'eventChannelName': eventChannelName,
+      });
+    } on PlatformException catch (error, stackTrace) {
+      final mapped = _mapStructuredPlatformException(error);
+      controller.addError(mapped, stackTrace);
+      unawaited(controller.close());
+      Error.throwWithStackTrace(mapped, stackTrace);
+    } catch (error, stackTrace) {
+      controller.addError(error, stackTrace);
+      unawaited(controller.close());
+      Error.throwWithStackTrace(error, stackTrace);
+    }
+  }
+
+  ICloudDocumentChange _mapDocumentChangeEvent(Object? event) {
+    if (event is! Map) {
+      throw PlatformException(
+        code: PlatformExceptionCode.invalidEvent,
+        message: 'Unexpected document change event type: '
+            '${event.runtimeType}',
+        details: event,
+      );
+    }
+    if (event['relativePath'] is! String || event['kind'] is! String) {
+      throw PlatformException(
+        code: PlatformExceptionCode.invalidEvent,
+        message: 'Malformed document change event payload',
+        details: event,
+      );
+    }
+    return ICloudDocumentChange.fromMap(event);
   }
 
   @override

--- a/lib/icloud_storage_platform_interface.dart
+++ b/lib/icloud_storage_platform_interface.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:icloud_storage_plus/icloud_storage_method_channel.dart';
 import 'package:icloud_storage_plus/models/container_item.dart';
 import 'package:icloud_storage_plus/models/gather_result.dart';
+import 'package:icloud_storage_plus/models/icloud_document_change.dart';
 import 'package:icloud_storage_plus/models/icloud_version.dart';
 import 'package:icloud_storage_plus/models/transfer_progress.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
@@ -61,6 +62,21 @@ abstract class ICloudStoragePlatform extends PlatformInterface {
     StreamHandler<GatherResult>? onUpdate,
   }) async {
     throw UnimplementedError('gather() has not been implemented.');
+  }
+
+  /// Watch remote-change/document-state events for one open document.
+  ///
+  /// The native implementation reuses the existing `ICloudDocument` presenter.
+  /// It does not create a new presenter type. The stream stays active until
+  /// the Dart subscription is canceled, which tears down native observation.
+  Future<void> watchDocumentChanges({
+    required String containerId,
+    required String relativePath,
+    required StreamHandler<ICloudDocumentChange> onChange,
+  }) async {
+    throw UnimplementedError(
+      'watchDocumentChanges() has not been implemented.',
+    );
   }
 
   /// Get the local path to the iCloud container root, if available.

--- a/lib/models/exceptions.dart
+++ b/lib/models/exceptions.dart
@@ -57,6 +57,9 @@ class PlatformExceptionCode {
   /// side.
   static const String initializationError = 'E_INIT';
 
+  /// The code indicates an event channel was not created before use.
+  static const String noEventHandler = 'E_NO_HANDLER';
+
   /// The code indicates the native layer sent an invalid event type
   /// This represents a bug in the plugin. Please open a GitHub issue if you
   /// encounter this error.

--- a/lib/models/icloud_document_change.dart
+++ b/lib/models/icloud_document_change.dart
@@ -18,17 +18,16 @@ class ICloudDocumentChange extends Equatable {
       );
     }
     final kind = map['kind'];
-    if (kind != null && kind is! String) {
+    if (kind is! String) {
       throw FormatException(
         'ICloudDocumentChange.fromMap expected String kind, '
         'got ${kind.runtimeType}',
       );
     }
-    final kindValue = kind == null ? null : kind as String;
 
     return ICloudDocumentChange(
       relativePath: relativePath,
-      kind: ICloudDocumentChangeKind.fromValue(kindValue),
+      kind: ICloudDocumentChangeKind.fromValue(kind),
     );
   }
 
@@ -61,6 +60,12 @@ enum ICloudDocumentChangeKind {
   /// Emitted on iOS when `UIDocument` reports editing is disabled. macOS does
   /// not expose an equivalent `NSDocument` file-presenter state for this
   /// stream.
+  ///
+  /// On iOS, `UIDocument`'s default `presentedItemDidChange` implementation
+  /// temporarily sets `.editingDisabled` then clears it during a remote sync
+  /// revert. An `editingDisabled` event may therefore be an implementation
+  /// artifact of the revert mechanism rather than a genuine editing
+  /// restriction imposed by the app or system.
   editingDisabled('editingDisabled'),
 
   /// The native payload contained an unknown kind.
@@ -71,8 +76,11 @@ enum ICloudDocumentChangeKind {
   /// Wire value sent over the event channel.
   final String value;
 
-  /// Parses a native event kind.
-  static ICloudDocumentChangeKind fromValue(String? value) {
+  /// Parses a native event kind string.
+  ///
+  /// Unrecognised values map to [ICloudDocumentChangeKind.unknown] for
+  /// forward-compatibility with new kinds added in future native releases.
+  static ICloudDocumentChangeKind fromValue(String value) {
     return ICloudDocumentChangeKind.values.firstWhere(
       (kind) => kind.value == value,
       orElse: () => ICloudDocumentChangeKind.unknown,

--- a/lib/models/icloud_document_change.dart
+++ b/lib/models/icloud_document_change.dart
@@ -1,0 +1,81 @@
+import 'package:equatable/equatable.dart';
+
+/// Typed event emitted when an observed iCloud document changes.
+class ICloudDocumentChange extends Equatable {
+  /// Creates a document change event.
+  const ICloudDocumentChange({
+    required this.relativePath,
+    required this.kind,
+  });
+
+  /// Creates a document change event from the native event payload.
+  factory ICloudDocumentChange.fromMap(Map<dynamic, dynamic> map) {
+    final relativePath = map['relativePath'];
+    if (relativePath is! String) {
+      throw FormatException(
+        'ICloudDocumentChange.fromMap expected String relativePath, '
+        'got ${relativePath.runtimeType}',
+      );
+    }
+    final kind = map['kind'];
+    if (kind != null && kind is! String) {
+      throw FormatException(
+        'ICloudDocumentChange.fromMap expected String kind, '
+        'got ${kind.runtimeType}',
+      );
+    }
+    final kindValue = kind == null ? null : kind as String;
+
+    return ICloudDocumentChange(
+      relativePath: relativePath,
+      kind: ICloudDocumentChangeKind.fromValue(kindValue),
+    );
+  }
+
+  /// Relative path of the observed item inside the iCloud container.
+  final String relativePath;
+
+  /// Kind of document change observed by the native presenter.
+  final ICloudDocumentChangeKind kind;
+
+  @override
+  List<Object?> get props => [relativePath, kind];
+}
+
+/// Stable event kinds emitted by the native document presenter bridge.
+enum ICloudDocumentChangeKind {
+  /// The existing `ICloudDocument` presenter observed a remote/item change.
+  remoteChange('remoteChange'),
+
+  /// The document entered a conflict state.
+  conflict('conflict'),
+
+  /// The document reported a saving error state.
+  ///
+  /// Emitted on iOS when `UIDocument` reports a saving error. macOS does not
+  /// expose an equivalent `NSDocument` file-presenter state for this stream.
+  savingError('savingError'),
+
+  /// The document reported editing is disabled.
+  ///
+  /// Emitted on iOS when `UIDocument` reports editing is disabled. macOS does
+  /// not expose an equivalent `NSDocument` file-presenter state for this
+  /// stream.
+  editingDisabled('editingDisabled'),
+
+  /// The native payload contained an unknown kind.
+  unknown('unknown');
+
+  const ICloudDocumentChangeKind(this.value);
+
+  /// Wire value sent over the event channel.
+  final String value;
+
+  /// Parses a native event kind.
+  static ICloudDocumentChangeKind fromValue(String? value) {
+    return ICloudDocumentChangeKind.values.firstWhere(
+      (kind) => kind.value == value,
+      orElse: () => ICloudDocumentChangeKind.unknown,
+    );
+  }
+}

--- a/macos/icloud_storage_plus.podspec
+++ b/macos/icloud_storage_plus.podspec
@@ -19,6 +19,7 @@ container, with document coordination via UIDocument/NSDocument.
     'icloud_storage_plus/Sources/icloud_storage_plus/**/*.{h,m,swift}',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedIO.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift',
+    'icloud_storage_plus/Sources/icloud_storage_plus_foundation/DocumentChangeObservation.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/MetadataQuerySupport.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/MetadataQuerySession.swift',
     'icloud_storage_plus/Sources/icloud_storage_plus_foundation/WriteEntrypointPreflight.swift',

--- a/macos/icloud_storage_plus/Package.swift
+++ b/macos/icloud_storage_plus/Package.swift
@@ -28,6 +28,7 @@ let package = Package(
                 "icloud_storage_plus",
                 "icloud_storage_plus_foundation/CoordinatedIO.swift",
                 "icloud_storage_plus_foundation/CoordinatedReplaceWriter.swift",
+                "icloud_storage_plus_foundation/DocumentChangeObservation.swift",
                 "icloud_storage_plus_foundation/MetadataQuerySupport.swift",
                 "icloud_storage_plus_foundation/MetadataQuerySession.swift",
                 "icloud_storage_plus_foundation/WriteEntrypointPreflight.swift",

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus/ICloudDocument.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus/ICloudDocument.swift
@@ -11,7 +11,29 @@ class ICloudDocument: NSDocument {
     /// Error occurred during the last operation (if any).
     var lastError: Error?
 
+    /// Event-channel observation state for this existing document presenter.
+    var changeObservation: DocumentChangeObservation? {
+        get {
+            changeObservationLock.lock()
+            defer { changeObservationLock.unlock() }
+            return _changeObservation
+        }
+        set {
+            changeObservationLock.lock()
+            _changeObservation = newValue
+            changeObservationLock.unlock()
+        }
+    }
+
+    private let changeObservationLock = NSLock()
+    private var _changeObservation: DocumentChangeObservation?
+
     // MARK: - NSDocument Override Methods
+
+    convenience init(fileURL: URL) {
+        self.init()
+        self.fileURL = fileURL
+    }
 
     override func read(from url: URL, ofType typeName: String) throws {
         guard let destinationURL = destinationURL else {
@@ -76,11 +98,14 @@ class ICloudDocument: NSDocument {
         super.presentedItemDidChange()
 
         guard let fileURL = fileURL else { return }
+
         guard let conflictVersions = NSFileVersion.unresolvedConflictVersionsOfItem(at: fileURL),
               !conflictVersions.isEmpty else {
+            changeObservation?.emit(kind: .remoteChange)
             return
         }
 
+        changeObservation?.emit(kind: .conflict)
         // Conflict policy is app-owned. The plugin only surfaces the
         // conflict; it never auto-resolves-and-deletes losing
         // `NSFileVersion`s. The app enumerates, copies out, and marks

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus/macOSICloudStoragePlugin.swift
@@ -23,6 +23,12 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     queue.qualityOfService = .userInitiated
     return queue
   }()
+  private var documentChangeRegistrations: [
+    String: DocumentChangeRegistration
+  ] = [:]
+  private let documentChangeRegistrationsQueue = DispatchQueue(
+    label: "icloud_storage_plus.document_change_registrations"
+  )
   private let ubiquityContainerResolver: UbiquityContainerResolver
 
   init(
@@ -38,6 +44,12 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     }
     for session in sessions {
       session.cancel()
+    }
+    let registrations = documentChangeRegistrationsQueue.sync {
+      Array(documentChangeRegistrations.values)
+    }
+    for registration in registrations {
+      registration.cancel()
     }
   }
 
@@ -56,6 +68,8 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       icloudAvailable(result)
     case "gather":
       gather(call, result)
+    case "watchDocumentChanges":
+      watchDocumentChanges(call, result)
     case "uploadFile":
       uploadFile(call, result)
     case "downloadFile":
@@ -111,12 +125,14 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     operation: String,
     relativePath: String? = nil,
     result: @escaping FlutterResult,
+    onFailure: (() -> Void)? = nil,
     onResolved: @escaping (URL) -> Void
   ) {
     Task { @MainActor [self] in
       guard let containerURL = await ubiquityContainerResolver.resolve(
         containerId: containerId
       ) else {
+        onFailure?()
         result(containerAccessError(
           operation: operation,
           relativePath: relativePath
@@ -205,6 +221,95 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       }
     }
     session.start()
+  }
+
+  /// Watches the existing ICloudDocument presenter's document-change events.
+  private func watchDocumentChanges(
+    _ call: FlutterMethodCall,
+    _ result: @escaping FlutterResult
+  ) {
+    guard let args = call.arguments as? Dictionary<String, Any>,
+          let containerId = args["containerId"] as? String,
+          let relativePath = args["relativePath"] as? String,
+          let eventChannelName = args["eventChannelName"] as? String,
+          !eventChannelName.isEmpty
+    else {
+      result(argumentError)
+      return
+    }
+
+    resolveContainerURL(
+      containerId: containerId,
+      operation: "watchDocumentChanges",
+      relativePath: relativePath,
+      result: result,
+      onFailure: { [weak self] in
+        self?.removeStreamHandler(eventChannelName)
+      }
+    ) { [self] containerURL in
+      startDocumentChangeObservation(
+        containerURL: containerURL,
+        relativePath: relativePath,
+        eventChannelName: eventChannelName,
+        result: result
+      )
+    }
+  }
+
+  private func startDocumentChangeObservation(
+    containerURL: URL,
+    relativePath: String,
+    eventChannelName: String,
+    result: @escaping FlutterResult
+  ) {
+    guard let streamHandler = registeredStreamHandler(for: eventChannelName)
+    else {
+      result(missingEventHandlerError(
+        eventChannelName: eventChannelName,
+        operation: "watchDocumentChanges",
+        relativePath: relativePath
+      ))
+      return
+    }
+
+    let documentURL = containerURL.appendingPathComponent(relativePath)
+    let document = ICloudDocument(fileURL: documentURL)
+    let observation = DocumentChangeObservation(
+      relativePath: relativePath,
+      onStart: { [weak document] in
+        guard let document else { return }
+        NSFileCoordinator.addFilePresenter(document)
+      },
+      onCancel: { [weak document] in
+        guard let document else { return }
+        NSFileCoordinator.removeFilePresenter(document)
+      },
+      emit: { payload in
+        DispatchQueue.main.async {
+          streamHandler.setEvent(payload)
+        }
+      }
+    )
+    document.changeObservation = observation
+    let registration = DocumentChangeRegistration(
+      document: document,
+      observation: observation
+    )
+    setDocumentChangeRegistration(registration, for: eventChannelName)
+    streamHandler.onCancelHandler = { [weak self, weak registration] in
+      guard let self, let registration else { return }
+
+      registration.cancel()
+      if self.removeDocumentChangeRegistration(
+        eventChannelName,
+        matching: registration
+      ) {
+        self.removeStreamHandler(eventChannelName)
+      }
+    }
+
+    observation.start()
+    result(nil)
   }
   
   /// Adds observers for metadata gather and update notifications.
@@ -1896,6 +2001,33 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
     }
   }
 
+  private func setDocumentChangeRegistration(
+    _ registration: DocumentChangeRegistration,
+    for eventChannelName: String
+  ) {
+    let existingRegistration = documentChangeRegistrationsQueue.sync {
+      let existing = documentChangeRegistrations[eventChannelName]
+      documentChangeRegistrations[eventChannelName] = registration
+      return existing
+    }
+    existingRegistration?.cancel()
+  }
+
+  private func removeDocumentChangeRegistration(
+    _ eventChannelName: String,
+    matching registration: DocumentChangeRegistration? = nil
+  ) -> Bool {
+    documentChangeRegistrationsQueue.sync {
+      if let registration,
+         documentChangeRegistrations[eventChannelName] !== registration {
+        return false
+      }
+
+      documentChangeRegistrations[eventChannelName] = nil
+      return true
+    }
+  }
+
   private func reserveProgressUpdate(
     _ progress: Double,
     eventChannelName: String
@@ -1958,6 +2090,22 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       code: "E_CTR",
       message: "Invalid containerId, or user is not signed in, or user disabled iCloud permission",
       category: "containerAccess",
+      operation: operation,
+      retryable: false,
+      relativePath: relativePath
+    )
+  }
+
+  private func missingEventHandlerError(
+    eventChannelName: String,
+    operation: String,
+    relativePath: String? = nil
+  ) -> FlutterError {
+    flutterError(
+      code: "E_NO_HANDLER",
+      message: "Event channel '\(eventChannelName)' not created. Call "
+        + "createEventChannel first.",
+      category: "invalidArgument",
       operation: operation,
       retryable: false,
       relativePath: relativePath
@@ -2106,6 +2254,37 @@ public class ICloudStoragePlugin: NSObject, FlutterPlugin {
       nativeError: nsError,
       underlying: String(describing: error)
     )
+  }
+}
+
+private final class DocumentChangeRegistration {
+  private let document: ICloudDocument
+  private let observation: DocumentChangeObservation
+  private let cancelLock = NSLock()
+  private var didCancel = false
+
+  init(document: ICloudDocument, observation: DocumentChangeObservation) {
+    self.document = document
+    self.observation = observation
+  }
+
+  deinit {
+    cancel()
+  }
+
+  func cancel() {
+    let shouldCancel: Bool = {
+      cancelLock.lock()
+      defer { cancelLock.unlock() }
+
+      guard !didCancel else { return false }
+      didCancel = true
+      return true
+    }()
+    guard shouldCancel else { return }
+
+    observation.cancel()
+    document.changeObservation = nil
   }
 }
 

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/DocumentChangeObservation.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/DocumentChangeObservation.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Kinds emitted when the existing `ICloudDocument` presenter observes a
+/// document change.
+enum DocumentChangeKind: String {
+    case remoteChange
+    case conflict
+    case savingError
+    case editingDisabled
+}
+
+/// Listener state for the existing `ICloudDocument` presenter bridge.
+///
+/// This is not a file presenter and does not observe the filesystem by itself.
+/// It only maps presenter callbacks from `ICloudDocument` into stable channel
+/// payloads and owns deterministic teardown for the event-channel subscription.
+final class DocumentChangeObservation {
+    typealias Payload = [String: Any]
+    typealias Emit = (Payload) -> Void
+
+    private let relativePath: String
+    private let onStart: () -> Void
+    private let onCancel: () -> Void
+    private let emitPayload: Emit
+    private let lock = NSLock()
+    private var active = false
+
+    init(
+        relativePath: String,
+        onStart: @escaping () -> Void,
+        onCancel: @escaping () -> Void,
+        emit: @escaping Emit
+    ) {
+        self.relativePath = relativePath
+        self.onStart = onStart
+        self.onCancel = onCancel
+        self.emitPayload = emit
+    }
+
+    deinit {
+        cancel()
+    }
+
+    func start() {
+        let shouldStart: Bool = lock.withLock {
+            guard !active else { return false }
+            active = true
+            return true
+        }
+        if shouldStart {
+            onStart()
+        }
+    }
+
+    func cancel() {
+        let shouldCancel: Bool = lock.withLock {
+            guard active else { return false }
+            active = false
+            return true
+        }
+        if shouldCancel {
+            onCancel()
+        }
+    }
+
+    func emit(kind: DocumentChangeKind) {
+        let payload: Payload? = lock.withLock {
+            guard active else { return nil }
+            return [
+                "relativePath": relativePath,
+                "kind": kind.rawValue,
+            ]
+        }
+        if let payload {
+            emitPayload(payload)
+        }
+    }
+}
+
+private extension NSLock {
+    func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        lock()
+        defer { unlock() }
+        return try body()
+    }
+}

--- a/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/DocumentChangeObservationTests.swift
+++ b/macos/icloud_storage_plus/Sources/icloud_storage_plus_foundation/Tests/icloud_storage_plus_foundationTests/DocumentChangeObservationTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import XCTest
+@testable import icloud_storage_plus_foundation
+
+final class DocumentChangeObservationTests: XCTestCase {
+    func testRemoteChangeEventEmitsTypedPayload() {
+        var payloads: [[String: Any]] = []
+        let observation = DocumentChangeObservation(
+            relativePath: "Documents/journal.json",
+            onStart: {},
+            onCancel: {},
+            emit: { payloads.append($0) }
+        )
+
+        observation.start()
+        observation.emit(kind: .remoteChange)
+
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(
+            payloads[0]["relativePath"] as? String,
+            "Documents/journal.json"
+        )
+        XCTAssertEqual(payloads[0]["kind"] as? String, "remoteChange")
+    }
+
+    func testCancelRemovesObserverAndSuppressesFutureEvents() {
+        var startCount = 0
+        var cancelCount = 0
+        var payloads: [[String: Any]] = []
+        let observation = DocumentChangeObservation(
+            relativePath: "Documents/journal.json",
+            onStart: { startCount += 1 },
+            onCancel: { cancelCount += 1 },
+            emit: { payloads.append($0) }
+        )
+
+        observation.start()
+        observation.cancel()
+        observation.emit(kind: .remoteChange)
+        observation.cancel()
+
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(cancelCount, 1)
+        XCTAssertTrue(payloads.isEmpty)
+    }
+
+    func testStartIsIdempotent() {
+        var startCount = 0
+        let observation = DocumentChangeObservation(
+            relativePath: "Documents/journal.json",
+            onStart: { startCount += 1 },
+            onCancel: {},
+            emit: { _ in }
+        )
+
+        observation.start()
+        observation.start()
+
+        XCTAssertEqual(startCount, 1)
+    }
+}

--- a/test/icloud_storage_method_channel_test.dart
+++ b/test/icloud_storage_method_channel_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:icloud_storage_plus/icloud_storage_method_channel.dart';
 import 'package:icloud_storage_plus/models/exceptions.dart';
+import 'package:icloud_storage_plus/models/icloud_document_change.dart';
 import 'package:icloud_storage_plus/models/icloud_file.dart';
 import 'package:icloud_storage_plus/models/icloud_version.dart';
 import 'package:icloud_storage_plus/models/transfer_progress.dart';
@@ -95,6 +96,8 @@ void main() {
         case 'copyConflictVersion':
           return null;
         case 'markConflictResolved':
+          return null;
+        case 'watchDocumentChanges':
           return null;
         default:
           return null;
@@ -560,10 +563,10 @@ void main() {
   });
 
   group('version exposure tests:', () {
-    test('enumerateUnresolvedConflictVersions sends method + args and '
+    test(
+        'enumerateUnresolvedConflictVersions sends method + args and '
         'decodes typed model', () async {
-      final versions =
-          await platform.enumerateUnresolvedConflictVersions(
+      final versions = await platform.enumerateUnresolvedConflictVersions(
         containerId: containerId,
         relativePath: 'Documents/file',
       );
@@ -589,7 +592,8 @@ void main() {
       );
     });
 
-    test('enumerateUnresolvedConflictVersions returns empty list when '
+    test(
+        'enumerateUnresolvedConflictVersions returns empty list when '
         'native returns null', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (methodCall) async {
@@ -599,8 +603,7 @@ void main() {
         return null;
       });
 
-      final versions =
-          await platform.enumerateUnresolvedConflictVersions(
+      final versions = await platform.enumerateUnresolvedConflictVersions(
         containerId: containerId,
         relativePath: 'Documents/file',
       );
@@ -623,7 +626,8 @@ void main() {
       expect(args['destinationPath'], '/tmp/backup-v1.json');
     });
 
-    test('markConflictResolved sends method + args including '
+    test(
+        'markConflictResolved sends method + args including '
         'removeOtherVersions', () async {
       await platform.markConflictResolved(
         containerId: containerId,
@@ -647,8 +651,7 @@ void main() {
       expect(args['removeOtherVersions'], false);
     });
 
-    test('version-exposure failures map to ICloudConflictException',
-        () async {
+    test('version-exposure failures map to ICloudConflictException', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (methodCall) async {
         if (methodCall.method == 'copyConflictVersion') {
@@ -675,6 +678,206 @@ void main() {
         ),
         throwsA(isA<ICloudConflictException>()),
       );
+    });
+  });
+
+  group('document change stream tests:', () {
+    test('watchDocumentChanges sends method args and maps typed payload',
+        () async {
+      mockStreamHandler = MockStreamHandler.inline(
+        onListen: (arguments, events) {
+          events
+            ..success({
+              'relativePath': 'Documents/journal.json',
+              'kind': 'remoteChange',
+            })
+            ..success({
+              'relativePath': 'Documents/journal.json',
+              'kind': 'conflict',
+            })
+            ..success({
+              'relativePath': 'Documents/journal.json',
+              'kind': 'savingError',
+            })
+            ..success({
+              'relativePath': 'Documents/journal.json',
+              'kind': 'editingDisabled',
+            })
+            ..endOfStream();
+        },
+      );
+
+      late Stream<ICloudDocumentChange> changeStream;
+
+      await platform.watchDocumentChanges(
+        containerId: containerId,
+        relativePath: 'Documents/journal.json',
+        onChange: (stream) {
+          changeStream = stream;
+        },
+      );
+
+      expect(mockMethodCalls.map((call) => call.method), [
+        'createEventChannel',
+        'watchDocumentChanges',
+      ]);
+      final args = mockArguments();
+      expect(args['containerId'], containerId);
+      expect(args['relativePath'], 'Documents/journal.json');
+      expect(args['eventChannelName'], lastEventChannelName);
+
+      final events = await changeStream.toList();
+      expect(events, [
+        const ICloudDocumentChange(
+          relativePath: 'Documents/journal.json',
+          kind: ICloudDocumentChangeKind.remoteChange,
+        ),
+        const ICloudDocumentChange(
+          relativePath: 'Documents/journal.json',
+          kind: ICloudDocumentChangeKind.conflict,
+        ),
+        const ICloudDocumentChange(
+          relativePath: 'Documents/journal.json',
+          kind: ICloudDocumentChangeKind.savingError,
+        ),
+        const ICloudDocumentChange(
+          relativePath: 'Documents/journal.json',
+          kind: ICloudDocumentChangeKind.editingDisabled,
+        ),
+      ]);
+    });
+
+    test('watchDocumentChanges maps stream errors to typed exceptions',
+        () async {
+      mockStreamHandler = MockStreamHandler.inline(
+        onListen: (arguments, events) {
+          events.error(
+            code: PlatformExceptionCode.coordination,
+            message: 'Document observation failed',
+            details: {
+              'category': 'coordination',
+              'operation': 'watchDocumentChanges',
+              'retryable': false,
+              'relativePath': 'Documents/journal.json',
+            },
+          );
+        },
+      );
+
+      late Stream<ICloudDocumentChange> changeStream;
+
+      await platform.watchDocumentChanges(
+        containerId: containerId,
+        relativePath: 'Documents/journal.json',
+        onChange: (stream) {
+          changeStream = stream;
+        },
+      );
+
+      await expectLater(
+        changeStream,
+        emitsError(isA<ICloudCoordinationException>()),
+      );
+    });
+
+    test('watchDocumentChanges does not expose stream when native start fails',
+        () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (methodCall) async {
+        mockMethodCall = methodCall;
+        mockMethodCalls.add(methodCall);
+        if (methodCall.method == 'createEventChannel') {
+          final args = mockArguments();
+          lastEventChannelName = args['eventChannelName'] as String?;
+          if (lastEventChannelName != null && mockStreamHandler != null) {
+            final eventChannel = EventChannel(lastEventChannelName!);
+            TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+                .setMockStreamHandler(eventChannel, mockStreamHandler);
+          }
+          return null;
+        }
+        if (methodCall.method == 'watchDocumentChanges') {
+          throw PlatformException(
+            code: PlatformExceptionCode.iCloudConnectionOrPermission,
+            message: 'iCloud container unavailable',
+            details: {
+              'category': 'containerAccess',
+              'operation': 'watchDocumentChanges',
+              'retryable': true,
+              'relativePath': 'Documents/journal.json',
+            },
+          );
+        }
+        return null;
+      });
+
+      late Stream<ICloudDocumentChange> changeStream;
+
+      await expectLater(
+        platform.watchDocumentChanges(
+          containerId: containerId,
+          relativePath: 'Documents/journal.json',
+          onChange: (stream) {
+            changeStream = stream;
+          },
+        ),
+        throwsA(isA<ICloudContainerAccessException>()),
+      );
+
+      await expectLater(
+        changeStream,
+        emitsError(isA<ICloudContainerAccessException>()),
+      );
+      expect(mockMethodCalls.map((call) => call.method), [
+        'createEventChannel',
+        'watchDocumentChanges',
+      ]);
+    });
+
+    test('watchDocumentChanges surfaces malformed payloads with stable code',
+        () async {
+      mockStreamHandler = MockStreamHandler.inline(
+        onListen: (arguments, events) {
+          events.success({'relativePath': 'Documents/journal.json'});
+        },
+      );
+
+      late Stream<ICloudDocumentChange> changeStream;
+
+      await platform.watchDocumentChanges(
+        containerId: containerId,
+        relativePath: 'Documents/journal.json',
+        onChange: (stream) {
+          changeStream = stream;
+        },
+      );
+
+      await expectLater(
+        changeStream,
+        emitsError(
+          isA<PlatformException>().having(
+            (error) => error.code,
+            'code',
+            PlatformExceptionCode.invalidEvent,
+          ),
+        ),
+      );
+    });
+
+    test('ICloudDocumentChange.fromMap rejects missing relativePath', () {
+      expect(
+        () => ICloudDocumentChange.fromMap(const {'kind': 'remoteChange'}),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('ICloudDocumentChange.fromMap maps unknown kind fallback', () {
+      final change = ICloudDocumentChange.fromMap(const {
+        'relativePath': 'Documents/journal.json',
+        'kind': 'newKind',
+      });
+
+      expect(change.kind, ICloudDocumentChangeKind.unknown);
     });
   });
 

--- a/test/icloud_storage_method_channel_test.dart
+++ b/test/icloud_storage_method_channel_test.dart
@@ -871,6 +871,15 @@ void main() {
       );
     });
 
+    test('ICloudDocumentChange.fromMap rejects missing kind', () {
+      expect(
+        () => ICloudDocumentChange.fromMap(const {
+          'relativePath': 'Documents/journal.json',
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
     test('ICloudDocumentChange.fromMap maps unknown kind fallback', () {
       final change = ICloudDocumentChange.fromMap(const {
         'relativePath': 'Documents/journal.json',

--- a/test/icloud_storage_test.dart
+++ b/test/icloud_storage_test.dart
@@ -77,6 +77,15 @@ class MockICloudStoragePlatform
   }
 
   @override
+  Future<void> watchDocumentChanges({
+    required String containerId,
+    required String relativePath,
+    required StreamHandler<ICloudDocumentChange> onChange,
+  }) async {
+    _calls.add('watchDocumentChanges');
+  }
+
+  @override
   Future<void> uploadFile({
     required String containerId,
     required String localPath,
@@ -324,6 +333,50 @@ void main() {
       final result = await ICloudStorage.gather(containerId: containerId);
       expect(result.files, isEmpty);
       expect(result.invalidEntries, isEmpty);
+    });
+
+    test('watchDocumentChanges', () async {
+      await ICloudStorage.watchDocumentChanges(
+        containerId: containerId,
+        relativePath: 'Documents/journal.json',
+        onChange: (_) {},
+      );
+
+      expect(fakePlatform.calls.last, 'watchDocumentChanges');
+    });
+
+    test('watchDocumentChanges rejects trailing slash relativePath', () async {
+      expect(
+        () async => ICloudStorage.watchDocumentChanges(
+          containerId: containerId,
+          relativePath: 'Documents/folder/',
+          onChange: (_) {},
+        ),
+        throwsA(isA<InvalidArgumentException>()),
+      );
+    });
+
+    test('watchDocumentChanges rejects blank relativePath', () async {
+      expect(
+        () async => ICloudStorage.watchDocumentChanges(
+          containerId: containerId,
+          relativePath: '   ',
+          onChange: (_) {},
+        ),
+        throwsA(isA<InvalidArgumentException>()),
+      );
+    });
+
+    test('watchDocumentChanges rejects invalid relativePath characters',
+        () async {
+      expect(
+        () async => ICloudStorage.watchDocumentChanges(
+          containerId: containerId,
+          relativePath: 'Documents/journal:1.json',
+          onChange: (_) {},
+        ),
+        throwsA(isA<InvalidArgumentException>()),
+      );
     });
 
     group('uploadFile tests:', () {


### PR DESCRIPTION
Part of MYT-1317.

Adds watchDocumentChanges to bridge existing ICloudDocument presenter remote/document-state events to Dart on iOS and macOS.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Jason-Holt-Digital/codesmith/icloud_storage_plus/pr/45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->